### PR TITLE
feat(mcp): add outputSchema to catalog, pack-item and guide tools

### DIFF
--- a/packages/mcp/src/output-schemas.ts
+++ b/packages/mcp/src/output-schemas.ts
@@ -31,23 +31,34 @@
  *   packrat_admin_stats         → AdminStatsSchema
  *   packrat_admin_analytics_*   → schemas-package analytics shapes
  *
- * Tier 2 deferral list — tools whose API response shape is loosely typed
- * by Eden Treaty / not currently modeled in `@packrat/schemas`. These
- * tools emit text-only output today and are tracked in
- * `docs/mcp/runbook.md` under "U8 output envelopes → Tier 2 deferral":
+ * Tier 2 lift (this change): these tools now declare an `outputSchema`,
+ * reusing shapes already modeled in `@packrat/schemas`:
  *
- *   - all of `packs.items.*` create/update/delete payloads
- *   - catalog vector-search responses
- *   - feed/trail-conditions/guides/knowledge handlers
- *   - admin list endpoints whose Treaty inferred type loses the array
- *     element shape after the response coercion
+ *   packrat_search_gear_catalog    → CatalogItemsResponseSchema
+ *   packrat_get_catalog_item       → CatalogItemSchema
+ *   packrat_semantic_gear_search   → catalog rows + `similarity`
+ *   packrat_similar_catalog_items  → catalog rows + `similarity`
+ *   packrat_list_pack_items        → list-of-PackItem with nextOffset
+ *   packrat_get_pack_item          → PackItemSchema
+ *   packrat_list_guides            → GuidesResponseSchema
+ *   packrat_search_guides          → GuideSearchResponseSchema
+ *   packrat_get_guide              → GuideDetailSchema
+ *   packrat_list_guide_categories  → GuideCategoriesResponseSchema
  *
- * The intent is that a follow-up unit derives the missing schemas from
- * the API route definitions and lifts those tools to Tier 1.
+ * Still text-only (shape not modeled, or Treaty loses the element type):
+ * pack/template/trip write payloads, feed, trail-conditions, knowledge,
+ * season suggestions.
  */
 
 import { AdminStatsSchema } from '@packrat/schemas/admin';
-import { PackSchema, PackWithItemsSchema } from '@packrat/schemas/packs';
+import { CatalogItemSchema, CatalogItemsResponseSchema } from '@packrat/schemas/catalog';
+import {
+  GuideCategoriesResponseSchema,
+  GuideDetailSchema,
+  GuideSearchResponseSchema,
+  GuidesResponseSchema,
+} from '@packrat/schemas/guides';
+import { PackItemSchema, PackSchema, PackWithItemsSchema } from '@packrat/schemas/packs';
 import { TripSchema } from '@packrat/schemas/trips';
 import { UserSchema } from '@packrat/schemas/users';
 import { z } from 'zod';
@@ -133,6 +144,52 @@ export const GetWeatherOutputSchema = z
     forecast: z.unknown().optional(),
   })
   .passthrough();
