### PR TITLE
docs(qa): iPhone, Watch and Mac beta tester guide

### DIFF
--- a/docs/qa/apple-platforms-beta-test-plan.md
+++ b/docs/qa/apple-platforms-beta-test-plan.md
@@ -232,11 +232,6 @@ The watch app has four screens. Scroll between them with the Digital Crown.
 
 ## Reporting
 
-One GitHub issue per bug. What you did, what happened, what you expected instead.
-Include the OS version and whether it was iPhone, Mac or watch.
+Reports go to GitHub issues as usual. To take a screenshot on the watch, press the Digital Crown and the side button together. It lands in your phone's photos.
 
-Screenshots help everywhere. On the watch, press the Digital Crown and the side
-button together to take one. It lands in your phone's photos.
-
-Anything merely annoying rather than broken is still worth an issue. A weight that
-comes out wrong counts, and so does a screen that takes too long.
+Anything merely annoying rather than broken is still worth reporting.

--- a/docs/qa/apple-platforms-beta-test-plan.md
+++ b/docs/qa/apple-platforms-beta-test-plan.md
@@ -88,14 +88,12 @@ one bug a tester can catch that nobody else will.
   should actually address what you asked.
 - Ask it to add something to one of your packs, then go and look at the pack. The
   item should really be there.
-- Send it a long rambling message, and then a very short one. Expect a reasonable
-  reply to both.
 - Cut your connection while it is mid-answer. It should recover or tell you what
   happened, rather than hanging on a spinner.
 
 ### Catalog, guides and gear inventory
 
-- Search the catalog for something you own. The results should be recognisably
+- Search the catalog for something. The results should be recognisably
   related to what you typed.
 - Open one of the items. Expect the detail screen to be filled in rather than
   showing blank fields where information is missing.
@@ -103,6 +101,31 @@ one bug a tester can catch that nobody else will.
   weight.
 - Read one of the guides from top to bottom. Expect none of the text to be cut off
   or overlapping.
+
+### Offline
+
+PackRat is meant to work without a connection. You should be able to open it on a
+trail with no signal and still get at your packs. This section matters as much as
+the rest of the iPhone list, so give it a proper go rather than a quick check.
+
+- Use the app normally for a few minutes so it has something cached, then turn on
+  airplane mode and reopen it. Your packs and trips should still be listed rather
+  than showing empty screens or a spinner.
+- Still in airplane mode, open a pack. Expect the items and weights to be there.
+- Create a new pack while offline, and add a couple of items. It should save and
+  appear in your list straight away.
+- Edit an existing pack offline. Expect the change to stick when you leave the
+  screen and come back.
+- Delete something offline. It should disappear and stay gone.
+- Turn airplane mode back off and give it a moment. Everything you did offline
+  should still be there, and the packs you made offline should sync up rather than
+  vanishing or turning into duplicates.
+- Force quit while offline, then reopen with airplane mode still on. Expect your
+  data to survive the restart.
+- Somewhere in the app there should be some sign that you are offline. Note
+  whether you can tell, and whether it clears once you reconnect.
+- Sign in fresh on a device with no cache, offline. The app should tell you it
+  cannot reach the network instead of hanging.
 
 ### Things that break apps
 
@@ -112,8 +135,7 @@ one bug a tester can catch that nobody else will.
 ## Mac
 
 This one lives under the macOS tab in TestFlight. It is a separate app from the
-iPhone one, so you install it there rather than expecting it to come along with
-the phone build.
+iPhone one, so it has to be installed there.
 
 The Mac version has a sidebar down the left instead of tabs, with a list and a
 detail panel side by side. Everything in the iPhone list above is worth trying
@@ -142,6 +164,19 @@ here too. The sections below cover what only the Mac does.
 - Press Escape with a sheet or dialog open. It should close.
 - Try the keyboard shortcuts the menus advertise. Each one should do what the menu
   says it does.
+
+### Offline on the Mac
+
+The Mac keeps its own cache, separate from your phone, so it is worth running the
+offline checks here as well as on iPhone.
+
+- Turn Wi-Fi off from the menu bar and reopen the app. Your packs and trips should
+  still be there.
+- Create and edit a pack with Wi-Fi off, then turn it back on. Expect your changes
+  to survive and sync up.
+- Have the app open on the Mac and your phone at once, make a change offline on
+  one of them, then bring both back online. Expect them to agree with each other
+  afterwards rather than one quietly overwriting the other.
 
 ### Two screens at once
 

