### PR TITLE
Chore/fixed nav bar guides link and favicon.

### DIFF
--- a/apps/guides/app/layout.tsx
+++ b/apps/guides/app/layout.tsx
@@ -17,7 +17,9 @@ export const metadata = {
   title: 'PackRat Guides | Hiking & Outdoor Adventures',
   description: 'Expert hiking and outdoor guides to help you prepare for your next adventure',
   icons: {
-    icon: '/PackRat.ico',
+    icon: [{ url: '/PackRat.ico', type: 'image/x-icon' }],
+    shortcut: '/favicon-16x16.png',
+    apple: '/apple-touch-icon.png',
   },
 };
 

--- a/apps/landing/components/main-nav.tsx
+++ b/apps/landing/components/main-nav.tsx
@@ -49,6 +49,13 @@ export default function MainNav() {
 
   // Handle smooth scrolling when clicking on navigation links
   const scrollToSection = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
+    if (href.startsWith('http')) {
+      // External link → open in a new tab
+      e.preventDefault();
+      window.open(href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
     e.preventDefault();
     const targetId = href.substring(1);
     const element = document.getElementById(targetId);
@@ -56,7 +63,7 @@ export default function MainNav() {
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' });
       setActiveSection(href);
-      setIsOpen(false); // Close mobile menu after clicking
+      setIsOpen(false);
     }
   };
 


### PR DESCRIPTION
Description:
- Fixed the guides nav bar link on the landing page.
- Ensured favicon is added and linked in the guides app (same setup as landing).
- Noticed favicon loads when running guides app directly but doesn’t appear when accessed via redirect from landing.

Notes:
- The .ico file is already added and linked.
- Might be related to browser caching or redirect behavior.

Testing:
- Verified the nav bar link works correctly on landing.
- Favicon confirmed on direct run, but still checking issue on redirect.