### PR TITLE
fix(ui): repair broken catalog card layout and invisible sign-out label

### DIFF
--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -87,15 +87,48 @@ function resolveVariant(variant: ButtonVariant): ResolvedVariant {
   return VARIANT_MAP[variant];
 }
 
-/** Unwraps `<Button><Text>Save</Text></Button>` to the string `'Save'`. */
+/**
+ * The `Text` props that carry visual intent. Any one of them present means the call site styled its
+ * own label, so `extractLabel` must not unwrap and repaint it.
+ */
+const STYLING_PROPS = Object.freeze([
+  'className',
+  'variant',
+  'color',
+  'textColor',
+  'textStyle',
+  'style',
+] as const);
+
+type TextStylingProps = { children?: ReactNode } & {
+  [K in (typeof STYLING_PROPS)[number]]?: unknown;
+};
+
+/**
+ * Unwraps `<Button><Text>Save</Text></Button>` to the string `'Save'`, so an unstyled label can be
+ * repainted with the button's own per-variant `LABEL_CLASS`.
+ *
+ * A `<Text>` that carries **its own styling props is deliberately left alone**. Unwrapping is
+ * lossy — it keeps the string and throws the element away — so restyling a label the call site had
+ * already styled silently reverses an explicit intent.
+ *
+ * The profile screen's sign-out button was exactly this bug. Its child looks like a ternary, but a
+ * JSX ternary evaluates to a *single element* before React sees it, so `Children.toArray` returns
+ * one child and every gate below passed: `<Text className="text-destructive">Log Out</Text>` was
+ * flattened to `'Log Out'` and re-rendered with `filled`'s `text-primary-foreground` (#FFFFFF).
+ * The call site's `className="bg-card"` also beats `bg-primary` under `twMerge`, so the pill was
+ * white too — white-on-white, an empty rounded rectangle at the right size with no visible glyphs.
+ * Bailing out here lets the call site's own `<Text>` render, in `destructive` red as intended.
+ */
 function extractLabel(children: ReactNode): string | undefined {
   const kids = Children.toArray(children);
   if (kids.length !== 1) return undefined;
   const only = kids[0];
   if (isString(only)) return only;
   if (isValidElement(only) && only.type === Text) {
-    const inner = (only.props as { children?: ReactNode }).children;
-    return isString(inner) ? inner : undefined;
+    const props = only.props as TextStylingProps;
+    if (STYLING_PROPS.some((prop) => props[prop] !== undefined)) return undefined;
+    return isString(props.children) ? props.children : undefined;
   }
   return undefined;
 }

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,4 +1,4 @@
-import { isString } from '@packrat/guards';
+import { isString, toRecord } from '@packrat/guards';
 import { cn } from 'expo-app/lib/cn';
 import { Children, isValidElement, type ReactNode } from 'react';
 import {
@@ -100,10 +100,6 @@ const STYLING_PROPS = Object.freeze([
   'style',
 ] as const);
 
-type TextStylingProps = { children?: ReactNode } & {
-  [K in (typeof STYLING_PROPS)[number]]?: unknown;
-};
-
 /**
  * Unwraps `<Button><Text>Save</Text></Button>` to the string `'Save'`, so an unstyled label can be
  * repainted with the button's own per-variant `LABEL_CLASS`.
@@ -126,7 +122,7 @@ function extractLabel(children: ReactNode): string | undefined {
   const only = kids[0];
   if (isString(only)) return only;
   if (isValidElement(only) && only.type === Text) {
-    const props = only.props as TextStylingProps;
+    const props = toRecord(only.props);
     if (STYLING_PROPS.some((prop) => props[prop] !== undefined)) return undefined;
     return isString(props.children) ? props.children : undefined;
   }

--- a/packages/ui/src/card-parts.tsx
+++ b/packages/ui/src/card-parts.tsx
@@ -17,7 +17,18 @@ function CardContent({
   return (
     <>
       {Platform.OS === 'ios' && (
-        <BlurView intensity={iosBlurIntensity} className={iosBlurClassName} />
+        <BlurView
+          intensity={iosBlurIntensity}
+          // `absolute inset-0` is load-bearing, not cosmetic. This blur is a *background fill*
+          // behind the content, but it has no children, so laid out in flow it is still a real
+          // flex child of `Card`'s `justify-end` column: Yoga gives it a share of the cross-axis
+          // and it displaces the siblings after it. On the catalog card that pushed the content
+          // block down until the last description line and the whole footer ran past the card's
+          // `overflow-hidden` edge — the description clipped mid-line and the weight row was
+          // sliced in half. Taking it out of flow makes it paint behind the content, which is
+          // what a background blur is supposed to do.
+          className={cn('absolute inset-0', iosBlurClassName)}
+        />
       )}
       <View className={cn('ios:px-5 gap-1.5 px-4 py-4', className)} {...props} />
     </>


### PR DESCRIPTION
## Description

Two iOS rendering bugs, both rooted in the shared `@packrat/ui` primitives rather than the screens that showed them. Fixing them in the primitives repairs every affected call site.

**1. Catalog cards rendered broken.** `CardContent`'s iOS blur is meant to be a background fill, but it had no children and no positioning, so it laid out as a real flex child of `Card`'s `justify-end` column and displaced the siblings after it. Content was pushed past the card's `overflow-hidden` edge: the description clipped mid-line and the weight row was sliced in half. Fixed with `absolute inset-0` so it paints behind the content. Android was never affected — that blur is iOS-only.

**2. Sign-out button rendered as an empty white pill.** `Button.extractLabel` unwrapped a `<Text>` child to a bare string and repainted it with the variant's `LABEL_CLASS`, discarding the call site's own styling. The profile screen's child *looks* like a ternary, but a JSX ternary evaluates to a single element before React sees it, so every gate passed: `<Text className="text-destructive">Log Out</Text>` was flattened to `'Log Out'` and repainted `text-primary-foreground` (#FFFFFF). The call site's `className="bg-card"` also beats `bg-primary` under `twMerge`, so the pill was white too — white-on-white, correct size, no visible glyphs. `extractLabel` now bails out when the child `<Text>` carries `className`/`variant`/`color`/`textColor`/`textStyle`/`style`; unstyled labels are unchanged.

Only iOS showed a blank pill: Android resolves that button to `secondary` → `outlined` (`text-foreground`) — wrong colour, but readable.

Both defects trace to the @expo/ui migration; the Card commit (8221bed) notes it was "Not verified on-device".

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- `packages/ui` (consumed by `apps/expo`)

## Changed paths

- `packages/ui/src/button.tsx`
- `packages/ui/src/card-parts.tsx`

## Test plan

- [x] `tsc --noEmit` — exit 0
- [x] `biome check` on changed files — clean
- [x] `bun test:expo` — 392 tests passing
- [x] `bun check:coverage` — `apps/expo` baseline met
- [x] Verified on-device by reviewer
- [ ] Remote CI passes

## Notes

`packages/ui` has no test harness, so these fixes ship without regression tests. The `extractLabel` behaviour in particular is easy to reintroduce and is worth covering in a follow-up.

A related latent issue is out of scope here: several buttons pass an *uncoloured* styled `<Text>` to a `filled` variant (`CatalogItemsAuthWall`, `WeatherAuthWall`, `ProfileAuthWall`, `NotFoundScreen`, and a few auth screens). With this change those labels now render in the default foreground on `bg-primary` instead of being repainted — visible, but not necessarily the intended colour. Worth a separate pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button label handling so custom styling on text labels is preserved.
  * Unstyled button text continues to receive the correct label styling.
  * Fixed iOS card blur backgrounds so they no longer affect card layout or spacing.
  * Card blur appearance remains configurable while consistently covering the card content area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->