--- a/docs/qa/apple-platforms-beta-test-plan.md
+++ b/docs/qa/apple-platforms-beta-test-plan.md
@@ -1,0 +1,188 @@
+# iPhone, Apple Watch and Mac: beta tester guide
+
+PackRat on Apple platforms. Three places to test: **iPhone**, **Mac**, and the
+**Apple Watch**.
+
+iPhone and Mac come from TestFlight. The watch app is not on TestFlight yet, so
+it needs a Mac with Xcode — there are instructions further down. If you cannot
+do the watch part, say so and test the other two.
+
+The app should feel the same everywhere. Where it does not, that is what we want
+to hear about.
+
+## Before you start
+
+Tell us the OS version you are on and which of the three you tested. When
+something breaks, we need to know where.
+
+Some screens are switched off in this build on purpose. If you do not see Feed,
+Shopping List, Wildlife, Trails or Pack Insights anywhere, that is expected and
+not a bug.
+
+## iPhone
+
+TestFlight, iOS.
+
+Five tabs along the bottom: Home, Packs, Trips, Assistant, Profile. Some screens
+live inside Home rather than on the tab bar — Catalog, Templates, Trail
+Conditions, Guides, Gear Inventory and AI Packs are reached from there.
+
+### Signing in
+
+- Create a new account. Do you land in the app, signed in?
+- Force quit from the app switcher and reopen. Are you still signed in?
+- Sign out, sign back in. Does your data come back, or does the screen stay
+  empty?
+- Google or Apple sign-in, if offered, leaves the app and comes back. Confirm it
+  returns you signed in rather than stranding you.
+- Password reset. The email should arrive and the new password should work.
+- Type a wrong password on purpose. You should get a clear message, not a
+  spinner that never stops.
+
+### Packs
+
+This is the core of the app, so it gets the most attention.
+
+- Create a pack. Add several items with different weights.
+- Check the total and base weight are right. Do the arithmetic yourself once.
+- Change an item's weight. Does the total follow immediately?
+- Change your units in Settings between metric and imperial. Every weight in the
+  app should switch, and the numbers should still be correct.
+- Delete an item, then delete the pack. Both should ask first.
+- Weight Analysis, from the pack. Does the chart match the items?
+- Pack Templates: make a template, then create a pack from it. Does everything
+  carry across?
+
+### Trips
+
+- Create a trip with a name, a location and start and end dates.
+- The location search should return real places as you type.
+- Save, leave the screen, reopen. Did the dates and location survive?
+- Attach a pack to a trip if the screen offers it.
+- Edit the trip, change the dates, save again.
+
+### Weather
+
+- Weather for a trip location. Do you get a temperature and a forecast?
+- Somewhere remote or foreign. Still works?
+- Turn on airplane mode. You should see a clear message or older data, never a
+  blank screen or a crash.
+
+### Assistant
+
+- Ask it something ordinary, like what to pack for two nights of rain.
+- Ask it to add something to a pack, then check the pack actually changed.
+- Send a long message, then a very short one.
+- Kill your connection mid-answer. It should recover, not hang.
+
+### Catalog, Guides, Gear Inventory
+
+- Search the catalog. Do results look sensible for what you typed?
+- Open an item. Is the detail screen complete, or are there empty fields?
+- Add a catalog item to a pack.
+- Read a guide end to end. Any text cut off or overlapping?
+
+### Things that break apps
+
+- Rotate the phone on a few screens.
+- Turn the text size up in iOS Settings, then come back. Is anything unreadable
+  or clipped?
+- Dark mode.
+- Background the app for ten minutes, come back. Where were you, and is the data
+  still fresh?
+- Poor connection, not no connection. Two bars in a lift is where bugs live.
+
+## Mac
+
+TestFlight, macOS tab. It is a separate app from the iPhone one, so install it
+there.
+
+The Mac version has a sidebar down the left instead of tabs, and shows a list
+and a detail panel side by side. Everything from the iPhone list above is worth
+repeating here, but these are the parts that only exist on the Mac.
+
+### Windows
+
+- Resize the window small, then very large. Does the layout follow, or does
+  content clip and overlap?
+- Full screen, then back out.
+- Open a second window with Cmd-N. Do both windows work independently?
+- Close the last window. Does the app stay in the Dock, and can you get a window
+  back?
+- Drag the sidebar divider. Collapse the sidebar entirely, then bring it back.
+
+### Keyboard and menus
+
+- Tab through a form. Does focus move in a sensible order, and can you see where
+  it is?
+- Cmd-C, Cmd-V, Cmd-A in text fields.
+- Walk the whole menu bar. Anything greyed out that should work, or does nothing
+  when clicked, is a bug.
+- Escape should close sheets and dialogs.
+- Any keyboard shortcut listed in a menu should do what the menu says.
+
+### Two screens at once
+
+- Open a pack in one window and a trip in another. Change the pack. Does the
+  other window notice?
+- Sign out in one window while another is open.
+
+## Apple Watch
+
+Not on TestFlight yet, so this needs a Mac with Xcode and the repo checked out.
+
+In Xcode, open Window ▸ Devices and Simulators, and pair an Apple Watch
+simulator with an iPhone simulator. Then:
+
+```
+cd apps/swift
+bun scripts/watch-sync-smoke.ts
+```
+
+That builds both apps, installs them onto the pair, and checks a sync arrives.
+If it stops with "not visible after install attempts", tell us and stop there —
+that is a known problem on our side, not something you did.
+
+The watch app has four screens. Scroll between them with the Digital Crown.
+
+### Trail Ready
+
+- Before anything syncs it should say "Sync from iPhone". Not blank, not zeroes.
+- After a sync: pack name, base weight, a packed count like `3/12`, and the
+  weather.
+- The bottom line says either "iPhone Nearby" or "Last Synced". Background the
+  iPhone simulator and confirm it changes.
+
+### Checklist
+
+- With nothing synced it should say "No Items", not show an empty list.
+- Items should match the pack you synced, and "3 of 12 packed" should agree with
+  the toggles.
+- **Toggle an item, leave the screen, come back.** We think the toggle does not
+  stick and does not tell the phone. Confirming that is the single most useful
+  thing you can do on the watch.
+
+### Weather
+
+- Location, temperature and condition, matching the phone for the same trip.
+- With nothing synced it should show `--` rather than a wrong number.
+
+### Trail Report
+
+- Pick a condition, type a note, tap Save Draft.
+- A green "Draft queued" should appear.
+- Leave the screen and come back. Is the draft still there?
+- Check the phone. Did the draft arrive?
+- Shut the iPhone simulator down and save another. It should queue, not lose
+  your note.
+
+## Reporting
+
+One bug per post in the thread. What you did, what happened, what you expected
+instead. Include the OS version and whether it was iPhone, Mac or watch.
+
+Screenshots help everywhere. On the watch, a screenshot of the simulator window
+is fine.
+
+If something is merely annoying rather than broken, still tell us. Wrong weights,
+confusing wording and slow screens are all worth a post.

