### PR TITLE
Feat/Sort Catalog by Usage

### DIFF
--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -52,7 +52,7 @@ function CatalogItemsScreen() {
     query: debouncedSearchValue,
     category: activeFilter === 'All' ? undefined : activeFilter,
     limit: 20,
-    sort: { field: 'createdAt', order: 'asc' },
+    sort: { field: 'usage', order: 'asc' },
   });
 
   // Disabled for now

--- a/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
+++ b/apps/expo/features/catalog/screens/CatalogItemsScreen.tsx
@@ -52,7 +52,7 @@ function CatalogItemsScreen() {
     query: debouncedSearchValue,
     category: activeFilter === 'All' ? undefined : activeFilter,
     limit: 20,
-    sort: { field: 'usage', order: 'asc' },
+    sort: { field: 'usage', order: 'desc' },
   });
 
   // Disabled for now

--- a/packages/api/src/routes/catalog/getCatalogItemsRoute.ts
+++ b/packages/api/src/routes/catalog/getCatalogItemsRoute.ts
@@ -49,6 +49,7 @@ export const handler: RouteHandler<typeof routeDefinition> = async (c) => {
     'ratingValue',
     'createdAt',
     'updatedAt',
+    'usage',
   ] as const;
   const validSortOrders = ['asc', 'desc'] as const;
 


### PR DESCRIPTION
This pull request updates the catalog item sorting logic to support sorting by usage, and refactors how catalog items are queried to include usage counts for more accurate sorting. The changes affect both the frontend and backend, ensuring that catalog items can now be sorted by how frequently they are used.

**Sorting and Query Enhancements:**

* Added support for `usage` as a sortable field in the `CatalogService` backend, allowing catalog items to be sorted by usage count.
* Updated the default ordering in the catalog item query to prioritize items with higher usage counts, falling back to item ID.
* Implemented logic to handle sorting by `usage` in the backend, using SQL to count associated pack items.

**Frontend Integration:**

* Changed the sort field in the catalog items screen to use `usage` instead of `createdAt`, so users see the most-used items first.

**Database Query Refactor:**

* Refactored catalog item queries to join with usage counts, ensuring items are sorted and returned according to their usage, and cleaned up the result to exclude the usage count from the returned item objects.