### PR TITLE
feat(mcp): serve OpenAI Apps domain-verification challenge

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -34,6 +34,10 @@
  *   GET  /favicon.ico                            → embedded favicon for
  *                                                  Anthropic's domain-ownership
  *                                                  probe.
+ *   GET  /.well-known/openai-apps-challenge      → OpenAI Apps domain
+ *                                                  verification token (from
+ *                                                  OPENAI_APPS_CHALLENGE_TOKEN;
+ *                                                  404 when unset).
  *   *    /mcp[/...]                              → JWT-gated; delegated to the
  *                                                  PackRatMCP Durable Object.
  *   *    *                                       → 404.
@@ -449,6 +453,21 @@ export default {
     }
     if (url.pathname === '/favicon.ico') {
       return withCorrelationHeader({ response: faviconResponse(), correlationId });
+    }
+    // OpenAI Apps domain verification: serve the connector-form-issued token
+    // as plain text so OpenAI can confirm we control this hostname. The token
+    // comes from an env binding (never hardcoded) so it can be rotated without
+    // a code change; when the binding is unset we 404 rather than serving an
+    // empty body, so an unconfigured environment fails closed and visibly.
+    if (url.pathname === '/.well-known/openai-apps-challenge') {
+      const token = env.OPENAI_APPS_CHALLENGE_TOKEN;
+      const response = token
+        ? new Response(token, {
+            status: 200,
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+          })
+        : Response.json({ error: 'Not Found' }, { status: 404 });
+      return withCorrelationHeader({ response, correlationId });
     }
 
     // ── 3. /mcp — JWT-gated protected resource ───────────────────────────────

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -114,6 +114,14 @@ export interface Env {
    */
   MCP_PUBLIC_URL?: string;
   /**
+   * Domain-verification token issued by the OpenAI Apps connector form. When
+   * set, the worker serves it as `text/plain` at
+   * `/.well-known/openai-apps-challenge` so OpenAI can verify we control this
+   * hostname. Supplied as a secret/var rather than hardcoded so the token can
+   * be rotated without a code change; when unset the route 404s.
+   */
+  OPENAI_APPS_CHALLENGE_TOKEN?: string;
+  /**
    * Workers Rate Limiting binding (U14). Configured under the
    * `rate_limiting` block in `packages/mcp/wrangler.jsonc` with a 60/60s
    * budget. Keyed `${props.userId}:${toolName}` per-call so per-user/

--- a/packages/mcp/wrangler.jsonc
+++ b/packages/mcp/wrangler.jsonc
@@ -24,6 +24,12 @@
   //
   // Optional vars:
   //   MCP_FEATURE_FLAGS            — comma-separated flag names enabled at boot
+  //   OPENAI_APPS_CHALLENGE_TOKEN  — domain-verification token from the OpenAI
+  //                                  Apps connector form; served as text/plain
+  //                                  at /.well-known/openai-apps-challenge.
+  //                                  Set via `wrangler secret put` so it can be
+  //                                  rotated without a code change. The route
+  //                                  404s when this is unset.
   //
   // The deploy identifier surfaced on /status comes from the
   // `version_metadata` binding below (CF_VERSION_METADATA) — injected by the


### PR DESCRIPTION
## What

Add `GET /.well-known/openai-apps-challenge` to the MCP worker, serving the OpenAI Apps domain-verification token as `text/plain`.

## Why

OpenAI's Apps connector form verifies hostname ownership by fetching a token from that path on the MCP origin. The worker had no such route, so verification failed with "Domain not verified".

## How

The token comes from a new optional `OPENAI_APPS_CHALLENGE_TOKEN` env binding rather than being hardcoded, so it can be rotated with `wrangler secret put` without a code change. When the binding is unset the route returns 404, so an unconfigured environment fails closed instead of serving an empty body.

## Verification

Exercised locally against a real `wrangler dev` boot:

- Token set → `200`, `content-type: text/plain; charset=utf-8`, body is an exact match for the issued token
- Token unset → `404`
- `/status`, `/mcp`, and `/.well-known/oauth-protected-resource` unaffected
- `tsc --noEmit` clean, `biome check` clean, `bun test:mcp` 1273 pass

## Deploy steps (required after merge)

1. `wrangler secret put OPENAI_APPS_CHALLENGE_TOKEN` on the `packrat-mcp` worker
2. Deploy

Both are needed: the secret alone has no route to serve it, and the deploy alone returns 404 without the token.