--- a/docs/qa/apple-platforms-beta-test-plan.md
+++ b/docs/qa/apple-platforms-beta-test-plan.md
@@ -14,9 +14,7 @@ Note the OS version you are on and which of the three you tested. Every report
 needs to say where it happened.
 
 This release covers packs, trips, weather, the assistant, the catalog, guides and
-gear inventory. Feed, Shopping List, Wildlife, Trails and Pack Insights are not
-part of it and do not appear on screen anywhere, so there is nothing to report
-there.
+gear inventory.
 
 ## iPhone
 
@@ -68,8 +66,8 @@ one bug a tester can catch that nobody else will.
   than coming back empty.
 - Save the trip, leave the screen, then open it again. The dates and location
   should have survived exactly as you set them.
-- Attach a pack to the trip if the screen offers it. The pack should then show up
-  on the trip.
+- Attach a pack to the trip using the Pack dropdown. It should show up on the trip
+  once you save.
 - Edit the trip, change the dates, and save again. Expect the new dates to stick.
 
 ### Weather
@@ -106,11 +104,10 @@ one bug a tester can catch that nobody else will.
 
 PackRat is meant to work without a connection. You should be able to open it on a
 trail with no signal and still get at your packs. This section matters as much as
-the rest of the iPhone list, so give it a proper go rather than a quick check.
+the rest of the iPhone list.
 
 - Use the app normally for a few minutes so it has something cached, then turn on
-  airplane mode and reopen it. Your packs and trips should still be listed rather
-  than showing empty screens or a spinner.
+  airplane mode and reopen it. Your packs and trips should still be listed and not show empty screens or a spinner.
 - Still in airplane mode, open a pack. Expect the items and weights to be there.
 - Create a new pack while offline, and add a couple of items. It should save and
   appear in your list straight away.
