### PR TITLE
fix(swift): flush the outbox from macOS standalone Pack/Trip windows

### DIFF
--- a/apps/swift/Sources/PackRat/PackRatApp.swift
+++ b/apps/swift/Sources/PackRat/PackRatApp.swift
@@ -46,10 +46,14 @@ struct PackRatApp: App {
                 .environment(authManager)
         }
 
+        // These windows host the same detail views as the main window, so they
+        // can queue writes on their own. Flush from here too — a standalone
+        // window may be the only one the user has open.
         WindowGroup("Pack", id: "pack", for: String.self) { $packId in
             if let id = packId {
                 PackWindowView(packId: id)
                     .environment(authManager)
+                    .flushesPendingWrites()
             }
         }
         .modelContainer(PersistenceController.shared.container)
@@ -59,6 +63,7 @@ struct PackRatApp: App {
             if let id = tripId {
                 TripWindowView(tripId: id)
                     .environment(authManager)
+                    .flushesPendingWrites()
             }
         }
         .modelContainer(PersistenceController.shared.container)


### PR DESCRIPTION
Follow-up to #2673 (merged), which added the offline write outbox.

## Problem

On macOS a pack or trip can be opened in its own window (`Open in New Window`), and those windows host the same detail views as the main window — so they queue writes of their own through `PackDetailView`'s `deleteItem` / `updateItem`.

Only the main window carried `.flushesPendingWrites()`. Writes made in a standalone window were queued correctly but that window never drained them, so sync stalled until the user returned to the main window.

This is not data loss — `PendingMutation` rows are durable and the main window still flushes on foreground and reconnect — but it's a real stall for anyone working primarily in a standalone window.

## Change

Attach `.flushesPendingWrites()` to both macOS `WindowGroup`s. `OutboxService.flush` already guards on `isFlushing`, so multiple windows cannot double-send a mutation.

## Scope

`PackRat-macOS` compiles the same `Sources/PackRat` as the iOS target, so the outbox itself was already present on macOS — this closes the one platform-specific gap in how it gets drained.

## Testing

Not verified on a running macOS build. The original outbox work was device-tested end-to-end on iOS (offline create and delete reaching a live API); this change is the same modifier already proven there, applied to two additional scenes.