### PR TITLE
Fix/Clean Up Packs and Pack Items

### DIFF
--- a/apps/expo/app/(app)/_layout.tsx
+++ b/apps/expo/app/(app)/_layout.tsx
@@ -1,16 +1,12 @@
 import { ActivityIndicator } from '@packrat/ui/nativewindui';
-import { Icon } from '@roninoss/icons';
 import { AiChatHeader } from 'expo-app/components/ai-chatHeader';
 import { ThemeToggle } from 'expo-app/components/ThemeToggle';
 import { useAuthInit } from 'expo-app/features/auth/hooks/useAuthInit';
-import { usePackItemDetailsFromStore } from 'expo-app/features/packs';
-import { usePackItemOwnershipCheck } from 'expo-app/features/packs/hooks/usePackItemOwnershipCheck';
-import { usePackOwnershipCheck } from 'expo-app/features/packs/hooks/usePackOwnershipCheck';
-import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
-import { assertDefined } from 'expo-app/utils/typeAssertions';
+import { getPackDetailOptions } from 'expo-app/features/packs/utils/getPackDetailOptions';
+import { getPackItemDetailOptions } from 'expo-app/features/packs/utils/getPackItemDetailOptions';
 import 'expo-dev-client';
-import { Stack, useRouter } from 'expo-router';
-import { Pressable, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { View } from 'react-native';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -255,64 +251,6 @@ const CATALOG_ADD_TO_PACK_ITEM_DETAILS_OPTIONS = {
   title: 'Item Details',
   animation: 'fade_from_bottom', // for android
 } as const;
-
-// DETAIL SCREENS
-export function getPackDetailOptions(id: string) {
-  return {
-    title: 'Pack Details',
-    headerRight: () => {
-      const { colors } = useColorScheme();
-      const router = useRouter();
-
-      const isOwner = usePackOwnershipCheck(id as string);
-
-      if (!isOwner) return null;
-
-      return (
-        <View className="flex-row items-center gap-2">
-          <Pressable onPress={() => router.push({ pathname: '/pack/[id]/edit', params: { id } })}>
-            <Icon name="pencil-box-outline" color={colors.foreground} />
-          </Pressable>
-          <Pressable onPress={() => router.push({ pathname: '/item/new', params: { packId: id } })}>
-            <Icon name="plus" color={colors.foreground} />
-          </Pressable>
-        </View>
-      );
-    },
-  };
-}
-
-export function getPackItemDetailOptions({ route }: { route: { params?: { id?: string } } }) {
-  return {
-    title: 'Item Details',
-    headerRight: () => {
-      const { colors } = useColorScheme();
-      const router = useRouter();
-      const id = route.params?.id as string;
-
-      const isOwner = usePackItemOwnershipCheck(id);
-      const item = usePackItemDetailsFromStore(id);
-
-      if (!isOwner) return null;
-      assertDefined(item);
-
-      return (
-        <View className="flex-row items-center">
-          <Pressable
-            onPress={() =>
-              router.push({
-                pathname: '/item/[id]/edit',
-                params: { id, packId: item.packId },
-              })
-            }
-          >
-            <Icon name="pencil-box-outline" color={colors.foreground} />
-          </Pressable>
-        </View>
-      );
-    },
-  };
-}
 
 const PACK_EDIT_OPTIONS = {
   title: 'Edit Pack',

--- a/apps/expo/components/initial/WeightBadge.tsx
+++ b/apps/expo/components/initial/WeightBadge.tsx
@@ -13,11 +13,11 @@ export function WeightBadge({ weight, unit = 'g', type = 'item' }: WeightBadgePr
   const getColorClass = () => {
     switch (type) {
       case 'base':
-        return 'bg-blue-100 text-blue-800';
+        return ['bg-blue-100', 'text-blue-800'];
       case 'total':
-        return 'bg-purple-100 text-purple-800';
+        return ['bg-purple-100', 'text-purple-800'];
       default:
-        return 'bg-gray-100 text-gray-800';
+        return ['bg-muted dark:bg-neutral-700', 'text-xs dark:text-neutral-200 font-normal'];
     }
   };
 
@@ -26,8 +26,8 @@ export function WeightBadge({ weight, unit = 'g', type = 'item' }: WeightBadgePr
   const formattedWeight = formatWeight(safeWeight, safeUnit);
 
   return (
-    <View className={cn('rounded-full px-2 py-1', getColorClass().split(' ')[0])}>
-      <Text className={cn('text-center text-xs font-medium', getColorClass().split(' ')[1])}>
+    <View className={cn('rounded-full px-2 py-1', getColorClass()[0])}>
+      <Text className={cn('text-center text-xs font-medium', getColorClass()[1])}>
         {formattedWeight}
       </Text>
     </View>

--- a/apps/expo/features/ai/components/ChatBubble.tsx
+++ b/apps/expo/features/ai/components/ChatBubble.tsx
@@ -79,9 +79,10 @@ export function ChatBubble({ item, userQuery, isLast, status }: ChatBubbleProps)
 
   return (
     <View className={cn('justify-center px-2 mb-6', isAI ? 'items-start pr-4' : 'items-end pl-16')}>
-      <ContextMenu
+      {/* <ContextMenu
         enabled={isAI ? !isLast || status === 'ready' : true}
         className="rounded-md"
+        
         items={[
           createContextItem({
             actionKey: 'copy',
@@ -119,35 +120,35 @@ export function ChatBubble({ item, userQuery, isLast, status }: ChatBubbleProps)
               break;
           }
         }}
+      > */}
+      <View
+        style={BORDER_CURVE}
+        className={cn(
+          'px-2',
+          isAI ? 'w-full' : 'py-1.5 bg-neutral-200 dark:bg-neutral-700 rounded-2xl',
+        )}
       >
-        <Pressable
-          style={BORDER_CURVE}
-          className={cn(
-            'px-2',
-            isAI ? 'w-full' : 'py-1.5 bg-neutral-200 dark:bg-neutral-700 rounded-2xl',
-          )}
-        >
-          {item.parts.map((part, idx) => {
-            const key = `${part.type}-${idx}`;
-            if (part.type === 'text')
-              return isAI ? (
-                <Markdown key={key}>{formatAIResponse(part.text)}</Markdown>
-              ) : (
-                <Text key={key}>{part.text}</Text>
-              );
+        {item.parts.map((part, idx) => {
+          const key = `${part.type}-${idx}`;
+          if (part.type === 'text')
+            return isAI ? (
+              <Markdown key={key}>{formatAIResponse(part.text)}</Markdown>
+            ) : (
+              <Text key={key}>{part.text}</Text>
+            );
 
-            if (isAI && part.type.startsWith('tool-'))
-              return (
-                <View key={key} className="my-2">
-                  <ToolInvocationRenderer
-                    key={(part as ToolUIPart).toolCallId}
-                    toolInvocation={part as ToolUIPart}
-                  />
-                </View>
-              );
-          })}
-        </Pressable>
-      </ContextMenu>
+          if (isAI && part.type.startsWith('tool-'))
+            return (
+              <View key={key} className="my-2">
+                <ToolInvocationRenderer
+                  key={(part as ToolUIPart).toolCallId}
+                  toolInvocation={part as ToolUIPart}
+                />
+              </View>
+            );
+        })}
+      </View>
+      {/* </ContextMenu> */}
 
       {isAI && userQuery && (!isLast || status === 'ready') && (
         <>

--- a/apps/expo/features/packs/components/CachedImage.tsx
+++ b/apps/expo/features/packs/components/CachedImage.tsx
@@ -25,8 +25,6 @@ export const CachedImage: React.FC<CachedImageProps> = ({
   const [imageLocalUri, setImageLocalUri] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  console.log(imageLocalUri);
-
   useEffect(() => {
     if (!imageObjectKey) return;
     const loadImage = async () => {

--- a/apps/expo/features/packs/components/PackCard.tsx
+++ b/apps/expo/features/packs/components/PackCard.tsx
@@ -1,10 +1,12 @@
-import { Alert, Button } from '@packrat/ui/nativewindui';
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { Alert, type AlertRef, Button, Text } from '@packrat/ui/nativewindui';
 import { Icon } from '@roninoss/icons';
-import { CategoryBadge } from 'expo-app/components/initial/CategoryBadge';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
+import { router } from 'expo-router';
 import { isArray } from 'radash';
-import { Image, Pressable, Text, View } from 'react-native';
+import { useRef } from 'react';
+import { Image, Pressable, View } from 'react-native';
 import { useDeletePack, usePackDetailsFromStore } from '../hooks';
 import { usePackOwnershipCheck } from '../hooks/usePackOwnershipCheck';
 import type { Pack, PackInStore } from '../types';
@@ -18,12 +20,66 @@ type PackCardProps = {
 export function PackCard({ pack: packArg, onPress, isGenUI = false }: PackCardProps) {
   const deletePack = useDeletePack();
   const { colors } = useColorScheme();
+  const { showActionSheetWithOptions } = useActionSheet();
+  const alertRef = useRef<AlertRef>(null);
   const isOwnedByUser = usePackOwnershipCheck(packArg.id);
   const packFromStore = usePackDetailsFromStore(packArg.id); // Use pack from store if it's owned by the current user so that component observe changes to it and thus update properly.
   const pack = (isOwnedByUser ? packFromStore : packArg) as Pack; // Use passed pack for non user owned pack.
 
-  const hasBaseWeight = typeof pack.baseWeight === 'number' && pack.baseWeight > 0;
-  const hasTotalWeight = typeof pack.totalWeight === 'number' && pack.totalWeight > 0;
+  const handleActionsPress = () => {
+    const options =
+      isOwnedByUser && !isGenUI
+        ? ['View Details', 'Edit', 'Delete', 'Cancel']
+        : ['View Details', 'Cancel'];
+
+    const cancelButtonIndex = options.length - 1;
+    const destructiveButtonIndex = options.indexOf('Delete');
+    const viewDetailsIndex = 0;
+    const editIndex = options.indexOf('Edit');
+
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex,
+        destructiveButtonIndex,
+        title: pack.name,
+        message: pack.description,
+        containerStyle: {
+          backgroundColor: colors.card,
+        },
+        textStyle: {
+          color: colors.foreground,
+        },
+        titleTextStyle: {
+          color: colors.foreground,
+          fontWeight: '600',
+        },
+        messageTextStyle: {
+          color: colors.grey2,
+        },
+      },
+      (selectedIndex) => {
+        switch (selectedIndex) {
+          case viewDetailsIndex:
+            onPress?.(pack);
+            break;
+          case editIndex:
+            router.push({ pathname: '/pack/[id]/edit', params: { id: pack.id } });
+            break;
+          case destructiveButtonIndex:
+            alertRef.current?.alert({
+              title: 'Delete pack?',
+              message: 'Are you sure you want to delete this pack? This action cannot be undone.',
+              buttons: [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'OK', onPress: () => deletePack(pack.id) },
+              ],
+            });
+            break;
+        }
+      },
+    );
+  };
 
   return (
     <Pressable
@@ -34,58 +90,49 @@ export function PackCard({ pack: packArg, onPress, isGenUI = false }: PackCardPr
         <Image source={{ uri: pack.image }} className="h-40 w-full" resizeMode="cover" />
       )}
       <View className="p-4">
-        <View className="mb-2 flex-row items-center justify-between">
-          <Text className="text-lg font-semibold text-foreground">{pack.name}</Text>
-          {pack.category && <CategoryBadge category={pack.category} />}
+        <View className="mb-2 flex-row items-start justify-between">
+          <View className="flex-1">
+            <Text className="text-lg font-semibold text-foreground">{pack.name}</Text>
+            {pack.category && <Text variant="footnote">{pack.category}</Text>}
+          </View>
+          <Button variant="plain" size="icon" onPress={handleActionsPress}>
+            <Icon name="dots-horizontal" size={20} color={colors.grey2} />
+          </Button>
         </View>
 
         {pack.description && (
-          <Text className="mb-3 text-foreground" numberOfLines={2}>
+          <Text className="text-sm text-muted-foreground" numberOfLines={2}>
             {pack.description}
           </Text>
         )}
 
-        <View className="flex-row items-center justify-between">
+        <View className="mt-3 flex-row items-center justify-between">
           <View className="flex-row gap-2">
-            {hasBaseWeight ? (
-              <WeightBadge weight={pack.baseWeight ?? 0} unit="g" type="base" />
-            ) : null}
-            {hasTotalWeight ? (
-              <WeightBadge weight={pack.totalWeight ?? 0} unit="g" type="total" />
-            ) : null}
+            <WeightBadge weight={pack.baseWeight ?? 0} unit="g" type="base" />
+            <WeightBadge weight={pack.totalWeight ?? 0} unit="g" type="total" />
           </View>
-          {pack.items && isArray(pack.items) && pack.items.length > 0 ? (
-            <Text className="text-xs text-foreground">{pack.items.length} items</Text>
-          ) : null}
+          <Text className="text-xs text-foreground">
+            {pack.items && isArray(pack.items) && pack.items.length > 0
+              ? `${pack.items.length} item${pack.items.length > 1 ? 's' : ''}`
+              : '0 items'}
+          </Text>
         </View>
 
         <View className="flex-row items-baseline justify-between">
           {pack.tags && isArray(pack.tags) && pack.tags.length > 0 ? (
             <View className="mt-3 flex-row flex-wrap">
               {pack.tags.map((tag) => (
-                <View key={tag} className="mb-1 mr-2 rounded-full bg-background px-2 py-1">
+                <View
+                  key={tag}
+                  className="mb-1 mr-2 rounded-full bg-neutral-200 dark:bg-neutral-700 px-2 py-1"
+                >
                   <Text className="text-xs text-foreground">#{tag}</Text>
                 </View>
               ))}
             </View>
           ) : null}
 
-          {!isGenUI && isOwnedByUser && (
-            <View className="ml-auto">
-              <Alert
-                title="Delete pack?"
-                message="Are you sure you want to delete this pack? This action cannot be undone."
-                buttons={[
-                  { text: 'Cancel', style: 'cancel' },
-                  { text: 'OK', onPress: () => deletePack(pack.id) },
-                ]}
-              >
-                <Button variant="plain" size="icon">
-                  <Icon name="trash-can" size={21} color={colors.grey2} />
-                </Button>
-              </Alert>
-            </View>
-          )}
+          <Alert title="" buttons={[]} ref={alertRef} />
         </View>
       </View>
     </Pressable>

--- a/apps/expo/features/packs/components/PackItemCard.tsx
+++ b/apps/expo/features/packs/components/PackItemCard.tsx
@@ -1,11 +1,13 @@
-import { Alert, Button } from '@packrat/ui/nativewindui';
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { Alert, type AlertRef, Button, Text } from '@packrat/ui/nativewindui';
 import { Icon } from '@roninoss/icons';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { cn } from 'expo-app/lib/cn';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { assertDefined } from 'expo-app/utils/typeAssertions';
 import { useRouter } from 'expo-router';
-import { Pressable, Text, View } from 'react-native';
+import { useRef } from 'react';
+import { Pressable, View } from 'react-native';
 import {
   useDeletePackItem,
   usePackItemDetailsFromStore,
@@ -22,6 +24,8 @@ type PackItemCardProps = {
 
 export function PackItemCard({ item: itemArg, onPress, isGenUI = false }: PackItemCardProps) {
   const router = useRouter();
+  const { showActionSheetWithOptions } = useActionSheet();
+  const alertRef = useRef<AlertRef>(null);
   const isOwnedByUser = usePackItemOwnershipCheck(itemArg.id);
   const itemFromStore = usePackItemDetailsFromStore(itemArg.id); // Use item from store if it's user owned so that component observe changes to it and thus update properly.
   const item = isOwnedByUser ? itemFromStore : itemArg; // Use passed item if it's not owned by the current user.
@@ -30,38 +34,97 @@ export function PackItemCard({ item: itemArg, onPress, isGenUI = false }: PackIt
   const deleteItem = useDeletePackItem();
   const { colors } = useColorScheme();
 
+  const handleActionsPress = () => {
+    const options =
+      isOwnedByUser && !isGenUI
+        ? ['View Details', 'Edit', 'Delete', 'Cancel']
+        : ['View Details', 'Cancel'];
+
+    const cancelButtonIndex = options.length - 1;
+    const destructiveButtonIndex = options.indexOf('Delete');
+    const viewDetailsIndex = 0;
+    const editIndex = options.indexOf('Edit');
+
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex,
+        destructiveButtonIndex,
+        title: item.name,
+        message: item.description,
+        containerStyle: {
+          backgroundColor: colors.card,
+        },
+        textStyle: {
+          color: colors.foreground,
+        },
+        titleTextStyle: {
+          color: colors.foreground,
+          fontWeight: '600',
+        },
+        messageTextStyle: {
+          color: colors.grey2,
+        },
+      },
+      (selectedIndex) => {
+        switch (selectedIndex) {
+          case viewDetailsIndex:
+            onPress?.(item);
+            break;
+          case editIndex:
+            router.push({
+              pathname: '/item/[id]/edit',
+              params: { id: item.id, packId: item.packId },
+            });
+            break;
+          case destructiveButtonIndex:
+            alertRef.current?.alert({
+              title: 'Delete pack?',
+              message: 'Are you sure you want to delete this pack? This action cannot be undone.',
+              buttons: [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'OK', onPress: () => deleteItem(item.id) },
+              ],
+            });
+            break;
+        }
+      },
+    );
+  };
+
   return (
     <Pressable
       className="mb-3 flex-row overflow-hidden rounded-lg bg-card shadow-sm"
       onPress={() => onPress?.(item)}
     >
-      <PackItemImage item={item} className="w-28" resizeMode="cover" />
-
-      <View className="flex-1 p-3">
-        <View className="flex-row items-start justify-between">
-          <View className="mr-2 flex-1">
-            <Text className="text-base font-medium text-foreground" numberOfLines={1}>
+      <View className="flex-1 p-2">
+        <View className="flex-row items-start justify-between gap-2 mb-2">
+          <PackItemImage
+            item={item}
+            className="w-32 h-20 rounded-lg border border-neutral-200 dark:border-neutral-700"
+            resizeMode="cover"
+          />
+          <View className="flex-1 py-1">
+            <Text
+              className="text-foreground tracking-tight leading-6"
+              variant="title3"
+              numberOfLines={2}
+            >
               {item.name}
             </Text>
-            <Text className="mb-1 text-xs text-muted-foreground">{item.category}</Text>
+            <Text variant="footnote" className="text-muted-foreground">
+              {item.category}
+            </Text>
           </View>
-
-          <WeightBadge weight={item.weight * item.quantity} unit={item.weightUnit} />
         </View>
 
-        {item.description && (
-          <Text className="mt-1 text-sm text-muted-foreground" numberOfLines={2}>
-            {item.description}
-          </Text>
-        )}
-
-        <View className="flex-row items-start justify-between">
+        <View className="flex-row pl-1 items-start justify-between">
           <View className="mt-2 flex-row items-center gap-2">
-            {item.quantity > 1 && (
-              <View className="rounded-full bg-muted px-2 py-0.5">
-                <Text className="text-xs text-muted-foreground">Qty: {item.quantity}</Text>
-              </View>
-            )}
+            <WeightBadge weight={item.weight * item.quantity} unit={item.weightUnit} />
+
+            <View className="rounded-full bg-muted px-2 py-0.5">
+              <Text className="text-xs text-muted-foreground">Qty: {item.quantity}</Text>
+            </View>
 
             {item.consumable && (
               <View className={cn('rounded-full px-2 py-0.5', 'bg-amber-100')}>
@@ -75,43 +138,11 @@ export function PackItemCard({ item: itemArg, onPress, isGenUI = false }: PackIt
               </View>
             )}
           </View>
-          {!isGenUI && isOwnedByUser && (
-            <View className="flex-row gap-[.4]">
-              <Alert
-                title="Delete item?"
-                message="Are you sure you want to delete this item?"
-                buttons={[
-                  {
-                    text: 'Cancel',
-                    style: 'cancel',
-                  },
-                  {
-                    text: 'OK',
-                    onPress: () => {
-                      deleteItem(item.id);
-                    },
-                  },
-                ]}
-              >
-                <Button variant="plain" size="icon">
-                  <Icon name="trash-can" size={21} color={colors.grey2} />
-                </Button>
-              </Alert>
-              <Button
-                variant="plain"
-                size="icon"
-                onPress={() =>
-                  router.push({
-                    pathname: '/item/[id]/edit',
-                    params: { id: item.id, packId: item.packId },
-                  })
-                }
-              >
-                <Icon name="pencil-box-outline" size={21} color={colors.grey2} />
-              </Button>
-            </View>
-          )}
+          <Button variant="plain" size="icon" onPress={handleActionsPress}>
+            <Icon name="dots-horizontal" size={20} color={colors.grey2} />
+          </Button>
         </View>
+        <Alert title="" buttons={[]} ref={alertRef} />
       </View>
     </Pressable>
   );

--- a/apps/expo/features/packs/components/PackItemCard.tsx
+++ b/apps/expo/features/packs/components/PackItemCard.tsx
@@ -122,8 +122,8 @@ export function PackItemCard({ item: itemArg, onPress, isGenUI = false }: PackIt
           <View className="mt-2 flex-row items-center gap-2">
             <WeightBadge weight={item.weight * item.quantity} unit={item.weightUnit} />
 
-            <View className="rounded-full bg-muted px-2 py-0.5">
-              <Text className="text-xs text-muted-foreground">Qty: {item.quantity}</Text>
+            <View className="rounded-full bg-muted dark:bg-neutral-700 px-2 py-0.5">
+              <Text className="text-xs dark:text-neutral-200">Qty: {item.quantity}</Text>
             </View>
 
             {item.consumable && (

--- a/apps/expo/features/packs/components/PackItemCard.tsx
+++ b/apps/expo/features/packs/components/PackItemCard.tsx
@@ -79,8 +79,8 @@ export function PackItemCard({ item: itemArg, onPress, isGenUI = false }: PackIt
             break;
           case destructiveButtonIndex:
             alertRef.current?.alert({
-              title: 'Delete pack?',
-              message: 'Are you sure you want to delete this pack? This action cannot be undone.',
+              title: 'Delete item?',
+              message: 'Are you sure you want to delete this item?',
               buttons: [
                 { text: 'Cancel', style: 'cancel' },
                 { text: 'OK', onPress: () => deleteItem(item.id) },

--- a/apps/expo/features/packs/components/PackItemSuggestionSkeleton.tsx
+++ b/apps/expo/features/packs/components/PackItemSuggestionSkeleton.tsx
@@ -3,7 +3,7 @@ import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
 export function PackItemSuggestionSkeleton({ hideSuggestions }: { hideSuggestions: () => void }) {
   return (
-    <View className="mb-4 bg-card p-4">
+    <View className="mb-4 p-4">
       <View className="mb-3 flex-row items-center justify-between">
         <View className="flex-row items-center">
           <Icon name="atom" size={18} />

--- a/apps/expo/features/packs/components/PackItemSuggestions.tsx
+++ b/apps/expo/features/packs/components/PackItemSuggestions.tsx
@@ -47,7 +47,7 @@ export function PackItemSuggestions({ packId }: AISuggestionsProps) {
   // If suggestions aren't being shown, display the generate button
   if (!showSuggestions) {
     return (
-      <View className="bg-card p-4">
+      <View className="p-4">
         <Button onPress={handleGenerateSuggestions} className="w-full" variant="secondary">
           <Icon name="atom" size={18} color={colors.foreground} />
           <Text>Get AI Item Suggestions</Text>
@@ -64,7 +64,7 @@ export function PackItemSuggestions({ packId }: AISuggestionsProps) {
   // Handle error state
   if (isError || !suggestions || suggestions.length === 0) {
     return (
-      <View className="mb-4 bg-card p-4">
+      <View className="mb-4 p-4">
         <View className="mb-3 flex-row items-center justify-between">
           <View className="flex-row items-center">
             <Icon name="atom" size={18} />
@@ -94,11 +94,11 @@ export function PackItemSuggestions({ packId }: AISuggestionsProps) {
 
   // Show suggestions
   return (
-    <View className="mb-4 bg-card p-4">
+    <View className="mb-4 p-4">
       <View className="mb-3 flex-row items-center justify-between">
-        <View className="flex-row items-center">
-          <Icon name="atom" size={18} />
-          <Text className="text-base font-semibold text-gray-700">AI Suggestions</Text>
+        <View className="flex-row items-center gap-2">
+          <Icon name="atom" size={18} color={colors.foreground} />
+          <Text className="text-base font-semibold text-muted-foreground">AI Suggestions</Text>
         </View>
         <TouchableOpacity onPress={handleHideSuggestions} className="rounded-full bg-gray-200 p-1">
           <Icon name="close" size={16} />

--- a/apps/expo/features/packs/screens/PackDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackDetailScreen.tsx
@@ -1,6 +1,5 @@
-import { ActivityIndicator, Alert, Button, Text } from '@packrat/ui/nativewindui';
+import { ActivityIndicator, Button, Text } from '@packrat/ui/nativewindui';
 import { Icon } from '@roninoss/icons';
-import { CategoryBadge } from 'expo-app/components/initial/CategoryBadge';
 import { Chip } from 'expo-app/components/initial/Chip';
 import { WeightBadge } from 'expo-app/components/initial/WeightBadge';
 import { isAuthed } from 'expo-app/features/auth/store';
@@ -11,7 +10,7 @@ import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Image, SafeAreaView, ScrollView, TouchableOpacity, View } from 'react-native';
-import { useDeletePack, usePackDetailsFromApi, usePackDetailsFromStore } from '../hooks';
+import { usePackDetailsFromApi, usePackDetailsFromStore } from '../hooks';
 import { usePackOwnershipCheck } from '../hooks/usePackOwnershipCheck';
 import type { Pack, PackItem } from '../types';
 
@@ -37,7 +36,6 @@ export function PackDetailScreen() {
 
   const pack = (isOwnedByUser ? packFromStore : packFromApi) as Pack;
 
-  const deletePack = useDeletePack();
   const { colors } = useColorScheme();
 
   const handleItemPress = (item: PackItem) => {
@@ -108,16 +106,16 @@ export function PackDetailScreen() {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-background">
+    <SafeAreaView className="flex-1">
       <ScrollView>
         {pack.image && (
           <Image source={{ uri: pack.image }} className="h-48 w-full" resizeMode="cover" />
         )}
 
-        <View className="mb-4 bg-card p-4">
-          <View className="mb-2 flex-row items-center justify-between">
+        <View className="mb-4 p-4">
+          <View className="mb-2">
             <Text className="text-2xl font-bold text-foreground">{pack.name}</Text>
-            {pack.category && <CategoryBadge category={pack.category} />}
+            {pack.category && <Text variant="footnote">{pack.category}</Text>}
           </View>
 
           {pack.description && (
@@ -141,52 +139,23 @@ export function PackDetailScreen() {
             </View>
           </View>
 
-          <View className="flex-row justify-between">
-            {pack.tags && pack.tags.length > 0 && (
-              <View className="flex-row flex-wrap">
-                {pack.tags.map((tag) => (
-                  <Chip
-                    key={tag}
-                    className="mb-1 mr-2"
-                    textClassName="text-xs text-center"
-                    variant="outline"
-                  >
-                    #{tag}
-                  </Chip>
-                ))}
-              </View>
-            )}
-            {isOwnedByUser && (
-              <View className="ml-auto">
-                <Alert
-                  title="Delete pack?"
-                  message="Are you sure you want to delete this pack? This action cannot be undone."
-                  buttons={[
-                    {
-                      text: 'Cancel',
-                      style: 'cancel',
-                    },
-                    {
-                      text: 'OK',
-                      onPress: () => {
-                        deletePack(pack.id);
-                        if (router.canGoBack()) {
-                          router.back();
-                        }
-                      },
-                    },
-                  ]}
+          {pack.tags && pack.tags.length > 0 && (
+            <View className="flex-row flex-wrap">
+              {pack.tags.map((tag) => (
+                <Chip
+                  key={tag}
+                  className="mb-1 mr-2"
+                  textClassName="text-xs text-center"
+                  variant="outline"
                 >
-                  <Button variant="plain" size="icon">
-                    <Icon name="trash-can" color={colors.grey2} size={21} />
-                  </Button>
-                </Alert>
-              </View>
-            )}
-          </View>
+                  #{tag}
+                </Chip>
+              ))}
+            </View>
+          )}
         </View>
 
-        <View className="bg-card">
+        <View>
           <View className="p-4">
             <Button
               variant="secondary"
@@ -240,7 +209,7 @@ export function PackDetailScreen() {
 
           {filteredItems.length > 0 ? (
             filteredItems.map((item) => (
-              <View key={item.id} className="px-4 pt-3">
+              <View key={item.id} className="px-2 pt-3">
                 <PackItemCard item={item} onPress={handleItemPress} />
               </View>
             ))

--- a/apps/expo/features/packs/screens/PackDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackDetailScreen.tsx
@@ -209,7 +209,7 @@ export function PackDetailScreen() {
 
           {filteredItems.length > 0 ? (
             filteredItems.map((item) => (
-              <View key={item.id} className="px-2 pt-3">
+              <View key={item.id} className="px-4 pt-3">
                 <PackItemCard item={item} onPress={handleItemPress} />
               </View>
             ))

--- a/apps/expo/features/packs/screens/PackItemDetailScreen.tsx
+++ b/apps/expo/features/packs/screens/PackItemDetailScreen.tsx
@@ -43,7 +43,7 @@ export function ItemDetailScreen() {
   // Loading state for non-owned items
   if (!isOwnedByUser && isLoading) {
     return (
-      <SafeAreaView className="flex-1 bg-background">
+      <SafeAreaView className="flex-1">
         <View className="flex-1 items-center justify-center p-4">
           <ActivityIndicator />
         </View>
@@ -54,7 +54,7 @@ export function ItemDetailScreen() {
   // Error state for non-owned packs
   if (!isOwnedByUser && isError) {
     return (
-      <SafeAreaView className="flex-1 bg-background">
+      <SafeAreaView className="flex-1">
         <View className="flex-1 items-center justify-center p-8">
           <View className="mb-4 rounded-full bg-destructive/10 p-4">
             <Icon name="exclamation" size={32} color="text-destructive" />
@@ -118,11 +118,11 @@ export function ItemDetailScreen() {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-background">
+    <SafeAreaView className="flex-1">
       <ScrollView>
         <PackItemImage item={item} className="h-64 w-full" resizeMode="contain" />
 
-        <View className="mb-4 bg-card p-4">
+        <View className="mb-4 p-4">
           <Text className="mb-1 text-2xl font-bold text-foreground">{item.name}</Text>
           <Text className="mb-3 text-muted-foreground">{item.category}</Text>
 
@@ -181,12 +181,12 @@ export function ItemDetailScreen() {
         {isOwnedByUser && (
           <View className="mb-8 mt-6 px-4">
             <Button
-              variant="primary"
+              variant="secondary"
               onPress={navigateToChat}
-              className="flex-row items-center justify-center rounded-full bg-primary px-4 py-3"
+              className="flex-row items-center justify-center rounded-full  px-4 py-3"
             >
-              <Icon name="message" size={20} color="white" />
-              <Text className="font-semibold text-white">Ask AI About This Item</Text>
+              <Icon name="message-outline" size={20} color="white" />
+              <Text className="text-white">Ask AI About This Item</Text>
             </Button>
           </View>
         )}

--- a/apps/expo/features/packs/utils/getPackDetailOptions.tsx
+++ b/apps/expo/features/packs/utils/getPackDetailOptions.tsx
@@ -1,0 +1,62 @@
+import { Alert, Button, useColorScheme } from '@packrat-ai/nativewindui';
+import { Icon } from '@roninoss/icons';
+import { useRouter } from 'expo-router';
+import { View } from 'react-native';
+import { useDeletePack, usePackOwnershipCheck } from '../hooks';
+
+export function getPackDetailOptions(id: string) {
+  return {
+    title: 'Pack Details',
+    headerRight: () => {
+      const { colors } = useColorScheme();
+      const router = useRouter();
+      const deletePack = useDeletePack();
+
+      const isOwner = usePackOwnershipCheck(id as string);
+
+      if (!isOwner) return null;
+
+      return (
+        <View className="flex-row items-center gap-2">
+          <Alert
+            title="Delete pack?"
+            message="Are you sure you want to delete this pack? This action cannot be undone."
+            buttons={[
+              {
+                text: 'Cancel',
+                style: 'cancel',
+              },
+              {
+                text: 'OK',
+                onPress: () => {
+                  deletePack(id);
+                  if (router.canGoBack()) {
+                    router.back();
+                  }
+                },
+              },
+            ]}
+          >
+            <Button variant="plain" size="icon">
+              <Icon name="trash-can-outline" color={colors.grey2} />
+            </Button>
+          </Alert>
+          <Button
+            variant="plain"
+            size="icon"
+            onPress={() => router.push({ pathname: '/pack/[id]/edit', params: { id } })}
+          >
+            <Icon name="pencil-box-outline" color={colors.grey2} />
+          </Button>
+          <Button
+            variant="plain"
+            size="icon"
+            onPress={() => router.push({ pathname: '/item/new', params: { packId: id } })}
+          >
+            <Icon name="plus" color={colors.grey2} />
+          </Button>
+        </View>
+      );
+    },
+  };
+}

--- a/apps/expo/features/packs/utils/getPackItemDetailOptions.tsx
+++ b/apps/expo/features/packs/utils/getPackItemDetailOptions.tsx
@@ -1,0 +1,67 @@
+import { Alert, Button, useColorScheme } from '@packrat-ai/nativewindui';
+import { Icon } from '@roninoss/icons';
+import { assertDefined } from 'expo-app/utils/typeAssertions';
+import { useRouter } from 'expo-router';
+import { View } from 'react-native';
+import {
+  useDeletePackItem,
+  usePackItemDetailsFromStore,
+  usePackItemOwnershipCheck,
+} from '../hooks';
+
+export function getPackItemDetailOptions({ route }: { route: { params?: { id?: string } } }) {
+  return {
+    title: 'Item Details',
+    headerRight: () => {
+      const { colors } = useColorScheme();
+      const router = useRouter();
+      const id = route.params?.id as string;
+
+      const isOwner = usePackItemOwnershipCheck(id);
+      const item = usePackItemDetailsFromStore(id);
+
+      const deleteItem = useDeletePackItem();
+
+      if (!isOwner) return null;
+      assertDefined(item);
+
+      return (
+        <View className="flex-row items-center gap-[.4]">
+          <Alert
+            title="Delete item?"
+            message="Are you sure you want to delete this item?"
+            buttons={[
+              {
+                text: 'Cancel',
+                style: 'cancel',
+              },
+              {
+                text: 'OK',
+                onPress: () => {
+                  deleteItem(item.id);
+                  router.back();
+                },
+              },
+            ]}
+          >
+            <Button variant="plain" size="icon">
+              <Icon name="trash-can" color={colors.grey2} />
+            </Button>
+          </Alert>
+          <Button
+            variant="plain"
+            size="icon"
+            onPress={() =>
+              router.push({
+                pathname: '/item/[id]/edit',
+                params: { id: item.id, packId: item.packId },
+              })
+            }
+          >
+            <Icon name="pencil-box-outline" color={colors.grey2} />
+          </Button>
+        </View>
+      );
+    },
+  };
+}


### PR DESCRIPTION
Temporarily disable the problematic context menu in ChatBubble. Clean up pack and pack item layouts to prevent content overflow, improve visual hierarchy, and add action sheets for better user interaction.

| Before | After |
|--------|--------|
| <img width="300" height="2340" alt="Screenshot_1757083268" src="https://github.com/user-attachments/assets/7cc68737-a720-4514-9e24-a96fdc703c6a" />|<img width="300" height="2340" alt="Screenshot_1757112175" src="https://github.com/user-attachments/assets/cdc67b14-cb0d-41f7-9bf6-7a2c6e9c5624" />|
|<img width="300" height="2340" alt="Screenshot_1757112270" src="https://github.com/user-attachments/assets/a18d4488-ff23-4d8b-8e24-f7948a8185ce" />|<img width="300" height="2340" alt="Screenshot_1757112291" src="https://github.com/user-attachments/assets/eedd2b64-9fb3-474e-a601-c5c0086ae2b5" />| 