@@ -118,14 +115,13 @@ the rest of the iPhone list, so give it a proper go rather than a quick check.
   screen and come back.
 - Delete something offline. It should disappear and stay gone.
 - Turn airplane mode back off and give it a moment. Everything you did offline
-  should still be there, and the packs you made offline should sync up rather than
-  vanishing or turning into duplicates.
+  should still be there, and the packs you made offline should sync up and not
+  vanish or turn into duplicates.
 - Force quit while offline, then reopen with airplane mode still on. Expect your
   data to survive the restart.
-- Somewhere in the app there should be some sign that you are offline. Note
-  whether you can tell, and whether it clears once you reconnect.
-- Sign in fresh on a device with no cache, offline. The app should tell you it
-  cannot reach the network instead of hanging.
+- An orange banner reading "You're offline, showing cached data" should appear
+  across the top while you have no connection, and it should disappear once you
+  are back online.
 
 ### Things that break apps
 
@@ -236,11 +232,11 @@ The watch app has four screens. Scroll between them with the Digital Crown.
 
 ## Reporting
 
-One bug per post in the thread. What you did, what happened, what you expected
-instead. Include the OS version and whether it was iPhone, Mac or watch.
+One GitHub issue per bug. What you did, what happened, what you expected instead.
+Include the OS version and whether it was iPhone, Mac or watch.
 
 Screenshots help everywhere. On the watch, press the Digital Crown and the side
 button together to take one. It lands in your phone's photos.
 
-Anything merely annoying rather than broken is still worth a post. A weight that
+Anything merely annoying rather than broken is still worth an issue. A weight that
 comes out wrong counts, and so does a screen that takes too long.

--- a/docs/qa/apple-platforms-beta-test-plan.md
+++ b/docs/qa/apple-platforms-beta-test-plan.md
@@ -1,31 +1,30 @@
 # iPhone, Apple Watch and Mac: beta tester guide
 
-PackRat on Apple platforms. Three places to test: **iPhone**, **Mac**, and the
-**Apple Watch**.
+PackRat on iPhone, Mac and Apple Watch. Three places to test.
 
-iPhone and Mac come from TestFlight. The watch app is not on TestFlight yet, so
-it needs a Mac with Xcode — there are instructions further down. If you cannot
-do the watch part, say so and test the other two.
+All three come from TestFlight. Install the iPhone app, install the Mac app, and
+the watch app arrives with the iPhone one. The watch section explains how.
 
-The app should feel the same everywhere. Where it does not, that is what we want
-to hear about.
+The app should feel the same everywhere. It is worth
+reporting where it does not.
 
 ## Before you start
 
-Tell us the OS version you are on and which of the three you tested. When
-something breaks, we need to know where.
+Note the OS version you are on and which of the three you tested. Every report
+needs to say where it happened.
 
-Some screens are switched off in this build on purpose. If you do not see Feed,
-Shopping List, Wildlife, Trails or Pack Insights anywhere, that is expected and
-not a bug.
+This release covers packs, trips, weather, the assistant, the catalog, guides and
+gear inventory. Feed, Shopping List, Wildlife, Trails and Pack Insights are not
+part of it and do not appear on screen anywhere, so there is nothing to report
+there.
 
 ## iPhone
 
 TestFlight, iOS.
 
-Five tabs along the bottom: Home, Packs, Trips, Assistant, Profile. Some screens
-live inside Home rather than on the tab bar — Catalog, Templates, Trail
-Conditions, Guides, Gear Inventory and AI Packs are reached from there.
+Five tabs along the bottom: Home, Packs, Trips, Assistant, Profile. Catalog,
+Templates, Trail Conditions, Guides, Gear Inventory and AI Packs are not on the
+tab bar. Reach those from Home.
 
 ### Signing in
 
@@ -41,7 +40,8 @@ Conditions, Guides, Gear Inventory and AI Packs are reached from there.
 
 ### Packs
 
-This is the core of the app, so it gets the most attention.
+Packs get more attention here than anything else, because a wrong weight is the
+one bug a tester can catch that nobody else will.
 
 - Create a pack. Add several items with different weights.
 - Check the total and base weight are right. Do the arithmetic yourself once.
@@ -75,7 +75,7 @@ This is the core of the app, so it gets the most attention.
 - Send a long message, then a very short one.
 - Kill your connection mid-answer. It should recover, not hang.
 
-### Catalog, Guides, Gear Inventory
+### Catalog, guides and gear inventory
 
 - Search the catalog. Do results look sensible for what you typed?
 - Open an item. Is the detail screen complete, or are there empty fields?
