### PR TITLE
feat(swift): add offline write outbox so local writes reach the server

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Catalog/CatalogView.swift
+++ b/apps/swift/Sources/PackRat/Features/Catalog/CatalogView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import NukeUI
+import SwiftData
 
 struct CatalogView: View {
     @Environment(AppState.self) private var appState
@@ -254,6 +255,7 @@ struct AddCatalogItemToPackSheet: View {
     let item: CatalogItem
     let packsViewModel: PacksViewModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
 
     @State private var selectedPackId: String?
     @State private var quantity = 1
@@ -325,7 +327,8 @@ struct AddCatalogItemToPackSheet: View {
                 category: item.categories?.first,
                 consumable: false,
                 worn: false,
-                notes: nil
+                notes: nil,
+                context: modelContext
             )
             success = true
             Task {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -226,7 +226,8 @@ struct PackDetailView: View {
                         category: category == "Uncategorized" ? nil : category,
                         consumable: item.consumable,
                         worn: item.worn,
-                        notes: item.notes
+                        notes: item.notes,
+                        context: modelContext
                     )
                 } catch {
                     self.error = error.localizedDescription

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -12,9 +12,11 @@ final class PacksViewModel {
     var searchText = ""
 
     let service: PackService
+    private let outbox: OutboxService
 
-    init(service: PackService = .shared) {
+    init(service: PackService = .shared, outbox: OutboxService = .shared) {
         self.service = service
+        self.outbox = outbox
     }
 
     var currentPage = 1
@@ -131,19 +133,37 @@ final class PacksViewModel {
         context: ModelContext? = nil
     ) async throws {
         let localPack = makeLocalPack(name: name, description: description, category: category, isPublic: isPublic)
+        let payload = PackMutationPayload(
+            name: name, description: description, category: category, isPublic: isPublic
+        )
+
+        func queueCreate() {
+            outbox.enqueue(
+                entityType: .pack,
+                entityId: localPack.id,
+                operation: .create,
+                payload: OutboxService.encode(payload),
+                context: context
+            )
+        }
+
         guard canUseRemotePersonalStore else {
             packs.insert(localPack, at: 0)
             upsertCachedPack(localPack, context: context)
+            queueCreate()
             return
         }
 
         let pack: Pack
         do {
+            // Send the local id so a retry can't create a duplicate record.
             pack = try await service.createPack(
-                name: name, description: description, category: category, isPublic: isPublic
+                id: localPack.id, name: name, description: description,
+                category: category, isPublic: isPublic
             )
         } catch {
             pack = localPack
+            queueCreate()
         }
         packs.insert(pack, at: 0)
         upsertCachedPack(pack, context: context)
@@ -167,6 +187,19 @@ final class PacksViewModel {
             updatedAt: Date.iso8601Now()
         )
 
+        let payload = PackMutationPayload(
+            name: name, description: description, category: category, isPublic: isPublic
+        )
+        func queueUpdate() {
+            outbox.enqueue(
+                entityType: .pack,
+                entityId: packId,
+                operation: .update,
+                payload: OutboxService.encode(payload),
+                context: context
+            )
+        }
+
         let updated: Pack
         if canUseRemotePersonalStore {
             do {
@@ -175,9 +208,11 @@ final class PacksViewModel {
                 )
             } catch {
                 updated = localUpdated
+                queueUpdate()
             }
         } else {
             updated = localUpdated
+            queueUpdate()
         }
         if let idx = packs.firstIndex(where: { $0.id == packId }) {
             packs[idx] = updated
@@ -185,19 +220,31 @@ final class PacksViewModel {
         upsertCachedPack(updated, context: context)
     }
 
-    // Optimistic delete: remove immediately, restore on error
+    /// Optimistic delete. The removal always sticks locally — an unreachable server
+    /// queues the delete for replay rather than resurrecting the pack, so delete now
+    /// behaves like create and update.
     func deletePack(_ packId: String, context: ModelContext? = nil) async throws {
         guard let idx = packs.firstIndex(where: { $0.id == packId }) else { return }
-        let removed = packs.remove(at: idx)
+        packs.remove(at: idx)
         deleteCachedPack(packId, context: context)
-        guard !packId.hasPrefix("local-") else { return }
-        guard canUseRemotePersonalStore else { return }
+
+        func queueDelete() {
+            outbox.enqueue(
+                entityType: .pack,
+                entityId: packId,
+                operation: .delete,
+                context: context
+            )
+        }
+
+        guard canUseRemotePersonalStore else {
+            queueDelete()
+            return
+        }
         do {
             try await service.deletePack(packId)
         } catch {
-            packs.insert(removed, at: idx)
-            upsertCachedPack(removed, context: context)
-            throw error
+            queueDelete()
         }
     }
 
@@ -208,18 +255,35 @@ final class PacksViewModel {
             packId: packId, name: name, weight: weight, weightUnit: weightUnit,
             quantity: quantity, category: category, consumable: consumable, worn: worn, notes: notes
         )
+        let payload = PackItemMutationPayload(
+            name: name, weight: weight, weightUnit: weightUnit, quantity: quantity,
+            category: category, consumable: consumable, worn: worn, notes: notes
+        )
+        func queueCreate() {
+            outbox.enqueue(
+                entityType: .packItem,
+                entityId: localItem.id,
+                operation: .create,
+                parentId: packId,
+                payload: OutboxService.encode(payload),
+                context: context
+            )
+        }
+
         let item: PackItem
         if canUseRemotePersonalStore {
             do {
                 item = try await service.addItem(
-                    to: packId, name: name, weight: weight, weightUnit: weightUnit,
+                    to: packId, id: localItem.id, name: name, weight: weight, weightUnit: weightUnit,
                     quantity: quantity, category: category, consumable: consumable, worn: worn, notes: notes
                 )
             } catch {
                 item = localItem
+                queueCreate()
             }
         } else {
             item = localItem
+            queueCreate()
         }
         if let idx = packs.firstIndex(where: { $0.id == packId }) {
             var items = packs[idx].items ?? []
@@ -248,6 +312,27 @@ final class PacksViewModel {
                 worn: worn,
                 notes: notes ?? current?.notes
             )
+            let payload = PackItemMutationPayload(
+                name: name,
+                weight: weight ?? current?.weight,
+                weightUnit: weightUnit ?? current?.weightUnit.rawValue,
+                quantity: quantity ?? current?.quantity,
+                category: category ?? current?.category,
+                consumable: consumable,
+                worn: worn,
+                notes: notes ?? current?.notes
+            )
+            func queueUpdate() {
+                outbox.enqueue(
+                    entityType: .packItem,
+                    entityId: itemId,
+                    operation: .update,
+                    parentId: packId,
+                    payload: OutboxService.encode(payload),
+                    context: context
+                )
+            }
+
             let updated: PackItem
             if canUseRemotePersonalStore {
                 do {
@@ -257,9 +342,11 @@ final class PacksViewModel {
                     )
                 } catch {
                     updated = localUpdated
+                    queueUpdate()
                 }
             } else {
                 updated = localUpdated
+                queueUpdate()
             }
             var items = packs[packIdx].items ?? []
             items[itemIdx] = updated
@@ -268,32 +355,43 @@ final class PacksViewModel {
         }
     }
 
-    // Optimistic item delete
+    /// Optimistic item delete. Like `deletePack`, a failed or offline delete stays
+    /// deleted locally and is queued for replay instead of being rolled back.
     func deleteItem(_ itemId: String, from packId: String, context: ModelContext? = nil) async throws {
         guard let packIdx = packs.firstIndex(where: { $0.id == packId }),
               let itemIdx = packs[packIdx].items?.firstIndex(where: { $0.id == itemId }) else { return }
         var items = packs[packIdx].items ?? []
-        let removed = items.remove(at: itemIdx)
+        items.remove(at: itemIdx)
         packs[packIdx] = rebuildPack(packs[packIdx], items: items)
         upsertCachedPack(packs[packIdx], context: context)
-        guard canUseRemotePersonalStore else { return }
+
+        func queueDelete() {
+            outbox.enqueue(
+                entityType: .packItem,
+                entityId: itemId,
+                operation: .delete,
+                parentId: packId,
+                context: context
+            )
+        }
+
+        guard canUseRemotePersonalStore else {
+            queueDelete()
+            return
+        }
         do {
             try await service.deleteItem(itemId, from: packId)
         } catch {
-            var restored = packs[packIdx].items ?? []
-            restored.insert(removed, at: itemIdx)
-            if let idx = packs.firstIndex(where: { $0.id == packId }) {
-                packs[idx] = rebuildPack(packs[idx], items: restored)
-                upsertCachedPack(packs[idx], context: context)
-            }
-            throw error
+            queueDelete()
         }
     }
 
     private func makeLocalPack(name: String, description: String?, category: String?, isPublic: Bool) -> Pack {
         let now = Date.iso8601Now()
+        // A plain client UUID — the same scheme the server accepts on create — so an
+        // offline pack is syncable as-is. No `local-` prefix to reconcile later.
         return Pack(
-            id: "local-\(UUID().uuidString)", userId: nil, name: name,
+            id: UUID().uuidString.lowercased(), userId: nil, name: name,
             description: description, category: PackCategory(rawValue: category ?? ""),
             isPublic: isPublic, image: nil, tags: nil, templateId: nil,
             deleted: false, isAIGenerated: false, items: [],
@@ -303,7 +401,7 @@ final class PacksViewModel {
     }
 
     private func makeLocalItem(
-        id: String = "local-item-\(UUID().uuidString)",
+        id: String = UUID().uuidString.lowercased(),
         packId: String,
         name: String,
         weight: Double?,

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsListView.swift
@@ -114,12 +114,12 @@ struct TripsListView: View {
             Divider()
             #endif
             Button("Delete", systemImage: "trash", role: .destructive) {
-                Task { try? await viewModel.deleteTrip(trip.id) }
+                Task { try? await viewModel.deleteTrip(trip.id, context: modelContext) }
             }
         }
         .swipeActions(edge: .trailing) {
             Button(role: .destructive) {
-                Task { try? await viewModel.deleteTrip(trip.id) }
+                Task { try? await viewModel.deleteTrip(trip.id, context: modelContext) }
             } label: {
                 Label("Delete", systemImage: "trash")
             }

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
@@ -12,9 +12,11 @@ final class TripsViewModel {
     var searchText = ""
 
     private let service: TripService
+    private let outbox: OutboxService
 
-    init(service: TripService = .shared) {
+    init(service: TripService = .shared, outbox: OutboxService = .shared) {
         self.service = service
+        self.outbox = outbox
     }
 
     var currentPage = 1
@@ -139,18 +141,43 @@ final class TripsViewModel {
             name: name, description: description, startDate: startDate, endDate: endDate,
             location: location, notes: notes, packId: packId
         )
+        let payload = TripMutationPayload(
+            name: name,
+            description: description,
+            startDate: startDate?.iso8601String(),
+            endDate: endDate?.iso8601String(),
+            latitude: location?.latitude,
+            longitude: location?.longitude,
+            locationName: location?.name,
+            notes: notes,
+            packId: packId
+        )
+        func queueCreate() {
+            outbox.enqueue(
+                entityType: .trip,
+                entityId: localTrip.id,
+                operation: .create,
+                payload: OutboxService.encode(payload),
+                context: context
+            )
+        }
+
         let trip: Trip
         if canUseRemotePersonalStore {
             do {
+                // Send the local id so a retry can't create a duplicate record.
                 trip = try await service.createTrip(
+                    id: localTrip.id,
                     name: name, description: description, startDate: startDate, endDate: endDate,
                     location: location, notes: notes, packId: packId
                 )
             } catch {
                 trip = localTrip
+                queueCreate()
             }
         } else {
             trip = localTrip
+            queueCreate()
         }
         trips.insert(trip, at: 0)
         upsertCachedTrip(trip, context: context)
@@ -171,6 +198,27 @@ final class TripsViewModel {
             packId: packId,
             updatedAt: Date.iso8601Now()
         )
+        let payload = TripMutationPayload(
+            name: name,
+            description: description,
+            startDate: startDate?.iso8601String(),
+            endDate: endDate?.iso8601String(),
+            latitude: location?.latitude,
+            longitude: location?.longitude,
+            locationName: location?.name,
+            notes: notes,
+            packId: packId
+        )
+        func queueUpdate() {
+            outbox.enqueue(
+                entityType: .trip,
+                entityId: tripId,
+                operation: .update,
+                payload: OutboxService.encode(payload),
+                context: context
+            )
+        }
+
         let updated: Trip
         if canUseRemotePersonalStore {
             do {
@@ -180,9 +228,11 @@ final class TripsViewModel {
                 )
             } catch {
                 updated = localUpdated
+                queueUpdate()
             }
         } else {
             updated = localUpdated
+            queueUpdate()
         }
         if let idx = trips.firstIndex(where: { $0.id == tripId }) {
             trips[idx] = updated
@@ -190,19 +240,30 @@ final class TripsViewModel {
         upsertCachedTrip(updated, context: context)
     }
 
-    // Optimistic delete
+    /// Optimistic delete. An unreachable server queues the delete for replay rather
+    /// than resurrecting the trip, matching create/update behaviour.
     func deleteTrip(_ tripId: String, context: ModelContext? = nil) async throws {
         guard let idx = trips.firstIndex(where: { $0.id == tripId }) else { return }
-        let removed = trips.remove(at: idx)
+        trips.remove(at: idx)
         deleteCachedTrip(tripId, context: context)
-        guard !tripId.hasPrefix("local-") else { return }
-        guard canUseRemotePersonalStore else { return }
+
+        func queueDelete() {
+            outbox.enqueue(
+                entityType: .trip,
+                entityId: tripId,
+                operation: .delete,
+                context: context
+            )
+        }
+
+        guard canUseRemotePersonalStore else {
+            queueDelete()
+            return
+        }
         do {
             try await service.deleteTrip(tripId)
         } catch {
-            trips.insert(removed, at: idx)
-            upsertCachedTrip(removed, context: context)
-            throw error
+            queueDelete()
         }
     }
 
@@ -216,8 +277,10 @@ final class TripsViewModel {
         packId: String?
     ) -> Trip {
         let now = Date.iso8601Now()
+        // A plain client UUID — the scheme the server accepts on create — so an
+        // offline trip is syncable as-is. No `local-` prefix to reconcile later.
         return Trip(
-            id: "local-\(UUID().uuidString)",
+            id: UUID().uuidString.lowercased(),
             name: name,
             description: description,
             notes: notes,

--- a/apps/swift/Sources/PackRat/PackRatApp.swift
+++ b/apps/swift/Sources/PackRat/PackRatApp.swift
@@ -28,6 +28,7 @@ struct PackRatApp: App {
         WindowGroup {
             AuthGateView()
                 .environment(authManager)
+                .flushesPendingWrites()
         }
         .modelContainer(PersistenceController.shared.container)
         #if os(macOS)

--- a/apps/swift/Sources/PackRat/Persistence/PendingMutation.swift
+++ b/apps/swift/Sources/PackRat/Persistence/PendingMutation.swift
@@ -1,0 +1,110 @@
+import Foundation
+import SwiftData
+
+/// The kind of entity a queued write applies to.
+enum OutboxEntityType: String, Codable, Sendable {
+    case pack
+    case packItem
+    case trip
+}
+
+/// The write being replayed. `create` and `update` carry a payload; `delete` does not.
+enum OutboxOperation: String, Codable, Sendable {
+    case create
+    case update
+    case delete
+}
+
+/// A durable record of a write that has not yet reached the server.
+///
+/// Every offline (or transport-failed) write enqueues one of these. `OutboxService`
+/// drains the queue in `createdAt` order on reconnect and on app foreground, so a
+/// create-then-update on the same entity replays in the order the user made it.
+@Model
+final class PendingMutation {
+    @Attribute(.unique) var id: String
+    /// Raw value of `OutboxEntityType` — SwiftData predicates can't filter on enums.
+    var entityTypeRaw: String
+    /// Client-generated UUID of the target entity. Stable across sync, so child
+    /// items keep valid foreign keys once the parent reaches the server.
+    var entityId: String
+    /// Raw value of `OutboxOperation`.
+    var operationRaw: String
+    /// For pack items, the owning pack's id. Nil for packs and trips.
+    var parentId: String?
+    /// JSON-encoded operation payload. Nil for deletes.
+    var payload: Data?
+    var createdAt: Date
+    var attemptCount: Int
+    var lastError: String?
+    /// Set once the mutation exhausts its retries or hits a non-retryable server
+    /// response. Failed mutations stay in the store for the UI to surface rather
+    /// than being dropped silently.
+    var failed: Bool
+
+    init(
+        id: String = UUID().uuidString,
+        entityType: OutboxEntityType,
+        entityId: String,
+        operation: OutboxOperation,
+        parentId: String? = nil,
+        payload: Data? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.entityTypeRaw = entityType.rawValue
+        self.entityId = entityId
+        self.operationRaw = operation.rawValue
+        self.parentId = parentId
+        self.payload = payload
+        self.createdAt = createdAt
+        self.attemptCount = 0
+        self.lastError = nil
+        self.failed = false
+    }
+
+    var entityType: OutboxEntityType? { OutboxEntityType(rawValue: entityTypeRaw) }
+    var operation: OutboxOperation? { OutboxOperation(rawValue: operationRaw) }
+}
+
+// MARK: - Payloads
+
+/// Field set for a queued pack create/update. Optionals are absent-means-unchanged
+/// on update, and carry the full record on create.
+struct PackMutationPayload: Codable, Sendable {
+    var name: String
+    var description: String?
+    var category: String?
+    var isPublic: Bool
+}
+
+/// Field set for a queued pack-item create/update.
+struct PackItemMutationPayload: Codable, Sendable {
+    var name: String
+    var weight: Double?
+    var weightUnit: String?
+    var quantity: Int?
+    var category: String?
+    var consumable: Bool
+    var worn: Bool
+    var notes: String?
+}
+
+/// Field set for a queued trip create/update. Dates are ISO-8601 strings so the
+/// payload round-trips through JSON without timezone drift.
+struct TripMutationPayload: Codable, Sendable {
+    var name: String
+    var description: String?
+    var startDate: String?
+    var endDate: String?
+    var latitude: Double?
+    var longitude: Double?
+    var locationName: String?
+    var notes: String?
+    var packId: String?
+
+    var location: TripLocationBody? {
+        guard let latitude, let longitude else { return nil }
+        return TripLocationBody(latitude: latitude, longitude: longitude, name: locationName)
+    }
+}

--- a/apps/swift/Sources/PackRat/Persistence/PersistenceController.swift
+++ b/apps/swift/Sources/PackRat/Persistence/PersistenceController.swift
@@ -8,7 +8,7 @@ final class PersistenceController {
     let container: ModelContainer
 
     private init() {
-        let schema = Schema([CachedPack.self, CachedTrip.self, ShoppingItem.self])
+        let schema = Schema([CachedPack.self, CachedTrip.self, ShoppingItem.self, PendingMutation.self])
         let config = ModelConfiguration("PackRat", schema: schema)
         do {
             try FileManager.default.createDirectory(

--- a/apps/swift/Sources/PackRat/Services/OutboxService.swift
+++ b/apps/swift/Sources/PackRat/Services/OutboxService.swift
@@ -1,0 +1,331 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Drains queued offline writes to the server.
+///
+/// Writes made while offline (or that fail with a transport error) are recorded as
+/// `PendingMutation` rows instead of being stranded on-device. This service replays
+/// them in `createdAt` order — serially, so a create-then-update on the same entity
+/// lands in the order the user made it — whenever connectivity returns or the app
+/// comes to the foreground.
+///
+/// Retry policy: transport failures are retried up to `maxAttempts`. A 4xx from the
+/// server is terminal — the payload is wrong, so retrying forever would never help;
+/// the mutation is marked `failed` and left in the store for the UI to surface. A
+/// 404 on delete, and a 409 on create, are treated as success: the server already
+/// agrees with the local state.
+@Observable
+@MainActor
+final class OutboxService {
+    static let shared = OutboxService()
+
+    /// Number of mutations still waiting to reach the server.
+    private(set) var pendingCount: Int = 0
+    /// Number of mutations that gave up and need user attention.
+    private(set) var failedCount: Int = 0
+    private(set) var isFlushing = false
+
+    /// Transport failures beyond this count mark the mutation `failed` rather than
+    /// retrying indefinitely.
+    static let maxAttempts = 5
+
+    private let packService: PackService
+    private let tripService: TripService
+
+    init(packService: PackService = .shared, tripService: TripService = .shared) {
+        self.packService = packService
+        self.tripService = tripService
+    }
+
+    // MARK: - Enqueue
+
+    /// Records a write that could not reach the server.
+    ///
+    /// Collapses redundant work before inserting: a delete of a never-synced entity
+    /// drops its queued create (and any updates) and never contacts the server, and
+    /// consecutive updates to the same entity collapse to the latest payload.
+    func enqueue(
+        entityType: OutboxEntityType,
+        entityId: String,
+        operation: OutboxOperation,
+        parentId: String? = nil,
+        payload: Data? = nil,
+        context: ModelContext?
+    ) {
+        guard let context else { return }
+
+        let existing = pendingMutations(for: entityId, context: context)
+
+        switch operation {
+        case .delete:
+            // A create still queued means the server has never seen this entity —
+            // create + delete cancel out entirely.
+            if existing.contains(where: { $0.operation == .create }) {
+                for mutation in existing { context.delete(mutation) }
+                saveAndRefresh(context)
+                return
+            }
+            // Otherwise the delete supersedes any queued updates.
+            for mutation in existing where mutation.operation == .update {
+                context.delete(mutation)
+            }
+
+        case .update:
+            // Fold into the queued create so the entity is created with its final
+            // values in a single request.
+            if let create = existing.first(where: { $0.operation == .create }) {
+                create.payload = payload
+                saveAndRefresh(context)
+                return
+            }
+            // Collapse consecutive updates to the last one.
+            for mutation in existing where mutation.operation == .update {
+                context.delete(mutation)
+            }
+
+        case .create:
+            break
+        }
+
+        context.insert(PendingMutation(
+            entityType: entityType,
+            entityId: entityId,
+            operation: operation,
+            parentId: parentId,
+            payload: payload
+        ))
+        saveAndRefresh(context)
+    }
+
+    // MARK: - Flush
+
+    /// Replays every queued write, oldest first. Safe to call repeatedly — it
+    /// no-ops while a flush is already running or while offline.
+    @discardableResult
+    func flush(context: ModelContext?) async -> Bool {
+        guard let context, !isFlushing else { return false }
+        guard NetworkMonitor.shared.isConnected, KeychainService.shared.sessionToken != nil else {
+            return false
+        }
+
+        isFlushing = true
+        defer {
+            isFlushing = false
+            refreshCounts(context)
+        }
+
+        var descriptor = FetchDescriptor<PendingMutation>(
+            predicate: #Predicate { !$0.failed }
+        )
+        descriptor.sortBy = [SortDescriptor(\.createdAt, order: .forward)]
+        let queued = (try? context.fetch(descriptor)) ?? []
+        guard !queued.isEmpty else { return false }
+
+        var didSync = false
+        for mutation in queued {
+            // Connectivity can drop mid-drain; stop and keep the rest queued.
+            guard NetworkMonitor.shared.isConnected else { break }
+            let outcome = await apply(mutation)
+            switch outcome {
+            case .success:
+                context.delete(mutation)
+                didSync = true
+            case .retry(let message):
+                mutation.attemptCount += 1
+                mutation.lastError = message
+                if mutation.attemptCount >= Self.maxAttempts {
+                    mutation.failed = true
+                }
+            case .terminal(let message):
+                mutation.attemptCount += 1
+                mutation.lastError = message
+                mutation.failed = true
+            }
+            try? context.save()
+        }
+        return didSync
+    }
+
+    /// Clears mutations that gave up, after the user has acknowledged them.
+    func discardFailed(context: ModelContext?) {
+        guard let context else { return }
+        let failed = (try? context.fetch(FetchDescriptor<PendingMutation>(
+            predicate: #Predicate { $0.failed }
+        ))) ?? []
+        for mutation in failed { context.delete(mutation) }
+        saveAndRefresh(context)
+    }
+
+    /// Recomputes `pendingCount` / `failedCount` from the store.
+    func refreshCounts(_ context: ModelContext?) {
+        guard let context else { return }
+        let all = (try? context.fetch(FetchDescriptor<PendingMutation>())) ?? []
+        pendingCount = all.filter { !$0.failed }.count
+        failedCount = all.filter(\.failed).count
+    }
+
+    // MARK: - Replay
+
+    private enum Outcome {
+        case success
+        /// Transport-level failure — worth another attempt later.
+        case retry(String)
+        /// Server rejected the payload; retrying can't fix it.
+        case terminal(String)
+    }
+
+    private func apply(_ mutation: PendingMutation) async -> Outcome {
+        guard let entityType = mutation.entityType, let operation = mutation.operation else {
+            return .terminal("Unrecognised queued mutation")
+        }
+        do {
+            switch (entityType, operation) {
+            case (.pack, .create):
+                let payload: PackMutationPayload = try decode(mutation.payload)
+                _ = try await packService.createPack(
+                    id: mutation.entityId,
+                    name: payload.name,
+                    description: payload.description,
+                    category: payload.category,
+                    isPublic: payload.isPublic
+                )
+            case (.pack, .update):
+                let payload: PackMutationPayload = try decode(mutation.payload)
+                _ = try await packService.updatePack(
+                    mutation.entityId,
+                    name: payload.name,
+                    description: payload.description,
+                    category: payload.category,
+                    isPublic: payload.isPublic
+                )
+            case (.pack, .delete):
+                try await packService.deletePack(mutation.entityId)
+
+            case (.packItem, .create):
+                let payload: PackItemMutationPayload = try decode(mutation.payload)
+                guard let packId = mutation.parentId else {
+                    return .terminal("Queued pack item has no pack")
+                }
+                _ = try await packService.addItem(
+                    to: packId,
+                    id: mutation.entityId,
+                    name: payload.name,
+                    weight: payload.weight,
+                    weightUnit: payload.weightUnit,
+                    quantity: payload.quantity,
+                    category: payload.category,
+                    consumable: payload.consumable,
+                    worn: payload.worn,
+                    notes: payload.notes
+                )
+            case (.packItem, .update):
+                let payload: PackItemMutationPayload = try decode(mutation.payload)
+                guard let packId = mutation.parentId else {
+                    return .terminal("Queued pack item has no pack")
+                }
+                _ = try await packService.updateItem(
+                    mutation.entityId,
+                    in: packId,
+                    name: payload.name,
+                    weight: payload.weight,
+                    weightUnit: payload.weightUnit,
+                    quantity: payload.quantity,
+                    category: payload.category,
+                    consumable: payload.consumable,
+                    worn: payload.worn,
+                    notes: payload.notes
+                )
+            case (.packItem, .delete):
+                guard let packId = mutation.parentId else {
+                    return .terminal("Queued pack item has no pack")
+                }
+                try await packService.deleteItem(mutation.entityId, from: packId)
+
+            case (.trip, .create):
+                let payload: TripMutationPayload = try decode(mutation.payload)
+                _ = try await tripService.createTrip(
+                    id: mutation.entityId,
+                    name: payload.name,
+                    description: payload.description,
+                    startDate: payload.startDate?.toDate(),
+                    endDate: payload.endDate?.toDate(),
+                    location: payload.location,
+                    notes: payload.notes,
+                    packId: payload.packId
+                )
+            case (.trip, .update):
+                let payload: TripMutationPayload = try decode(mutation.payload)
+                _ = try await tripService.updateTrip(
+                    mutation.entityId,
+                    name: payload.name,
+                    description: payload.description,
+                    startDate: payload.startDate?.toDate(),
+                    endDate: payload.endDate?.toDate(),
+                    location: payload.location,
+                    notes: payload.notes,
+                    packId: payload.packId
+                )
+            case (.trip, .delete):
+                try await tripService.deleteTrip(mutation.entityId)
+            }
+            return .success
+        } catch {
+            return classify(error, operation: operation)
+        }
+    }
+
+    /// Decides whether a replay failure is worth retrying.
+    private func classify(_ error: Error, operation: OutboxOperation) -> Outcome {
+        switch error {
+        case PackRatError.httpError(let statusCode, let message):
+            // The server already agrees with our intent.
+            if operation == .delete, statusCode == 404 { return .success }
+            if operation == .create, statusCode == 409 { return .success }
+            // 4xx means the request itself is wrong — retrying can't fix it.
+            if (400...499).contains(statusCode) {
+                return .terminal(message ?? "Server rejected the change (\(statusCode))")
+            }
+            // 5xx is transient.
+            return .retry(message ?? "Server error (\(statusCode))")
+        case PackRatError.notFound:
+            return operation == .delete ? .success : .terminal("The item no longer exists on the server")
+        case PackRatError.unauthorized:
+            // Keep queued: the write should survive a re-auth.
+            return .retry("Sign-in required to sync")
+        case PackRatError.decodingError:
+            return .terminal("Could not read the server response")
+        default:
+            return .retry(error.localizedDescription)
+        }
+    }
+
+    private func decode<T: Decodable>(_ data: Data?) throws -> T {
+        guard let data else { throw PackRatError.decodingError(OutboxError.missingPayload) }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private func pendingMutations(for entityId: String, context: ModelContext) -> [PendingMutation] {
+        var descriptor = FetchDescriptor<PendingMutation>(
+            predicate: #Predicate { $0.entityId == entityId && !$0.failed }
+        )
+        descriptor.sortBy = [SortDescriptor(\.createdAt, order: .forward)]
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func saveAndRefresh(_ context: ModelContext) {
+        try? context.save()
+        refreshCounts(context)
+    }
+}
+
+enum OutboxError: Error {
+    case missingPayload
+}
+
+extension OutboxService {
+    /// Convenience for encoding a payload at the call site.
+    static func encode<T: Encodable>(_ value: T) -> Data? {
+        try? JSONEncoder().encode(value)
+    }
+}

--- a/apps/swift/Sources/PackRat/Services/PackService.swift
+++ b/apps/swift/Sources/PackRat/Services/PackService.swift
@@ -14,10 +14,12 @@ final class PackService: Sendable {
         return try await api.send(endpoint)
     }
 
-    func createPack(name: String, description: String? = nil, category: String? = nil, isPublic: Bool = false) async throws -> Pack {
+    /// `id` is caller-supplied so an offline-created pack keeps the same identity
+    /// when the outbox replays its create against the server.
+    func createPack(id: String = UUID().uuidString.lowercased(), name: String, description: String? = nil, category: String? = nil, isPublic: Bool = false) async throws -> Pack {
         let now = Date.iso8601Now()
         let body = CreatePackRequest(
-            id: UUID().uuidString.lowercased(),
+            id: id,
             name: name,
             description: description,
             category: category,
@@ -46,9 +48,9 @@ final class PackService: Sendable {
         try await api.sendDiscarding(endpoint)
     }
 
-    func addItem(to packId: String, name: String, weight: Double? = nil, weightUnit: String? = nil, quantity: Int? = nil, category: String? = nil, consumable: Bool? = nil, worn: Bool? = nil, notes: String? = nil) async throws -> PackItem {
+    func addItem(to packId: String, id: String = UUID().uuidString.lowercased(), name: String, weight: Double? = nil, weightUnit: String? = nil, quantity: Int? = nil, category: String? = nil, consumable: Bool? = nil, worn: Bool? = nil, notes: String? = nil) async throws -> PackItem {
         let body = CreatePackItemRequest(
-            id: UUID().uuidString.lowercased(),
+            id: id,
             name: name,
             weight: weight,
             weightUnit: weightUnit,

--- a/apps/swift/Sources/PackRat/Services/TripService.swift
+++ b/apps/swift/Sources/PackRat/Services/TripService.swift
@@ -11,7 +11,10 @@ final class TripService: Sendable {
         return try await api.send(endpoint)
     }
 
+    /// `id` is caller-supplied so an offline-created trip keeps the same identity
+    /// when the outbox replays its create against the server.
     func createTrip(
+        id: String = UUID().uuidString.lowercased(),
         name: String,
         description: String? = nil,
         startDate: Date? = nil,
@@ -22,7 +25,7 @@ final class TripService: Sendable {
     ) async throws -> Trip {
         let now = Date.iso8601Now()
         let body = CreateTripRequest(
-            id: UUID().uuidString.lowercased(),
+            id: id,
             name: name,
             description: description,
             location: location,

--- a/apps/swift/Sources/PackRat/Shared/OutboxFlushModifier.swift
+++ b/apps/swift/Sources/PackRat/Shared/OutboxFlushModifier.swift
@@ -1,0 +1,36 @@
+import SwiftData
+import SwiftUI
+
+/// Drains the offline write queue whenever it can plausibly succeed: at launch,
+/// when connectivity returns, and when the app comes back to the foreground.
+private struct OutboxFlushModifier: ViewModifier {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
+
+    private var outbox: OutboxService { .shared }
+    private var isConnected: Bool { NetworkMonitor.shared.isConnected }
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                outbox.refreshCounts(modelContext)
+                await outbox.flush(context: modelContext)
+            }
+            // NetworkMonitor is @Observable, so this fires on every connectivity change.
+            .onChange(of: isConnected) { _, connected in
+                guard connected else { return }
+                Task { await outbox.flush(context: modelContext) }
+            }
+            .onChange(of: scenePhase) { _, phase in
+                guard phase == .active else { return }
+                Task { await outbox.flush(context: modelContext) }
+            }
+    }
+}
+
+extension View {
+    /// Attach once, above the app's content, to keep queued offline writes moving.
+    func flushesPendingWrites() -> some View {
+        modifier(OutboxFlushModifier())
+    }
+}


### PR DESCRIPTION
Fixes #2672.

## Problem

The Swift app is offline-first only on the **read** path. Writes made while offline were stranded on-device permanently — no outbox, no retry, and no path by which a locally-created pack or trip ever reached the server. Every reference to the `local-` id prefix was a guard that *skipped* the server rather than a push.

Delete was also inconsistent with create/update in the same file: `deletePack` restored the removed pack and rethrew ("Couldn't Delete Pack"), while `createPack` under identical conditions silently succeeded locally.

## Approach

The API already accepts client-supplied ids on create (`packages/api/src/routes/packs/index.ts` inserts `data.id`), so the only reason offline records were unsyncable is that the offline path minted a deliberately-poisoned `local-` id instead of reusing the same client UUID scheme. Dropping the prefix removes the id-reconciliation problem entirely.

## Changes

- **`PendingMutation`** (new SwiftData model) — entity type, entity id, operation, optional parent id, JSON payload, `attemptCount`, `lastError`, `failed`. Registered in the container, so queued writes survive kill/relaunch.
- **`OutboxService`** (new) — drains the queue serially in `createdAt` order, so create-then-update on the same entity replays in the order the user made it.
- **Retired the `local-` prefix** in Packs/Trips for a plain client UUID, and threaded that id through `createPack` / `addItem` / `createTrip` so a replayed create can't produce a duplicate record.
- **Mutation collapsing on enqueue** — create+delete of a never-synced entity cancels out and never contacts the server; updates fold into a pending create; consecutive updates collapse to the latest.
- **Terminal-failure policy** — 4xx is terminal (the payload is wrong, retrying never helps); 5xx and transport errors retry up to 5 attempts, then mark the mutation `failed` and keep it for the UI rather than dropping it silently. 404-on-delete and 409-on-create count as success — the server already agrees with local state.
- **Delete now matches create/update** — a failed or offline delete stays deleted locally and flushes later, for both `deletePack` and `deleteItem`.
- **`.flushesPendingWrites()`** on the root view flushes at launch, on `NetworkMonitor.isConnected` change, and on foreground.

## Acceptance criteria

- [x] A pack created, edited, and deleted entirely offline reaches the server correctly on reconnect
- [x] Killing and relaunching before reconnect does not lose queued writes (SwiftData-backed)
- [x] A 4xx surfaces instead of retrying indefinitely
- [x] `deletePack` and `createPack` behave consistently when the network is unavailable

## Decisions on the issue's open questions

- **Conflict resolution**: last-write-wins, no conflict UI. Appropriate for single-user pack data, but it can silently lose edits across two devices — worth revisiting if multi-device lands.
- **Scope**: built the outbox as a general shape (any entity type), rolled out to Packs + Trips only, matching current cache coverage.
- **Delete of a never-synced entity**: drops the queued create and never contacts the server.

## Out of scope

The `local-` guards in `PackTemplatesViewModel` and `TrailConditionsViewModel` are left alone — they mint and guard consistently within their own files and are outside this issue's Packs/Trips scope. Extending caching to the remaining 18 features is likewise separate.

## Test plan

Launch with `--force-offline`, create/edit/delete a pack and a trip, force-quit and relaunch, then remove the flag and confirm all writes land server-side on reconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable offline support for creating, updating, and deleting packs, items, and trips.
  * Pending changes now sync automatically when connectivity returns or the app becomes active.
  * Added retry handling for temporary sync failures.
* **Bug Fixes**
  * Deleted content remains removed locally while synchronization is pending.
  * Improved consistency when adding items, changing categories, and deleting trips.
* **Improvements**
  * Offline-created content now preserves its identity during synchronization.
  * Pending and failed changes are tracked for more reliable recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->