### PR TITLE
chore(mcp): set destructiveHint explicitly on all read-only tools

### DIFF
--- a/packages/mcp/src/tools/ai.ts
+++ b/packages/mcp/src/tools/ai.ts
@@ -17,6 +17,7 @@ export function registerAiTools(agent: AgentContext): void {
       annotations: {
         title: 'Web Search',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: false,
         openWorldHint: true,
       },
@@ -47,6 +48,7 @@ export function registerAiTools(agent: AgentContext): void {
   //     annotations: {
   //       title: 'Execute Read-Only SQL Query',
   //       readOnlyHint: true,
+  //       destructiveHint: false,
   //       idempotentHint: true,
   //       openWorldHint: false,
   //     },
@@ -72,6 +74,7 @@ export function registerAiTools(agent: AgentContext): void {
   //     annotations: {
   //       title: 'Get Database Schema',
   //       readOnlyHint: true,
+  //       destructiveHint: false,
   //       idempotentHint: true,
   //       openWorldHint: false,
   //     },

--- a/packages/mcp/src/tools/auth.ts
+++ b/packages/mcp/src/tools/auth.ts
@@ -44,6 +44,7 @@ export function registerAuthTools(agent: AgentContext): void {
       annotations: {
         title: 'Who Am I',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/catalog.ts
+++ b/packages/mcp/src/tools/catalog.ts
@@ -47,6 +47,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       annotations: {
         title: 'Search Gear Catalog',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -82,6 +83,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       annotations: {
         title: 'Semantic Gear Search',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -108,6 +110,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Catalog Item',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -136,6 +139,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       annotations: {
         title: 'Find Similar Catalog Items',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -166,6 +170,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       annotations: {
         title: 'List Gear Categories',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -270,6 +275,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       annotations: {
         title: 'Compare Gear Items',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/feed.ts
+++ b/packages/mcp/src/tools/feed.ts
@@ -19,6 +19,7 @@ export function registerFeedTools(agent: AgentContext): void {
       annotations: {
         title: 'List Feed Posts',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -75,6 +76,7 @@ export function registerFeedTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Feed Post',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -152,6 +154,7 @@ export function registerFeedTools(agent: AgentContext): void {
       annotations: {
         title: 'List Feed Comments',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/guides.ts
+++ b/packages/mcp/src/tools/guides.ts
@@ -26,6 +26,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       annotations: {
         title: 'List Outdoor Guides',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -54,6 +55,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       annotations: {
         title: 'List Guide Categories',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -85,6 +87,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       annotations: {
         title: 'Search Outdoor Guides',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -106,6 +109,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Guide',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/knowledge.ts
+++ b/packages/mcp/src/tools/knowledge.ts
@@ -20,6 +20,7 @@ export function registerKnowledgeTools(agent: AgentContext): void {
       annotations: {
         title: 'Search Outdoor Knowledge Base',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -44,6 +45,7 @@ export function registerKnowledgeTools(agent: AgentContext): void {
       annotations: {
         title: 'Extract URL Content',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: false,
         openWorldHint: true,
       },

--- a/packages/mcp/src/tools/packTemplates.ts
+++ b/packages/mcp/src/tools/packTemplates.ts
@@ -118,6 +118,7 @@ export function registerPackTemplateTools(agent: AgentContext): void {
       annotations: {
         title: 'List Pack Templates',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -136,6 +137,7 @@ export function registerPackTemplateTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Pack Template',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -366,6 +368,7 @@ export function registerPackTemplateTools(agent: AgentContext): void {
       annotations: {
         title: 'List Pack Template Items',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/packs.ts
+++ b/packages/mcp/src/tools/packs.ts
@@ -41,6 +41,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'List My Packs',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -83,6 +84,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Pack',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -232,6 +234,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'List Pack Items',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -256,6 +259,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Pack Item',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -436,6 +440,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Find Similar Pack Items',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -471,6 +476,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Suggest Pack Items',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -497,6 +503,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Pack Weight History',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -547,6 +554,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Analyze Pack Weight',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -586,6 +594,7 @@ export function registerPackTools(agent: AgentContext): void {
       annotations: {
         title: 'Analyze Pack Gaps',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -634,6 +643,7 @@ export function registerPackTools(agent: AgentContext): void {
   //     annotations: {
   //       title: 'Analyze Pack Image',
   //       readOnlyHint: true,
+  //       destructiveHint: false,
   //       idempotentHint: false,
   //       openWorldHint: true,
   //     },

--- a/packages/mcp/src/tools/seasons.ts
+++ b/packages/mcp/src/tools/seasons.ts
@@ -20,6 +20,7 @@ export function registerSeasonTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Season Suggestions',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/trail-conditions.ts
+++ b/packages/mcp/src/tools/trail-conditions.ts
@@ -21,6 +21,7 @@ export function registerTrailConditionTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Trail Condition Reports',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -51,6 +52,7 @@ export function registerTrailConditionTools(agent: AgentContext): void {
       annotations: {
         title: 'List My Trail Reports',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/trips.ts
+++ b/packages/mcp/src/tools/trips.ts
@@ -42,6 +42,7 @@ export function registerTripTools(agent: AgentContext): void {
       annotations: {
         title: 'List My Trips',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
@@ -76,6 +77,7 @@ export function registerTripTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Trip',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/user.ts
+++ b/packages/mcp/src/tools/user.ts
@@ -16,6 +16,7 @@ export function registerUserTools(agent: AgentContext): void {
       annotations: {
         title: 'Get My Profile',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },

--- a/packages/mcp/src/tools/weather.ts
+++ b/packages/mcp/src/tools/weather.ts
@@ -27,6 +27,7 @@ export function registerWeatherTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Weather Forecast',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: true,
       },
@@ -52,6 +53,7 @@ export function registerWeatherTools(agent: AgentContext): void {
       annotations: {
         title: 'Search Weather Locations',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: true,
       },
@@ -79,6 +81,7 @@ export function registerWeatherTools(agent: AgentContext): void {
       annotations: {
         title: 'Search Weather By Coordinates',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: true,
       },
@@ -105,6 +108,7 @@ export function registerWeatherTools(agent: AgentContext): void {
       annotations: {
         title: 'Get Weather Forecast By Location ID',
         readOnlyHint: true,
+        destructiveHint: false,
         idempotentHint: true,
         openWorldHint: true,
       },


### PR DESCRIPTION
## What

Set `destructiveHint` explicitly on the 38 read-only MCP tools that previously omitted it.

## Why

The ChatGPT Apps submission requires `readOnlyHint`, `openWorldHint`, and `destructiveHint` to all be set explicitly on every tool. Missing or null values are a submission blocker, even though MCP has protocol-level defaults.

Our read-only tools declared `readOnlyHint: true` and `openWorldHint` but left `destructiveHint` unset. All 38 are strict read paths (no create/update/delete), so they now declare `destructiveHint: false`.

Write and delete tools already declared all three correctly and are unchanged, e.g. `packrat_delete_pack` / `packrat_delete_trip` / `packrat_remove_pack_item` keep `destructiveHint: true`.

## Scope

Annotation-only. No runtime behavior change, no schema change, no tool added or removed.

13 files, +42 lines, 0 deletions.

## Verification

- `tsc --noEmit` clean
- `biome check` clean
- `bun test:mcp` 1273 pass, 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Clarified that search, catalog, feed, guide, knowledge, pack, season, trail, trip, profile, weather, and authentication tools are non-destructive.
  * Improved tool metadata to help integrations safely identify read-only operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->