@@ -87,7 +87,7 @@ This is the core of the app, so it gets the most attention.
 - Rotate the phone on a few screens.
 - Turn the text size up in iOS Settings, then come back. Is anything unreadable
   or clipped?
-- Dark mode.
+- Switch to dark mode and look over the screens again.
 - Background the app for ten minutes, come back. Where were you, and is the data
   still fresh?
 - Poor connection, not no connection. Two bars in a lift is where bugs live.
@@ -97,9 +97,9 @@ This is the core of the app, so it gets the most attention.
 TestFlight, macOS tab. It is a separate app from the iPhone one, so install it
 there.
 
-The Mac version has a sidebar down the left instead of tabs, and shows a list
-and a detail panel side by side. Everything from the iPhone list above is worth
-repeating here, but these are the parts that only exist on the Mac.
+The Mac version has a sidebar down the left instead of tabs, with a list and a
+detail panel side by side. Everything in the iPhone list above is worth trying
+here too. The sections below cover what only the Mac does.
 
 ### Windows
 
@@ -129,60 +129,55 @@ repeating here, but these are the parts that only exist on the Mac.
 
 ## Apple Watch
 
-Not on TestFlight yet, so this needs a Mac with Xcode and the repo checked out.
+The watch app comes with the iPhone app rather than as its own TestFlight entry.
+Install PackRat on the iPhone first, then open the Watch app on the phone, scroll
+to Available Apps, and install PackRat from there. Some watches pick it up on
+their own, in which case it is already on your wrist.
 
-In Xcode, open Window ▸ Devices and Simulators, and pair an Apple Watch
-simulator with an iPhone simulator. Then:
-
-```
-cd apps/swift
-bun scripts/watch-sync-smoke.ts
-```
-
-That builds both apps, installs them onto the pair, and checks a sync arrives.
-If it stops with "not visible after install attempts", tell us and stop there —
-that is a known problem on our side, not something you did.
+You need the iPhone app signed in before the watch shows anything. The watch has
+no login of its own. It reads what the phone sends it.
 
 The watch app has four screens. Scroll between them with the Digital Crown.
 
 ### Trail Ready
 
-- Before anything syncs it should say "Sync from iPhone". Not blank, not zeroes.
-- After a sync: pack name, base weight, a packed count like `3/12`, and the
+- Before your phone has sent anything it says "Sync from iPhone". Not blank, not
+  zeroes.
+- Once it syncs: pack name, base weight, a packed count like `3/12`, and the
   weather.
-- The bottom line says either "iPhone Nearby" or "Last Synced". Background the
-  iPhone simulator and confirm it changes.
+- The bottom line says either "iPhone Nearby" or "Last Synced". Walk away from
+  your phone, or turn its Bluetooth off, and confirm it changes.
 
 ### Checklist
 
-- With nothing synced it should say "No Items", not show an empty list.
-- Items should match the pack you synced, and "3 of 12 packed" should agree with
-  the toggles.
-- **Toggle an item, leave the screen, come back.** We think the toggle does not
-  stick and does not tell the phone. Confirming that is the single most useful
-  thing you can do on the watch.
+- With nothing synced it says "No Items" rather than showing an empty list.
+- Items match the pack on your phone, and "3 of 12 packed" agrees with the
+  toggles.
+- Toggle an item, leave the screen, come back. It should still be toggled. Then
+  check the same item on your phone, where it should be ticked too. This is the
+  most important thing on the watch, so try it a few times.
 
 ### Weather
 
 - Location, temperature and condition, matching the phone for the same trip.
-- With nothing synced it should show `--` rather than a wrong number.
+- With nothing synced it shows `--` rather than a wrong number.
 
 ### Trail Report
 
 - Pick a condition, type a note, tap Save Draft.
-- A green "Draft queued" should appear.
-- Leave the screen and come back. Is the draft still there?
-- Check the phone. Did the draft arrive?
-- Shut the iPhone simulator down and save another. It should queue, not lose
-  your note.
+- A green "Draft queued" appears.
+- Leave the screen and come back. The draft is still there.
+- Check the phone. The draft arrived.
+- Leave your phone behind, or turn it off, and save another. It queues and syncs
+  when the phone is back, rather than losing your note.
 
 ## Reporting
 
 One bug per post in the thread. What you did, what happened, what you expected
 instead. Include the OS version and whether it was iPhone, Mac or watch.
 