+
+// ── Tier 2 → Tier 1 lift ─────────────────────────────────────────────────────
+// The tools below were previously text-only (see the "Tier 2 deferral list"
+// in the module docstring). Their API response shapes ARE modeled in
+// `@packrat/schemas`, so per this file's reuse policy we re-export those
+// rather than re-deriving them here.
+
+/** `packrat_search_gear_catalog` — paginated catalog page. */
+export const SearchGearCatalogOutputSchema = CatalogItemsResponseSchema;
+
+/** `packrat_get_catalog_item` — a single catalog row. */
+export const GetCatalogItemOutputSchema = CatalogItemSchema;
+
+/**
+ * `packrat_semantic_gear_search` / `packrat_similar_catalog_items` — vector
+ * search returns catalog rows with a cosine `similarity` score attached, and
+ * the service drops the 1536-dim `embedding` column from the projection.
+ * `.passthrough()` keeps validation from failing if the service adds a field.
+ */
+export const CatalogSimilarityOutputSchema = z
+  .object({
+    items: z.array(CatalogItemSchema.extend({ similarity: z.number() }).passthrough()),
+    total: z.number().int().optional(),
+    limit: z.number().int().optional(),
+    offset: z.number().int().optional(),
+    nextOffset: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+
+/** `packrat_list_pack_items` — the API returns a bare array; we wrap it. */
+export const ListPackItemsOutputSchema = paginatedWithNextOffset(PackItemSchema);
+
+/** `packrat_get_pack_item` — a single pack item row. */
+export const GetPackItemOutputSchema = PackItemSchema;
+
+/** `packrat_list_guides` — paginated guides page. */
+export const ListGuidesOutputSchema = GuidesResponseSchema;
+
+/** `packrat_search_guides` — same page shape plus the echoed query. */
+export const SearchGuidesOutputSchema = GuideSearchResponseSchema;
+
+/** `packrat_get_guide` — a single guide including its MDX/Markdown body. */
+export const GetGuideOutputSchema = GuideDetailSchema;
+
+/** `packrat_list_guide_categories` — the category list plus a count. */
+export const ListGuideCategoriesOutputSchema = GuideCategoriesResponseSchema;
 
 /** `packrat_admin_stats` — re-export of the API's admin stats schema. */
 export const AdminStatsOutputSchema = AdminStatsSchema;

--- a/packages/mcp/src/tools/catalog.ts
+++ b/packages/mcp/src/tools/catalog.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 import { call, clampLimit, PAGINATION_LIMIT_MAX } from '../client';
 import { CatalogSortField, SortOrder } from '../enums';
+import {
+  CatalogSimilarityOutputSchema,
+  GetCatalogItemOutputSchema,
+  SearchGearCatalogOutputSchema,
+} from '../output-schemas';
 import { tool } from '../registerTool';
 import type { AgentContext } from '../types';
 
@@ -44,6 +49,7 @@ export function registerCatalogTools(agent: AgentContext): void {
         sort_by: z.nativeEnum(CatalogSortField).optional(),
         sort_order: z.nativeEnum(SortOrder).default(SortOrder.Asc),
       },
+      outputSchema: SearchGearCatalogOutputSchema.shape,
       annotations: {
         title: 'Search Gear Catalog',
         readOnlyHint: true,
@@ -63,6 +69,7 @@ export function registerCatalogTools(agent: AgentContext): void {
           },
         }),
         action: 'search catalog',
+        structured: true,
       }),
   );
 
@@ -79,6 +86,7 @@ export function registerCatalogTools(agent: AgentContext): void {
         query: z.string().min(3),
         limit: z.number().int().min(1).max(30).default(8),
       },
+      outputSchema: CatalogSimilarityOutputSchema.shape,
       annotations: {
         title: 'Semantic Gear Search',
         readOnlyHint: true,
@@ -90,6 +98,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       call({
         promise: agent.api.user.catalog['vector-search'].get({ query: { q: query, limit } }),
         action: 'semantic catalog search',
+        structured: true,
       }),
   );
 
@@ -105,6 +114,7 @@ export function registerCatalogTools(agent: AgentContext): void {
       inputSchema: {
         item_id: z.number().int().describe('The catalog item ID'),
       },
+      outputSchema: GetCatalogItemOutputSchema.shape,
       annotations: {
         title: 'Get Catalog Item',
         readOnlyHint: true,
@@ -117,6 +127,7 @@ export function registerCatalogTools(agent: AgentContext): void {
         promise: agent.api.user.catalog({ id: String(item_id) }).get(),
         action: 'get catalog item',
         resourceHint: `catalog item ${item_id}`,
+        structured: true,
       }),
   );
 
@@ -133,6 +144,7 @@ export function registerCatalogTools(agent: AgentContext): void {
         limit: z.number().int().min(1).max(50).default(10),
         threshold: z.number().min(0).max(1).optional(),
       },
