### PR TITLE
Fix/AI Packs Issues

### DIFF
--- a/apps/expo/features/ai-packs/hooks/useGeneratedPacks.ts
+++ b/apps/expo/features/ai-packs/hooks/useGeneratedPacks.ts
@@ -1,5 +1,7 @@
+import { use$ } from '@legendapp/state/react';
 import { useMutation } from '@tanstack/react-query';
 import type { Pack } from 'expo-app/features/packs';
+import { packsStore } from 'expo-app/features/packs/store';
 import axiosInstance, { handleApiError } from 'expo-app/lib/api/client';
 import type { GenerationRequest } from '../types';
 
@@ -16,8 +18,20 @@ const generatePacks = async (request: GenerationRequest): Promise<Pack[]> => {
 };
 
 export function useGeneratePacks() {
-  return useMutation({
+  const mutation = useMutation({
     mutationFn: generatePacks,
     mutationKey: ['generatePacks'],
   });
+
+  const generatedPacksFromStore = use$(() => {
+    if (mutation.data) {
+      return mutation.data.map((pack) =>
+        // @ts-ignore: Safe because Legend-State uses Proxy
+        packsStore[pack.id].get(),
+      );
+    }
+    return [];
+  });
+
+  return { ...mutation, generatedPacksFromStore };
 }

--- a/apps/expo/features/ai-packs/hooks/useGeneratedPacks.ts
+++ b/apps/expo/features/ai-packs/hooks/useGeneratedPacks.ts
@@ -5,7 +5,9 @@ import type { GenerationRequest } from '../types';
 
 const generatePacks = async (request: GenerationRequest): Promise<Pack[]> => {
   try {
-    const response = await axiosInstance.post('/api/packs/generate-packs', request);
+    const response = await axiosInstance.post('/api/packs/generate-packs', request, {
+      timeout: 0,
+    });
     return response.data;
   } catch (error) {
     const { message } = handleApiError(error);

--- a/apps/expo/features/ai-packs/screens/AIPacksScreen.tsx
+++ b/apps/expo/features/ai-packs/screens/AIPacksScreen.tsx
@@ -18,7 +18,7 @@ import { useGeneratePacks } from '../hooks/useGeneratedPacks';
 export function AIPacksScreen() {
   const { colors } = useColorScheme();
   const alertRef = useRef<AlertRef>(null);
-  const generatePacksMutation = useGeneratePacks();
+  const { mutateAsync: generatePacks, isPending, generatedPacksFromStore } = useGeneratePacks();
   const [packsModalVisible, setPacksModalVisible] = useState(false);
   const router = useRouter();
 
@@ -28,7 +28,7 @@ export function AIPacksScreen() {
     },
     onSubmit: async ({ value }) => {
       try {
-        const packs = await generatePacksMutation.mutateAsync(value);
+        const packs = await generatePacks(value);
         alertRef.current?.alert({
           title: 'Packs Generated',
           message: `Successfully generated ${packs.length} packs.`,
@@ -96,12 +96,8 @@ export function AIPacksScreen() {
           </form.Field>
 
           <View className="mt-4">
-            <Button
-              onPress={handleGeneratePacks}
-              disabled={generatePacksMutation.isPending}
-              className="w-full"
-            >
-              {generatePacksMutation.isPending ? (
+            <Button onPress={handleGeneratePacks} disabled={isPending} className="w-full">
+              {isPending ? (
                 <View className="flex-row items-center space-x-2">
                   <ActivityIndicator size="small" />
                   <Text>Generating...</Text>
@@ -137,8 +133,8 @@ export function AIPacksScreen() {
             </TouchableOpacity>
           </View>
           <ScrollView className="flex-1 gap-2 px-4 py-6">
-            {generatePacksMutation.data?.length &&
-              generatePacksMutation.data.map((pack) => (
+            {generatedPacksFromStore.every((pack) => !!pack) ? (
+              generatedPacksFromStore.map((pack) => (
                 <PackCard
                   key={pack.id}
                   pack={pack}
@@ -149,7 +145,14 @@ export function AIPacksScreen() {
                     });
                   }}
                 />
-              ))}
+              ))
+            ) : (
+              <View className="flex-1 items-center justify-center p-8">
+                <Text className="text-center text-muted-foreground mt-2">
+                  Waiting for packs to sync.
+                </Text>
+              </View>
+            )}
           </ScrollView>
         </SafeAreaView>
       </Modal>

--- a/apps/expo/features/ai-packs/screens/AIPacksScreen.tsx
+++ b/apps/expo/features/ai-packs/screens/AIPacksScreen.tsx
@@ -6,17 +6,20 @@ import {
   LargeTitleHeader,
   Text,
 } from '@packrat/ui/nativewindui';
+import { Icon } from '@roninoss/icons';
 import { useForm } from '@tanstack/react-form';
+import { PackCard } from 'expo-app/features/packs/components/PackCard';
 import { useColorScheme } from 'expo-app/lib/hooks/useColorScheme';
 import { useRouter } from 'expo-router';
-import { useRef } from 'react';
-import { SafeAreaView, TextInput, View } from 'react-native';
+import { useRef, useState } from 'react';
+import { Modal, SafeAreaView, ScrollView, TextInput, TouchableOpacity, View } from 'react-native';
 import { useGeneratePacks } from '../hooks/useGeneratedPacks';
 
 export function AIPacksScreen() {
   const { colors } = useColorScheme();
   const alertRef = useRef<AlertRef>(null);
   const generatePacksMutation = useGeneratePacks();
+  const [packsModalVisible, setPacksModalVisible] = useState(false);
   const router = useRouter();
 
   const form = useForm({
@@ -33,9 +36,9 @@ export function AIPacksScreen() {
           buttons: [
             { text: 'Return', onPress: () => {} },
             {
-              text: 'Go to Packs',
+              text: 'View',
               onPress: () => {
-                router.push({ pathname: '/packs', params: { view: 'all' } });
+                setPacksModalVisible(true);
               },
             },
           ],
@@ -118,6 +121,38 @@ export function AIPacksScreen() {
       </View>
 
       <Alert title="" buttons={[]} ref={alertRef} />
+
+      <Modal
+        visible={packsModalVisible}
+        animationType="slide"
+        onRequestClose={() => setPacksModalVisible(false)}
+      >
+        <SafeAreaView className="flex-1 bg-background">
+          <View className="flex-row items-center justify-between border-b border-border p-4">
+            <View className="flex-row items-center">
+              <Text>Generated Packs</Text>
+            </View>
+            <TouchableOpacity onPress={() => setPacksModalVisible(false)}>
+              <Icon name="close" size={24} color={colors.foreground} />
+            </TouchableOpacity>
+          </View>
+          <ScrollView className="flex-1 gap-2 px-4 py-6">
+            {generatePacksMutation.data?.length &&
+              generatePacksMutation.data.map((pack) => (
+                <PackCard
+                  key={pack.id}
+                  pack={pack}
+                  onPress={(pack) => {
+                    router.push({
+                      pathname: '/pack/[id]',
+                      params: { id: pack.id },
+                    });
+                  }}
+                />
+              ))}
+          </ScrollView>
+        </SafeAreaView>
+      </Modal>
     </SafeAreaView>
   );
 }

--- a/apps/expo/features/catalog/components/CatalogItemImage.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemImage.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@roninoss/icons';
 import { Image, type ImageProps, Platform, View } from 'react-native';
 
 interface PackItemImageProps extends Omit<ImageProps, 'source'> {
-  imageUrl?: string;
+  imageUrl?: string | null;
 }
 
 export function CatalogItemImage({ imageUrl, ...imageProps }: PackItemImageProps) {

--- a/apps/expo/features/catalog/components/CatalogItemImage.tsx
+++ b/apps/expo/features/catalog/components/CatalogItemImage.tsx
@@ -32,6 +32,7 @@ export function CatalogItemImage({ imageUrl, ...imageProps }: PackItemImageProps
           : {}),
       }}
       {...imageProps}
+      className={`bg-muted ${imageProps.className}`}
     />
   );
 }

--- a/apps/expo/features/packs/components/PackItemImage.tsx
+++ b/apps/expo/features/packs/components/PackItemImage.tsx
@@ -1,11 +1,11 @@
 import { useColorScheme } from '@packrat/ui/nativewindui';
 import { Icon } from '@roninoss/icons';
+import { CatalogItemImage } from 'expo-app/features/catalog/components/CatalogItemImage';
 import { buildPackItemImageUrl } from 'expo-app/lib/utils/buildPackItemImageUrl';
 import { Image, type ImageProps, View } from 'react-native';
 import { usePackItemOwnershipCheck } from '../hooks';
 import type { PackItem } from '../types';
 import { CachedImage } from './CachedImage';
-import { CatalogItemImage } from 'expo-app/features/catalog/components/CatalogItemImage';
 
 interface PackItemImageProps extends Omit<ImageProps, 'source'> {
   item: PackItem;

--- a/apps/expo/features/packs/components/PackItemImage.tsx
+++ b/apps/expo/features/packs/components/PackItemImage.tsx
@@ -5,6 +5,7 @@ import { Image, type ImageProps, View } from 'react-native';
 import { usePackItemOwnershipCheck } from '../hooks';
 import type { PackItem } from '../types';
 import { CachedImage } from './CachedImage';
+import { CatalogItemImage } from 'expo-app/features/catalog/components/CatalogItemImage';
 
 interface PackItemImageProps extends Omit<ImageProps, 'source'> {
   item: PackItem;
@@ -13,6 +14,10 @@ interface PackItemImageProps extends Omit<ImageProps, 'source'> {
 export function PackItemImage({ item, ...imageProps }: PackItemImageProps) {
   const isItemOwnedByUser = usePackItemOwnershipCheck(item.id);
   const { colors } = useColorScheme();
+
+  if (item.isAIGenerated) {
+    return <CatalogItemImage imageUrl={item.image} {...imageProps} />;
+  }
 
   if (!item.image)
     return (

--- a/apps/expo/features/packs/hooks/useCreatePackItem.ts
+++ b/apps/expo/features/packs/hooks/useCreatePackItem.ts
@@ -14,6 +14,7 @@ export function useCreatePackItem() {
         ...itemData,
         category: itemData.category || 'general',
         packId,
+        isAIGenerated: false,
         deleted: false,
       };
 

--- a/apps/expo/features/packs/types.ts
+++ b/apps/expo/features/packs/types.ts
@@ -23,6 +23,7 @@ export interface PackItem {
   catalogItem?: CatalogItem | null;
   userId?: number;
   deleted: boolean;
+  isAIGenerated: boolean;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/packages/api/drizzle/0031_organic_switch.sql
+++ b/packages/api/drizzle/0031_organic_switch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pack_items" ADD COLUMN "is_ai_generated" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "packs" ADD COLUMN "is_ai_generated" boolean DEFAULT false NOT NULL;

--- a/packages/api/drizzle/meta/0031_snapshot.json
+++ b/packages/api/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,1453 @@
+{
+  "id": "07c62114-0dba-46fb-bb76-f380531a1545",
+  "prevId": "94ee0353-7b79-4264-8e73-c4b0c6ff6f4c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_providers": {
+      "name": "auth_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_providers_user_id_users_id_fk": {
+          "name": "auth_providers_user_id_users_id_fk",
+          "tableFrom": "auth_providers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_item_etl_jobs": {
+      "name": "catalog_item_etl_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "catalog_item_id": {
+          "name": "catalog_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etl_job_id": {
+          "name": "etl_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_item_etl_jobs_catalog_item_id_catalog_items_id_fk": {
+          "name": "catalog_item_etl_jobs_catalog_item_id_catalog_items_id_fk",
+          "tableFrom": "catalog_item_etl_jobs",
+          "tableTo": "catalog_items",
+          "columnsFrom": ["catalog_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "catalog_item_etl_jobs_etl_job_id_etl_jobs_id_fk": {
+          "name": "catalog_item_etl_jobs_etl_job_id_etl_jobs_id_fk",
+          "tableFrom": "catalog_item_etl_jobs",
+          "tableTo": "etl_jobs",
+          "columnsFrom": ["etl_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_items": {
+      "name": "catalog_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_url": {
+          "name": "product_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_value": {
+          "name": "rating_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seller": {
+          "name": "seller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_sku": {
+          "name": "product_sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variants": {
+          "name": "variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "techs": {
+          "name": "techs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qas": {
+          "name": "qas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embedding_idx": {
+          "name": "embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalog_items_sku_unique": {
+          "name": "catalog_items_sku_unique",
+          "nullsNotDistinct": false,
+          "columns": ["sku"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.etl_jobs": {
+      "name": "etl_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "etl_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_processed": {
+          "name": "total_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_valid": {
+          "name": "total_valid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_invalid": {
+          "name": "total_invalid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraper_revision": {
+          "name": "scraper_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "etl_jobs_scraper_revision_idx": {
+          "name": "etl_jobs_scraper_revision_idx",
+          "columns": [
+            {
+              "expression": "scraper_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invalid_item_logs": {
+      "name": "invalid_item_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_index": {
+          "name": "row_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invalid_item_logs_job_id_etl_jobs_id_fk": {
+          "name": "invalid_item_logs_job_id_etl_jobs_id_fk",
+          "tableFrom": "invalid_item_logs",
+          "tableTo": "etl_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.one_time_passwords": {
+      "name": "one_time_passwords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "one_time_passwords_user_id_users_id_fk": {
+          "name": "one_time_passwords_user_id_users_id_fk",
+          "tableFrom": "one_time_passwords",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pack_items": {
+      "name": "pack_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumable": {
+          "name": "consumable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "worn": {
+          "name": "worn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_item_id": {
+          "name": "catalog_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ai_generated": {
+          "name": "is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "template_item_id": {
+          "name": "template_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pack_items_embedding_idx": {
+          "name": "pack_items_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pack_items_pack_id_packs_id_fk": {
+          "name": "pack_items_pack_id_packs_id_fk",
+          "tableFrom": "pack_items",
+          "tableTo": "packs",
+          "columnsFrom": ["pack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pack_items_catalog_item_id_catalog_items_id_fk": {
+          "name": "pack_items_catalog_item_id_catalog_items_id_fk",
+          "tableFrom": "pack_items",
+          "tableTo": "catalog_items",
+          "columnsFrom": ["catalog_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pack_items_user_id_users_id_fk": {
+          "name": "pack_items_user_id_users_id_fk",
+          "tableFrom": "pack_items",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pack_items_template_item_id_pack_template_items_id_fk": {
+          "name": "pack_items_template_item_id_pack_template_items_id_fk",
+          "tableFrom": "pack_items",
+          "tableTo": "pack_template_items",
+          "columnsFrom": ["template_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pack_template_items": {
+      "name": "pack_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumable": {
+          "name": "consumable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "worn": {
+          "name": "worn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pack_template_id": {
+          "name": "pack_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_item_id": {
+          "name": "catalog_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pack_template_items_pack_template_id_pack_templates_id_fk": {
+          "name": "pack_template_items_pack_template_id_pack_templates_id_fk",
+          "tableFrom": "pack_template_items",
+          "tableTo": "pack_templates",
+          "columnsFrom": ["pack_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pack_template_items_catalog_item_id_catalog_items_id_fk": {
+          "name": "pack_template_items_catalog_item_id_catalog_items_id_fk",
+          "tableFrom": "pack_template_items",
+          "tableTo": "catalog_items",
+          "columnsFrom": ["catalog_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pack_template_items_user_id_users_id_fk": {
+          "name": "pack_template_items_user_id_users_id_fk",
+          "tableFrom": "pack_template_items",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pack_templates": {
+      "name": "pack_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_app_template": {
+          "name": "is_app_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "local_created_at": {
+          "name": "local_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_updated_at": {
+          "name": "local_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pack_templates_user_id_users_id_fk": {
+          "name": "pack_templates_user_id_users_id_fk",
+          "tableFrom": "pack_templates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_history": {
+      "name": "weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_created_at": {
+          "name": "local_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weight_history_user_id_users_id_fk": {
+          "name": "weight_history_user_id_users_id_fk",
+          "tableFrom": "weight_history",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_history_pack_id_packs_id_fk": {
+          "name": "weight_history_pack_id_packs_id_fk",
+          "tableFrom": "weight_history",
+          "tableTo": "packs",
+          "columnsFrom": ["pack_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.packs": {
+      "name": "packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ai_generated": {
+          "name": "is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "local_created_at": {
+          "name": "local_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_updated_at": {
+          "name": "local_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packs_user_id_users_id_fk": {
+          "name": "packs_user_id_users_id_fk",
+          "tableFrom": "packs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packs_template_id_pack_templates_id_fk": {
+          "name": "packs_template_id_pack_templates_id_fk",
+          "tableFrom": "packs",
+          "tableTo": "pack_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_token": {
+          "name": "replaced_by_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_unique": {
+          "name": "refresh_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reported_content": {
+      "name": "reported_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_query": {
+          "name": "user_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_response": {
+          "name": "ai_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_comment": {
+          "name": "user_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reported_content_user_id_users_id_fk": {
+          "name": "reported_content_user_id_users_id_fk",
+          "tableFrom": "reported_content",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reported_content_reviewed_by_users_id_fk": {
+          "name": "reported_content_reviewed_by_users_id_fk",
+          "tableFrom": "reported_content",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1757790647629,
       "tag": "0030_careless_vindicator",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1758301845482,
+      "tag": "0031_organic_switch",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -80,6 +80,7 @@ export const packs = pgTable('packs', {
   image: text('image'),
   tags: jsonb('tags').$type<string[]>(),
   deleted: boolean('deleted').notNull().default(false),
+  isAIGenerated: boolean('is_ai_generated').notNull().default(false),
   localCreatedAt: timestamp('local_created_at').notNull(),
   localUpdatedAt: timestamp('local_updated_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(), // for controlling sync. controlled by server.
@@ -202,6 +203,7 @@ export const packItems = pgTable(
       .references(() => users.id)
       .notNull(),
     deleted: boolean('deleted').notNull().default(false),
+    isAIGenerated: boolean('is_ai_generated').notNull().default(false),
     templateItemId: text('template_item_id').references(() => packTemplateItems.id),
     embedding: vector('embedding', { dimensions: 1536 }),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/packages/api/src/schemas/packs.ts
+++ b/packages/api/src/schemas/packs.ts
@@ -17,6 +17,7 @@ export const PackItemSchema = z
     catalogItemId: z.number().int().nullable().openapi({ example: 12345 }),
     userId: z.number().int().openapi({ example: 1 }),
     deleted: z.boolean().openapi({ example: false }),
+    isAIGenerated: z.boolean().openapi({ example: false }),
     templateItemId: z.string().nullable().openapi({ example: 'pti_123456' }),
     createdAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00Z' }),
     updatedAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00Z' }),
@@ -40,6 +41,7 @@ export const PackSchema = z
       .nullable()
       .openapi({ example: ['backpacking', 'summer', 'mountains'] }),
     deleted: z.boolean().openapi({ example: false }),
+    isAIGenerated: z.boolean().openapi({ example: false }),
     createdAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00Z' }),
     updatedAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00Z' }),
     items: z.array(PackItemSchema).optional(),

--- a/packages/api/src/services/packService.ts
+++ b/packages/api/src/services/packService.ts
@@ -1,7 +1,6 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { createDb } from '@packrat/api/db';
 import {
-  type CatalogItem,
   type NewPack,
   type NewPackItem,
   type PackWithItems,
@@ -13,62 +12,31 @@ import { getEnv } from '@packrat/api/utils/env-validation';
 import { generateObject } from 'ai';
 import { and, eq } from 'drizzle-orm';
 import type { Context } from 'hono';
-import { env } from 'hono/adapter';
 import { z } from 'zod';
 import { computePackWeights } from '../utils/compute-pack';
 import { CatalogService } from './catalogService';
 
-const PACK_CONCEPTS_SYSTEM_PROMPT = `You are an expert Adventure Planner specializing in real-world outdoor and travel experiences. When given a specific count, generate that exact number of unique, practical adventure concepts that people can actually undertake. Each concept should include a name, a description, category, tags and a list of rich descriptive strings for the logical items needed. These descriptions should be optimized for a vector search against an items catalog to find the most suitable real-world item.`;
+const PACK_CONCEPTS_SYSTEM_PROMPT = `You are an expert Adventure Planner specializing in real-world outdoor and travel experiences. When given a specific count, generate that exact number of unique, practical adventure concepts that people can actually undertake. Each concept should include a name, a description, category, tags and a list of the logical items needed. Items should be rich descriptions optimized for a vector search against an items catalog to find the most suitable real-world item.`;
 
-const PACKS_CONSTRUCTION_SYSTEM_PROMPT = `You are an expert Adventure Planner. Your task is to turn a rough concept for a pack into a finalize pack with real items.
-              I'll provide you with pack concepts where each includes:
-              - A pack name and a description.
-              - A list of items, where each has a requestedItem description.
-              - A list of candidate items for each request, with details like price, weight, rating, tech specs, etc.
-              Your job is to select the best candidate items for each requested item, ensuring the final pack meets the concept.`;
+const packItemConceptSchema = z.object({
+  item: z.string(),
+  quantity: z.number().int().positive().default(1),
+  category: z.string(),
+  consumable: z.boolean().default(false).describe('Whether the item is consumable'),
+  worn: z.boolean().default(false).describe('Whether the item is worn'),
+  notes: z.string().nullable().optional(),
+});
 
 const packConceptSchema = z.object({
   name: z.string(),
   description: z.string(),
   category: z.string(),
   tags: z.array(z.string()).optional(),
-  items: z.array(z.string()),
+  items: z.array(packItemConceptSchema),
 });
 
 type PackConcept = z.infer<typeof packConceptSchema>;
-
-type PackConceptWithCandidateItems = Omit<PackConcept, 'items'> & {
-  items: {
-    requestedItem: string;
-    candidateItems: (Omit<CatalogItem, 'reviews' | 'embedding'> & { similarity: number })[];
-  }[];
-};
-
-const itemSchema = z.object({
-  catalogItemId: z.number().int(),
-  name: z.string(),
-  description: z.string().nullable().optional(),
-  weight: z.number().nonnegative(),
-  weightUnit: z.enum(['g', 'oz', 'kg', 'lb']),
-  quantity: z.number().int().positive().default(1),
-  category: z.string(),
-  consumable: z.boolean().default(false).describe('Whether the item is consumable'),
-  worn: z.boolean().default(false).describe('Whether the item is worn'),
-  notes: z.string().nullable().optional(),
-  image: z.string().nullable().optional(),
-});
-
-const finalPackSchema = z.object({
-  name: z.string(),
-  description: z.string(),
-  category: z.string(),
-  tags: z.array(z.string()).optional(),
-  items: z.array(itemSchema),
-});
-
-type FinalPack = z.infer<typeof finalPackSchema>;
-
-type VectorSearchResult = (CatalogItem & { similarity: number })[][];
+type PackItemConceptSchema = z.infer<typeof packItemConceptSchema>;
 
 export class PackService {
   private db;
@@ -109,32 +77,26 @@ export class PackService {
     // 1. Generate pack concepts
     const concepts = await this.generatePackConcepts(count);
 
-    // 2. Search catalog for candidate items
-    const packConceptsWithCandidateItems = await Promise.all(
+    // 2. Search catalog for items
+    const packsResult = await Promise.allSettled(
       concepts.map(async (concept) => {
-        const searchResults = await this.searchCatalog(concept.items);
+        const packItems = await this.getItems(concept.items);
         return {
           ...concept,
-          items: concept.items.map((item, idx) => ({
-            requestedItem: item,
-            candidateItems:
-              searchResults[idx]?.map((item) => {
-                const { reviews: _reviews, ...rest } = item; // remove unhelpful fields to manage context
-                return rest;
-              }) ?? [],
-          })),
+          items: packItems,
         };
       }),
     );
 
-    // 3. Select best items for each concept
-    const finalPacks = await this.constructPacks(packConceptsWithCandidateItems);
-
-    // 4. Save the packs to db
+    // 3. Save the packs to db
     const createdPacks = await this.db.transaction(async (tx) => {
       const packsToInsert: NewPack[] = [];
       const itemsToInsert: NewPackItem[] = [];
-      for (const pack of finalPacks) {
+      for (const packResult of packsResult) {
+        if (packResult.status === 'rejected') {
+          continue;
+        }
+        const pack = packResult.value;
         const packId = crypto.randomUUID();
         packsToInsert.push({
           id: packId,
@@ -159,6 +121,7 @@ export class PackService {
           })),
         );
       }
+
       const createdPacks = await tx.insert(packs).values(packsToInsert).returning();
 
       await tx.insert(packItems).values(itemsToInsert);
@@ -181,68 +144,38 @@ export class PackService {
       schema: packConceptSchema,
       system: PACK_CONCEPTS_SYSTEM_PROMPT,
       prompt: `${count}`,
+      temperature: 0.8,
     });
 
     return object;
   }
 
-  private async searchCatalog(items: string[]): Promise<VectorSearchResult> {
+  private async getItems(
+    packItemConcepts: PackItemConceptSchema[],
+  ): Promise<Omit<NewPackItem, 'id' | 'userId' | 'packId'>[]> {
     const catalogService = new CatalogService(this.c);
-    const searchResults = await catalogService.batchVectorSearch(items);
-    // Map each group to add the missing fields back
-    return searchResults.items.map((group) =>
-      group.map((item) => ({
-        id: item.id,
-        name: item.name,
-        productUrl: item.productUrl,
-        sku: item.sku,
-        weight: item.weight,
-        weightUnit: item.weightUnit,
-        description: item.description,
-        categories: item.categories,
-        images: item.images,
-        brand: item.brand,
-        model: item.model,
-        ratingValue: item.ratingValue,
-        color: item.color,
-        size: item.size,
-        price: item.price,
-        availability: item.availability,
-        seller: item.seller,
-        productSku: item.productSku,
-        material: item.material,
-        currency: item.currency,
-        condition: item.condition,
-        reviewCount: item.reviewCount,
-        variants: item.variants,
-        techs: item.techs,
-        links: item.links,
-        reviews: item.reviews,
-        qas: item.qas,
-        faqs: item.faqs,
-        createdAt: item.createdAt,
-        updatedAt: item.updatedAt,
-        embedding: null,
-        similarity: item.similarity,
-      })),
+    const searchResults = await catalogService.batchVectorSearch(
+      packItemConcepts.map((item) => item.item),
+      1,
     );
-  }
 
-  private async constructPacks(
-    packConceptsWithCandidateItems: PackConceptWithCandidateItems[],
-  ): Promise<FinalPack[]> {
-    const openai = createOpenAI({
-      apiKey: env(this.c).OPENAI_API_KEY,
-    });
+    return packItemConcepts
+      .map((item, idx) => {
+        const catalogItem = searchResults.items[idx]?.[0];
+        if (!catalogItem) {
+          return null;
+        }
 
-    const { object } = await generateObject({
-      model: openai(DEFAULT_MODELS.OPENAI_CHAT),
-      output: 'array',
-      schema: finalPackSchema,
-      system: PACKS_CONSTRUCTION_SYSTEM_PROMPT,
-      prompt: JSON.stringify(packConceptsWithCandidateItems),
-    });
-
-    return object;
+        return {
+          ...item,
+          catalogItemId: catalogItem.id,
+          name: catalogItem.name,
+          description: catalogItem.description,
+          weight: catalogItem.weight,
+          weightUnit: catalogItem.weightUnit,
+          image: catalogItem.images?.[0],
+        };
+      })
+      .filter((item): item is NonNullable<typeof item> => item !== null);
   }
 }

--- a/packages/api/src/services/packService.ts
+++ b/packages/api/src/services/packService.ts
@@ -144,6 +144,7 @@ export class PackService {
           category: pack.category,
           tags: pack.tags,
           isPublic: true,
+          isAIGenerated: true,
           localCreatedAt: new Date(),
           localUpdatedAt: new Date(),
         });
@@ -153,6 +154,7 @@ export class PackService {
             ...item,
             id: crypto.randomUUID(),
             packId,
+            isAIGenerated: true,
             userId: this.userId,
           })),
         );


### PR DESCRIPTION
This pull request introduces fixes for AI-generated packs and items throughout the codebase, improves the pack generation workflow, and enhances the user interface for viewing generated packs. The most important changes include schema updates, backend logic adjustments, and UI improvements to handle and display AI-generated content.

### AI-generated packs and items support

* Added an `isAIGenerated` boolean field to both `packs` and `pack_items` tables in the database schema, including migration scripts and schema definitions for API and frontend types. [[1]](diffhunk://#diff-e0c39e44f6016564095bf2c3e52848f29b70598bf6222012453f7a5bf13718a0R1-R2) [[2]](diffhunk://#diff-742cf0a719f61dafe5bf9a7cfcd30ca428cd12dfe60348a38354a30ff48073ccR83) [[3]](diffhunk://#diff-742cf0a719f61dafe5bf9a7cfcd30ca428cd12dfe60348a38354a30ff48073ccR206) [[4]](diffhunk://#diff-e9aa6008595b2b4ffc40b5feea5de44e5aac8677aeb1fe0aa2001e4cee09a6e0R26) [[5]](diffhunk://#diff-db59f86aa19cc4a9f8e3cc6415abd9329746c9ebd0440f56819e725d2c9546aaR20) [[6]](diffhunk://#diff-db59f86aa19cc4a9f8e3cc6415abd9329746c9ebd0440f56819e725d2c9546aaR44)
* Updated pack and item creation logic on both backend and frontend to set `isAIGenerated` appropriately for AI-generated and user-created items. [[1]](diffhunk://#diff-9a021816f7eeb9dc709a3452012c8fe065f21b9d1da3d9b07a1d789f4154859dR17) [[2]](diffhunk://#diff-16f7bb47b55ff43f3b42b4f5227ad33edcfc89728fc3ceae245478fde7b1a6f8R109) [[3]](diffhunk://#diff-16f7bb47b55ff43f3b42b4f5227ad33edcfc89728fc3ceae245478fde7b1a6f8R119-R124)

### Pack generation workflow improvements

* Refactored backend pack generation: now generates packs and items in a single step, marks them as AI-generated, and simplifies the process by removing candidate item selection and directly saving generated items. [[1]](diffhunk://#diff-16f7bb47b55ff43f3b42b4f5227ad33edcfc89728fc3ceae245478fde7b1a6f8L16-R39) [[2]](diffhunk://#diff-16f7bb47b55ff43f3b42b4f5227ad33edcfc89728fc3ceae245478fde7b1a6f8L112-R99) [[3]](diffhunk://#diff-16f7bb47b55ff43f3b42b4f5227ad33edcfc89728fc3ceae245478fde7b1a6f8R109) [[4]](diffhunk://#diff-16f7bb47b55ff43f3b42b4f5227ad33edcfc89728fc3ceae245478fde7b1a6f8R119-R124)

### UI enhancements for generated packs

* Added a modal to the `AIPacksScreen` for viewing AI-generated packs immediately after generation, including loading state and navigation to pack details. [[1]](diffhunk://#diff-6ead6d47f08a79449de18adee894e264023b872f8ad48289268539c08231aa6bL28-R41) [[2]](diffhunk://#diff-6ead6d47f08a79449de18adee894e264023b872f8ad48289268539c08231aa6bL96-R100) [[3]](diffhunk://#diff-6ead6d47f08a79449de18adee894e264023b872f8ad48289268539c08231aa6bR120-R158)
* Updated `useGeneratedPacks` hook to provide generated packs from the store for use in the modal. [[1]](diffhunk://#diff-efd8a8134472a456fd2af91eb51879e627fec0bed0112549fff3d73d3173d568R1-R12) [[2]](diffhunk://#diff-efd8a8134472a456fd2af91eb51879e627fec0bed0112549fff3d73d3173d568L17-R36)

### Improved handling of AI-generated item images

* Updated `PackItemImage` component to use `CatalogItemImage` for AI-generated items, ensuring consistent image rendering. [[1]](diffhunk://#diff-9550c694ca605fa67a1d52d3f13a9a8d629ac84e8e3b37456f23b8777c9bd8f8R8) [[2]](diffhunk://#diff-9550c694ca605fa67a1d52d3f13a9a8d629ac84e8e3b37456f23b8777c9bd8f8R18-R21)
* Minor improvements to `CatalogItemImage` props and styling for better compatibility and appearance. [[1]](diffhunk://#diff-4d2ab228f4c358e1eef6fb8d7dd0022384b22639452dc48fc31e8f9e908b2f58L6-R6) [[2]](diffhunk://#diff-4d2ab228f4c358e1eef6fb8d7dd0022384b22639452dc48fc31e8f9e908b2f58R35)

### Migration and metadata updates

* Added migration script and metadata entry for new database columns to support AI-generated flags. [[1]](diffhunk://#diff-e0c39e44f6016564095bf2c3e52848f29b70598bf6222012453f7a5bf13718a0R1-R2) [[2]](diffhunk://#diff-28047e561d3652f73c1eff792b1dc31a2b868a9f126a49d7657714415cbaf73eR228-R234)