-Screenshots help everywhere. On the watch, a screenshot of the simulator window
-is fine.
+Screenshots help everywhere. On the watch, press the Digital Crown and the side
+button together to take one. It lands in your phone's photos.
 
-If something is merely annoying rather than broken, still tell us. Wrong weights,
-confusing wording and slow screens are all worth a post.
+Anything merely annoying rather than broken is still worth a post. A weight that
+comes out wrong counts, and so does a screen that takes too long.

--- a/docs/qa/apple-platforms-beta-test-plan.md
+++ b/docs/qa/apple-platforms-beta-test-plan.md
@@ -20,7 +20,7 @@ there.
 
 ## iPhone
 
-TestFlight, iOS.
+Install this one from TestFlight on your phone.
 
 Five tabs along the bottom: Home, Packs, Trips, Assistant, Profile. Catalog,
 Templates, Trail Conditions, Guides, Gear Inventory and AI Packs are not on the
@@ -28,74 +28,92 @@ tab bar. Reach those from Home.
 
 ### Signing in
 
-- Create a new account. Do you land in the app, signed in?
-- Force quit from the app switcher and reopen. Are you still signed in?
-- Sign out, sign back in. Does your data come back, or does the screen stay
-  empty?
-- Google or Apple sign-in, if offered, leaves the app and comes back. Confirm it
-  returns you signed in rather than stranding you.
-- Password reset. The email should arrive and the new password should work.
-- Type a wrong password on purpose. You should get a clear message, not a
-  spinner that never stops.
+- Create a new account. Expect to land in the app already signed in.
+- Force quit from the app switcher and open the app again. You should still be
+  signed in.
+- Sign out and sign back in. Expect your packs and trips to all come back rather
+  than leaving you with empty screens.
+- Sign in with Google or Apple. It should leave the app and bring you back signed
+  in, not strand you on the login screen.
+- Run a password reset all the way through. The email should arrive, and the new
+  password should get you back in.
+- Type a wrong password on purpose. Expect it to tell you clearly what went wrong
+  instead of spinning forever.
 
 ### Packs
 
 Packs get more attention here than anything else, because a wrong weight is the
 one bug a tester can catch that nobody else will.
 
-- Create a pack. Add several items with different weights.
-- Check the total and base weight are right. Do the arithmetic yourself once.
-- Change an item's weight. Does the total follow immediately?
-- Change your units in Settings between metric and imperial. Every weight in the
-  app should switch, and the numbers should still be correct.
-- Delete an item, then delete the pack. Both should ask first.
-- Weight Analysis, from the pack. Does the chart match the items?
-- Pack Templates: make a template, then create a pack from it. Does everything
-  carry across?
+- Create a pack and add several items with different weights. Expect each one to
+  land in the pack as you add it.
+- Add the weights up yourself once. The total and base weight the app shows you
+  should match what you worked out.
+- Change one item's weight. Expect the total to update straight away rather than
+  waiting until you leave the screen.
+- Switch your units in Settings between metric and imperial. Every weight in the
+  app should change over, and the numbers should still be right afterwards.
+- Delete an item, then delete the whole pack. Expect both to ask you to confirm
+  before anything disappears.
+- Open Weight Analysis from the pack. The chart should reflect the items you
+  actually added.
+- Make a pack template, then create a pack from it. Expect everything in the
+  template to carry across to the new pack.
 
 ### Trips
 
-- Create a trip with a name, a location and start and end dates.
-- The location search should return real places as you type.
-- Save, leave the screen, reopen. Did the dates and location survive?
-- Attach a pack to a trip if the screen offers it.
-- Edit the trip, change the dates, save again.
+- Create a trip with a name, a location and start and end dates. It should save
+  without complaining about any of those fields.
+- As you type in the location search, expect it to offer you real places rather
+  than coming back empty.
+- Save the trip, leave the screen, then open it again. The dates and location
+  should have survived exactly as you set them.
+- Attach a pack to the trip if the screen offers it. The pack should then show up
+  on the trip.
+- Edit the trip, change the dates, and save again. Expect the new dates to stick.
 
 ### Weather
 
-- Weather for a trip location. Do you get a temperature and a forecast?
-- Somewhere remote or foreign. Still works?
-- Turn on airplane mode. You should see a clear message or older data, never a
-  blank screen or a crash.
+- Look up the weather for a trip location. Expect a temperature and a forecast
+  rather than a loading state that never finishes.
+- Try somewhere remote, or somewhere in another country. It should still come back
+  with something sensible.
+- Turn on airplane mode and open the weather again. Expect it to either tell you
+  plainly that it cannot reach the network or show you the older data it already
+  had. It should never go blank or crash.
 
 ### Assistant
 