+      outputSchema: CatalogSimilarityOutputSchema.shape,
       annotations: {
         title: 'Find Similar Catalog Items',
         readOnlyHint: true,
@@ -150,6 +162,7 @@ export function registerCatalogTools(agent: AgentContext): void {
         }),
         action: 'find similar catalog items',
         resourceHint: `catalog item ${item_id}`,
+        structured: true,
       }),
   );
 

--- a/packages/mcp/src/tools/guides.ts
+++ b/packages/mcp/src/tools/guides.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 import { call } from '../client';
+import {
+  GetGuideOutputSchema,
+  ListGuideCategoriesOutputSchema,
+  ListGuidesOutputSchema,
+  SearchGuidesOutputSchema,
+} from '../output-schemas';
 import { tool } from '../registerTool';
 import type { AgentContext } from '../types';
 
@@ -23,6 +29,7 @@ export function registerGuidesTools(agent: AgentContext): void {
         sort_field: z.enum(['title', 'category', 'createdAt', 'updatedAt']).optional(),
         sort_order: z.enum(['asc', 'desc']).optional(),
       },
+      outputSchema: ListGuidesOutputSchema.shape,
       annotations: {
         title: 'List Outdoor Guides',
         readOnlyHint: true,
@@ -41,6 +48,7 @@ export function registerGuidesTools(agent: AgentContext): void {
           },
         }),
         action: 'list guides',
+        structured: true,
       }),
   );
 
@@ -51,6 +59,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       title: 'List Guide Categories',
       description: 'List all guide categories.',
       inputSchema: {},
+      outputSchema: ListGuideCategoriesOutputSchema.shape,
       annotations: {
         title: 'List Guide Categories',
         readOnlyHint: true,
@@ -62,6 +71,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       call({
         promise: agent.api.user.guides.categories.get(),
         action: 'list guide categories',
+        structured: true,
       }),
   );
 
@@ -82,6 +92,7 @@ export function registerGuidesTools(agent: AgentContext): void {
         limit: z.number().int().min(1).max(50).default(20),
         category: z.string().optional(),
       },
+      outputSchema: SearchGuidesOutputSchema.shape,
       annotations: {
         title: 'Search Outdoor Guides',
         readOnlyHint: true,
@@ -93,6 +104,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       call({
         promise: agent.api.user.guides.search.get({ query: { q: query, page, limit, category } }),
         action: 'search guides',
+        structured: true,
       }),
   );
 
@@ -103,6 +115,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       title: 'Get Guide',
       description: 'Get a specific guide by ID. Returns MDX/Markdown content.',
       inputSchema: { guide_id: z.string() },
