### PR TITLE
feat(auth): enable dynamic client registration for MCP OAuth

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -280,9 +280,11 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
       //    `scopes_supported` in the AS metadata.
       //  - `validAudiences`: RFC 8707 — `/oauth2/authorize` rejects any
       //    `resource` parameter not in this list with 400 invalid_request.
-      //  - `allowDynamicClientRegistration: false` + Claude pre-registered
-      //    via packages/api/src/db/seed-claude-oauth-client.ts — DCR is
-      //    closed because we know our connector clients ahead of time.
+      //  - `allowDynamicClientRegistration: true` (+ unauthenticated) so the
+      //    Claude connector can self-register; see the security note at the
+      //    option below. The pre-registered client seeded by
+      //    packages/api/src/db/seed-claude-oauth-client.ts still works and is
+      //    kept as the preferred path if DCR is closed again.
       //  - `consentPage`: points at `/oauth/consent` (mounted in the worker
       //    fetch handler in src/index.ts). The consent page server-side
       //    filters `mcp:admin` from non-admin grants and POSTs the reduced
@@ -310,8 +312,28 @@ async function buildAuth(env: ValidatedEnv): Promise<any> {
             audiences.push(`${env.PACKRAT_MCP_URL.replace(TRAILING_SLASH_RE, '')}/mcp`);
           return audiences;
         })(),
-        allowDynamicClientRegistration: false,
-        allowUnauthenticatedClientRegistration: false,
+        // DCR enabled so the Claude connector can self-register instead of
+        // requiring Anthropic to pre-provision our static client_id (the
+        // "Anthropic-held client credentials" listing path needs a manual
+        // coordination step on their side).
+        //
+        // `allowUnauthenticatedClientRegistration` must ALSO be true: the
+        // plugin gates POST /oauth2/register on `session || allowUnauth...`,
+        // and Anthropic registers server-to-server with no PackRat session.
+        //
+        // SECURITY NOTE: this opens client registration to anyone. A hostile
+        // registrant can choose its own redirect_uri and client display
+        // metadata (name/icon/tos/policy are rendered on our consent screen),
+        // which is a phishing vector: a user could be shown a legitimate-looking
+        // PackRat consent page and approve a token that is delivered to an
+        // attacker-controlled URI. PKCE does not mitigate this, because the
+        // attacker IS the registered client. Mitigations that remain in force:
+        // per-user consent, audience-bound tokens, and the consent page's
+        // server-side filtering of `mcp:admin` for non-admin users — that
+        // filter is now load-bearing. Revisit (and prefer the static
+        // pre-registered client) once directory listing no longer requires it.
+        allowDynamicClientRegistration: true,
+        allowUnauthenticatedClientRegistration: true,
         consentPage: '/oauth/consent',
         loginPage: '/api/auth/sign-in',
       }),


### PR DESCRIPTION
## What

Enables OAuth Dynamic Client Registration (RFC 7591) on the API's authorization server so the Claude connector can self-register.

## Why

Listing in Anthropic's connector directory via "Anthropic-held client credentials" requires them to manually pre-provision our static `client_id` (`packrat-claude-mcp`) before publish. DCR is the self-serve path and removes that coordination dependency.

## Both flags are needed

The plugin gates `POST /oauth2/register` on `session || allowUnauthenticatedClientRegistration` (`@better-auth/oauth-provider` dist/index.mjs:1263). Anthropic registers server-to-server with no PackRat session, so unauthenticated registration must also be on.

## Security tradeoff — please read

This **opens client registration to anyone**. A hostile registrant controls:
- its own `redirect_uri`
- the client display metadata (`name`/`icon`/`tos`/`policy`) rendered on our consent page

That is a phishing vector: a user can be shown a legitimate-looking PackRat consent screen on our real authorization server and approve a token delivered to an attacker-controlled URI. **PKCE does not mitigate this** because the attacker is the registered client.

Mitigations still in force:
- consent is per-user (a user must be phished into approving)
- tokens are audience-bound to the MCP resource
- the consent page filters `mcp:admin` server-side for non-admins, and that filter is now load-bearing

The pre-registered client remains seeded (`seed-claude-oauth-client.ts`), so DCR can be closed again once directory listing no longer depends on it. Recommend treating this as reversible/temporary.

## Testing

- API unit tests: 619 pass
- tsc + biome clean
- Manual: connect the Claude connector against a tunnel and confirm it self-registers and completes the OAuth flow without the pre-seeded client.