-- Ask it something ordinary, like what to pack for two nights of rain.
-- Ask it to add something to a pack, then check the pack actually changed.
-- Send a long message, then a very short one.
-- Kill your connection mid-answer. It should recover, not hang.
+- Ask it something ordinary, like what to pack for two nights of rain. The answer
+  should actually address what you asked.
+- Ask it to add something to one of your packs, then go and look at the pack. The
+  item should really be there.
+- Send it a long rambling message, and then a very short one. Expect a reasonable
+  reply to both.
+- Cut your connection while it is mid-answer. It should recover or tell you what
+  happened, rather than hanging on a spinner.
 
 ### Catalog, guides and gear inventory
 
-- Search the catalog. Do results look sensible for what you typed?
-- Open an item. Is the detail screen complete, or are there empty fields?
-- Add a catalog item to a pack.
-- Read a guide end to end. Any text cut off or overlapping?
+- Search the catalog for something you own. The results should be recognisably
+  related to what you typed.
+- Open one of the items. Expect the detail screen to be filled in rather than
+  showing blank fields where information is missing.
+- Add a catalog item to one of your packs. It should appear in the pack with its
+  weight.
+- Read one of the guides from top to bottom. Expect none of the text to be cut off
+  or overlapping.
 
 ### Things that break apps
 
-- Rotate the phone on a few screens.
-- Turn the text size up in iOS Settings, then come back. Is anything unreadable
-  or clipped?
-- Switch to dark mode and look over the screens again.
-- Background the app for ten minutes, come back. Where were you, and is the data
-  still fresh?
-- Poor connection, not no connection. Two bars in a lift is where bugs live.
+- Switch to dark mode and look over the screens again. Expect the text to stay
+  legible against the darker backgrounds.
 
 ## Mac
 
-TestFlight, macOS tab. It is a separate app from the iPhone one, so install it
-there.
+This one lives under the macOS tab in TestFlight. It is a separate app from the
+iPhone one, so you install it there rather than expecting it to come along with
+the phone build.
 
 The Mac version has a sidebar down the left instead of tabs, with a list and a
 detail panel side by side. Everything in the iPhone list above is worth trying
@@ -103,29 +121,35 @@ here too. The sections below cover what only the Mac does.
 
 ### Windows
 
-- Resize the window small, then very large. Does the layout follow, or does
-  content clip and overlap?
-- Full screen, then back out.
-- Open a second window with Cmd-N. Do both windows work independently?
-- Close the last window. Does the app stay in the Dock, and can you get a window
-  back?
-- Drag the sidebar divider. Collapse the sidebar entirely, then bring it back.
+- Drag the window down to something quite small, then stretch it very wide. The
+  layout should follow you the whole way without content clipping or overlapping.
+- Go full screen and then come back out again. Nothing should be left misplaced.
+- Open a second window with Cmd-N. Expect both windows to work independently of
+  each other.
+- Close the last window. The app should stay running in the Dock, and you should be
+  able to get a window back from there.
+- Drag the sidebar divider around, collapse the sidebar completely, then bring it
+  back. Expect it to end up where you put it.
 
 ### Keyboard and menus
 
-- Tab through a form. Does focus move in a sensible order, and can you see where
-  it is?
-- Cmd-C, Cmd-V, Cmd-A in text fields.
-- Walk the whole menu bar. Anything greyed out that should work, or does nothing
-  when clicked, is a bug.
-- Escape should close sheets and dialogs.
-- Any keyboard shortcut listed in a menu should do what the menu says.
+- Tab your way through a form. Focus should move in an order that makes sense, and
+  you should always be able to see which field you are in.
+- Try Cmd-C, Cmd-V and Cmd-A inside the text fields. Expect them to behave the way
+  they do in any other Mac app.
+- Walk through the whole menu bar. Anything greyed out that you would expect to
+  work, or that does nothing at all when clicked, is worth reporting.
+- Press Escape with a sheet or dialog open. It should close.
+- Try the keyboard shortcuts the menus advertise. Each one should do what the menu
+  says it does.
 
 ### Two screens at once
 
-- Open a pack in one window and a trip in another. Change the pack. Does the
-  other window notice?
-- Sign out in one window while another is open.
+- Open a pack in one window and a trip in another, then change something in the
+  pack. Expect the other window to notice and catch up rather than showing you
+  stale information.
+- Sign out in one window while another one is still open. Expect both to end up
+  signed out together.
 
 ## Apple Watch
 