+      outputSchema: GetGuideOutputSchema.shape,
       annotations: {
         title: 'Get Guide',
         readOnlyHint: true,
@@ -114,6 +127,7 @@ export function registerGuidesTools(agent: AgentContext): void {
       call({
         promise: agent.api.user.guides({ id: guide_id }).get(),
         action: 'get guide',
+        structured: true,
         resourceHint: `guide ${guide_id}`,
       }),
   );

--- a/packages/mcp/src/tools/packs.ts
+++ b/packages/mcp/src/tools/packs.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import { call, clampLimit, nowIso, ok, PAGINATION_LIMIT_MAX, withNextOffset } from '../client';
 import { ItemCategory, PackCategory } from '../enums';
-import { GetPackOutputSchema, ListPacksOutputSchema } from '../output-schemas';
+import {
+  GetPackItemOutputSchema,
+  GetPackOutputSchema,
+  ListPackItemsOutputSchema,
+  ListPacksOutputSchema,
+} from '../output-schemas';
 import { tool } from '../registerTool';
 import type { AgentContext } from '../types';
 
@@ -229,6 +234,7 @@ export function registerPackTools(agent: AgentContext): void {
       title: 'List Pack Items',
       description: 'List all items in a pack.',
       inputSchema: { pack_id: z.string().describe('The pack ID') },
+      outputSchema: ListPackItemsOutputSchema.shape,
       annotations: {
         title: 'List Pack Items',
         readOnlyHint: true,
@@ -236,12 +242,24 @@ export function registerPackTools(agent: AgentContext): void {
         openWorldHint: false,
       },
     },
-    async ({ pack_id }) =>
-      call({
-        promise: agent.api.user.packs({ packId: pack_id }).items.get(),
-        action: 'list pack items',
-        resourceHint: `pack ${pack_id}`,
-      }),
+    async ({ pack_id }) => {
+      const result = await agent.api.user.packs({ packId: pack_id }).items.get();
+      if (result.error || result.data == null) {
+        // Defer to the standard error envelope for failure consistency.
+        return call({
+          promise: Promise.resolve(result),
+          action: 'list pack items',
+          resourceHint: `pack ${pack_id}`,
+        });
+      }
+      // The API returns a bare array; normalise into the `{ data, nextOffset }`
+      // envelope the declared outputSchema expects (same shape as list_packs).
+      const items = Array.isArray(result.data) ? result.data : [];
+      return ok({
+        data: withNextOffset({ items, offset: 0, limit: items.length }),
+        structured: true,
+      });
+    },
   );
 
   // ── Get a single pack item ────────────────────────────────────────────────
@@ -253,6 +271,7 @@ export function registerPackTools(agent: AgentContext): void {
       title: 'Get Pack Item',
       description: 'Get full details of a single pack item.',
       inputSchema: { item_id: z.string().describe('The pack item ID') },
+      outputSchema: GetPackItemOutputSchema.shape,
       annotations: {
         title: 'Get Pack Item',
         readOnlyHint: true,
@@ -265,6 +284,7 @@ export function registerPackTools(agent: AgentContext): void {
         promise: agent.api.user.packs.items({ itemId: item_id }).get(),
         action: 'get pack item',
         resourceHint: `item ${item_id}`,
+        structured: true,
       }),
   );
 


### PR DESCRIPTION
## What

Adds `outputSchema` to ten MCP tools that previously emitted text-only results, lifting them from the "Tier 2 deferral" list documented in `output-schemas.ts`.

| Tool | Schema |
|---|---|
| `packrat_search_gear_catalog` | `CatalogItemsResponseSchema` |
| `packrat_get_catalog_item` | `CatalogItemSchema` |
| `packrat_semantic_gear_search` | catalog rows + `similarity` |
| `packrat_similar_catalog_items` | catalog rows + `similarity` |
| `packrat_list_pack_items` | list-of-`PackItem` with `nextOffset` |
| `packrat_get_pack_item` | `PackItemSchema` |
| `packrat_list_guides` | `GuidesResponseSchema` |
| `packrat_search_guides` | `GuideSearchResponseSchema` |
| `packrat_get_guide` | `GuideDetailSchema` |
| `packrat_list_guide_categories` | `GuideCategoriesResponseSchema` |

## Why

The Anthropic connector-directory review flags "Recommended: Add an outputSchema so models can better understand this tool's results" on most tools. Declaring one also makes the SDK validate `structuredContent` before it's sent, so a response-shape drift fails loudly in tests rather than silently degrading model output.

## Approach

Per the reuse policy in `output-schemas.ts`, these re-export shapes already modeled in `@packrat/schemas` rather than re-deriving them — so a future API response change propagates from the single source of truth.

Two things worth a reviewer's attention:

- **`packrat_list_pack_items` needed a handler change, not just a schema.** It returned the API's bare array, which would not validate against the `{ data, nextOffset }` envelope. It now normalises via `withNextOffset`, matching `packrat_list_packs`. Error paths still defer to the standard `call()` envelope.
- **The similarity schemas use `.passthrough()`** so a service-side field addition doesn't fail validation in production before a fix can ship (same rationale as the existing `GetWeatherOutputSchema`).

The module docstring's Tier 1/Tier 2 lists are updated to match reality.

## Testing

- `bun test:mcp` — 1273 pass, 23 skipped
- tsc + biome clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured responses for catalog search, item lookup, similarity search, pack items, and guide tools.
  * Added consistent pagination metadata for list results.
  * Improved error handling for pack-item listings.
  * Expanded support for validated output formats across MCP tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->