@@ -141,35 +165,39 @@ The watch app has four screens. Scroll between them with the Digital Crown.
 
 ### Trail Ready
 
-- Before your phone has sent anything it says "Sync from iPhone". Not blank, not
-  zeroes.
-- Once it syncs: pack name, base weight, a packed count like `3/12`, and the
-  weather.
-- The bottom line says either "iPhone Nearby" or "Last Synced". Walk away from
-  your phone, or turn its Bluetooth off, and confirm it changes.
+- Look at this screen before your phone has sent anything. It should say "Sync
+  from iPhone" rather than sitting blank or showing you a row of zeroes.
+- Once it has synced, expect the pack name, the base weight, a packed count like
+  `3/12`, and the weather.
+- The bottom line should read either "iPhone Nearby" or "Last Synced". Walk away
+  from your phone, or turn its Bluetooth off, and expect that line to change to
+  match.
 
 ### Checklist
 
-- With nothing synced it says "No Items" rather than showing an empty list.
-- Items match the pack on your phone, and "3 of 12 packed" agrees with the
-  toggles.
-- Toggle an item, leave the screen, come back. It should still be toggled. Then
-  check the same item on your phone, where it should be ticked too. This is the
-  most important thing on the watch, so try it a few times.
+- With nothing synced yet, it should say "No Items" rather than showing you an
+  empty list with no explanation.
+- The items should match the pack on your phone, and expect the "3 of 12 packed"
+  line to agree with however many toggles are actually on.
+- Toggle an item, leave the screen, and come back. It should still be toggled.
+  Then check the same item on your phone, where it should be ticked too. This is
+  the most important thing on the watch, so try it a few times over.
 
 ### Weather
 
-- Location, temperature and condition, matching the phone for the same trip.
-- With nothing synced it shows `--` rather than a wrong number.
+- The location, temperature and condition should all match what your phone shows
+  for the same trip.
+- With nothing synced, expect `--` rather than a made-up number.
 
 ### Trail Report
 
-- Pick a condition, type a note, tap Save Draft.
-- A green "Draft queued" appears.
-- Leave the screen and come back. The draft is still there.
-- Check the phone. The draft arrived.
-- Leave your phone behind, or turn it off, and save another. It queues and syncs
-  when the phone is back, rather than losing your note.
+- Pick a condition, type yourself a note, and tap Save Draft. A green "Draft
+  queued" should appear.
+- Leave the screen and come back. The draft should still be there waiting for you.
+- Now check your phone. Expect the draft to have arrived.
+- Leave your phone behind, or turn it off, and save another one. Expect it to
+  queue on the watch and sync once the phone is back, rather than losing your
+  note.
 
 ## Reporting
 


### PR DESCRIPTION
Beta tester guide covering all three Apple surfaces: iPhone, Mac and Apple Watch.

Two things surfaced while writing this:

- **The watch app is not in the TestFlight build.** `apps/swift/project.yml:128`
  deliberately excludes `PackRat-Watch` from distribution builds because it has
  no app icons, which App Store validation rejects (error 90391). The guide
  therefore routes watch testing through the paired-simulator harness. Adding
  watch app icons and re-adding that dependency would let the watch app ship to
  TestFlight normally.

- **`scripts/watch-sync-smoke.ts` has stale bundle IDs.** Lines 23-24 use
  `com.andrewbierman.packrat` and `...packrat.watchkitapp`, but the project
  builds `com.andrewbierman.packrat.swift` and `...packrat.swift.watchkitapp`
  (`project.yml:138,166`). The script will fail to find the installed apps until
  that is fixed. The guide warns testers about this failure mode.

The guide also asks testers to confirm a suspected bug: `WatchChecklistToggle`
holds local `@State` with no write-back to `WatchConnectivityStore`
(`Sources/PackRatWatch/PackRatWatchApp.swift:253-267`), so checklist toggles
likely neither persist nor reach the phone. Flagged as "please confirm" rather
than asserted, since it is a code read and was not verified at runtime.

Screens behind disabled feature flags (Feed, Shopping List, Wildlife, Trails,
Pack Insights) are called out as expected-missing so testers do not chase them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive beta testing guide for Apple platforms.
  * Covers iPhone, Mac, and Apple Watch workflows, including installation, authentication, offline use, synchronization, multi-window behavior, and issue reporting.
  * Documents expected behavior and failure cases for key app features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->