### PR TITLE
feat(swift): add Ask AI, catalog browse, photo scan, and packing mode to pack detail

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Chat/ChatView.swift
+++ b/apps/swift/Sources/PackRat/Features/Chat/ChatView.swift
@@ -18,6 +18,25 @@ struct ChatView: View {
         viewModel.sendMessage()
     }
 
+    /// Pack-scoped chats are presented inside their own sheet, which supplies
+    /// the "Ask AI" title — leaving the generic one here would override it.
+    private var navigationTitleText: String {
+        viewModel.context.packName == nil ? "AI Assistant" : "Ask AI"
+    }
+
+    /// The generic starter prompts assume no pack context. When scoped to a
+    /// pack, offer prompts that exercise the `getPackDetails` tool instead.
+    private var activeSuggestions: [(String, String)] {
+        guard let packName = viewModel.context.packName else { return Self.suggestions }
+        return [
+            ("What's missing?", "Review “\(packName)” and tell me what essential gear is missing."),
+            ("Cut weight", "How can I reduce the weight of “\(packName)”? Suggest the biggest wins."),
+            ("Heaviest items", "What are the heaviest items in “\(packName)” and what are lighter alternatives?"),
+            ("Redundant gear", "Is there anything redundant or unnecessary in “\(packName)”?"),
+            ("Rain ready", "Is “\(packName)” ready for wet weather? What should I add?"),
+        ]
+    }
+
     var body: some View {
         Group {
             if authManager.isAuthenticated {
@@ -37,7 +56,7 @@ struct ChatView: View {
                 )
             }
         }
-        .navigationTitle("AI Assistant")
+        .navigationTitle(navigationTitleText)
         .toolbar {
             if authManager.isAuthenticated {
                 ToolbarItem(placement: .automatic) {
@@ -91,9 +110,12 @@ struct ChatView: View {
                         .font(.title2)
                         .foregroundStyle(Color.accentColor)
                 }
-            Text("PackRat AI")
+            Text(viewModel.context.packName ?? "PackRat AI")
                 .font(.title3.bold())
-            Text("Ask me anything about gear, trips, or packing strategy")
+                .multilineTextAlignment(.center)
+            Text(viewModel.context.packName == nil
+                 ? "Ask me anything about gear, trips, or packing strategy"
+                 : "I can see this pack's contents — ask about gaps, weight, or what to leave behind")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -117,7 +139,7 @@ struct ChatView: View {
     private var suggestionsBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                ForEach(Self.suggestions, id: \.0) { label, prompt in
+                ForEach(activeSuggestions, id: \.0) { label, prompt in
                     Button {
                         viewModel.inputText = prompt
                         send()

--- a/apps/swift/Sources/PackRat/Features/Chat/ChatViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Chat/ChatViewModel.swift
@@ -9,15 +9,24 @@ final class ChatViewModel {
     var isStreaming = false
     var error: String?
 
+    /// What this conversation is scoped to. Sent on every request so the server
+    /// can attach pack context to the system prompt.
+    let context: ChatContext
+
     private let service: any ChatServicing
     private var streamingTask: Task<Void, Never>?
 
-    init(service: any ChatServicing = ChatService.shared) {
+    init(service: any ChatServicing = ChatService.shared, context: ChatContext = .general) {
         self.service = service
-        messages.append(ChatMessage(
-            role: .assistant,
-            content: "Hi! I'm your PackRat AI assistant. I can help you plan trips, build packing lists, research gear, and answer questions about outdoor adventures. What are you working on?"
-        ))
+        self.context = context
+        messages.append(ChatMessage(role: .assistant, content: Self.greeting(for: context)))
+    }
+
+    private static func greeting(for context: ChatContext) -> String {
+        if let packName = context.packName {
+            return "Ask me anything about “\(packName)” — what's missing, how to cut weight, or whether it suits your trip."
+        }
+        return "Hi! I'm your PackRat AI assistant. I can help you plan trips, build packing lists, research gear, and answer questions about outdoor adventures. What are you working on?"
     }
 
     var canSend: Bool { !inputText.trimmingCharacters(in: .whitespaces).isEmpty && !isStreaming }
@@ -39,7 +48,7 @@ final class ChatViewModel {
             defer { isStreaming = false }
             do {
                 let history = Array(messages.dropLast())
-                for try await chunk in await service.sendMessage(messages: history) {
+                for try await chunk in await service.sendMessage(messages: history, context: context) {
                     guard let data = chunk.data(using: .utf8),
                           let parsed = try? JSONDecoder().decode(UIStreamChunk.self, from: data)
                     else { continue }
@@ -85,7 +94,9 @@ final class ChatViewModel {
         messages.removeAll()
         messages.append(ChatMessage(
             role: .assistant,
-            content: "Chat cleared. What can I help you with?"
+            content: context.packName == nil
+                ? "Chat cleared. What can I help you with?"
+                : Self.greeting(for: context)
         ))
     }
 

--- a/apps/swift/Sources/PackRat/Features/Packs/PackAskAISheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackAskAISheet.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Pack-scoped wrapper around `ChatView`.
+///
+/// Mirrors Expo, which routes to `/ai-chat` with `{ packId, packName,
+/// contextType: 'pack' }` rather than hosting a separate chat implementation
+/// (apps/expo/features/packs/screens/PackDetailScreen.tsx `handleAskAI`). The
+/// view model is created per-presentation so each pack gets its own transcript
+/// and the global assistant's history is left untouched.
+struct PackAskAISheet: View {
+    let pack: Pack
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel: ChatViewModel
+
+    init(pack: Pack) {
+        self.pack = pack
+        _viewModel = State(initialValue: ChatViewModel(
+            context: .pack(id: pack.id, name: pack.name)
+        ))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ChatView(viewModel: viewModel)
+                .navigationTitle("Ask AI")
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                            .accessibilityIdentifier("pack_ask_ai_done")
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 520, minHeight: 600)
+        #endif
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
@@ -1,0 +1,371 @@
+import SwiftUI
+
+/// Multi-select catalog browser for adding gear to a pack.
+///
+/// The Swift app already had a single-item "Add to Pack" path from the catalog
+/// tab (`AddCatalogItemToPackSheet`), which works the other way round: start at
+/// an item, pick a pack. This is the pack-first flow Expo has
+/// (`CatalogBrowserModal`) — you are already in a pack, so you search, tick
+/// several items, and add them all at once.
+@MainActor
+@Observable
+final class PackCatalogBrowserViewModel {
+    var searchText = ""
+    var items: [CatalogItem] = []
+    var categories: [String] = []
+    var selectedCategory: String?
+    /// Catalog id → quantity. Presence means selected.
+    var selection: [Int: Int] = [:]
+    var isLoading = false
+    var isAdding = false
+    var error: String?
+    var hasLoadedOnce = false
+
+    private let service: CatalogService
+    private var page = 1
+    private var hasMore = true
+    private var searchTask: Task<Void, Never>?
+
+    init(service: CatalogService = .shared) {
+        self.service = service
+    }
+
+    var selectedCount: Int { selection.count }
+
+    var canAdd: Bool { !selection.isEmpty && !isAdding }
+
+    func isSelected(_ item: CatalogItem) -> Bool { selection[item.id] != nil }
+
+    func toggleSelection(_ item: CatalogItem) {
+        if selection[item.id] == nil {
+            selection[item.id] = 1
+        } else {
+            selection.removeValue(forKey: item.id)
+        }
+    }
+
+    func setQuantity(_ quantity: Int, for item: CatalogItem) {
+        guard selection[item.id] != nil else { return }
+        selection[item.id] = max(1, quantity)
+    }
+
+    func clearSelection() { selection.removeAll() }
+
+    /// Debounced search. Unlike the catalog tab, an empty query is a valid
+    /// browse (show popular gear) rather than a no-op, so the pack flow always
+    /// has something on screen to pick from.
+    func onSearchTextChanged() {
+        searchTask?.cancel()
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            await load(reset: true)
+        }
+    }
+
+    func selectCategory(_ category: String?) {
+        selectedCategory = category
+        Task { await load(reset: true) }
+    }
+
+    func loadInitialIfNeeded() async {
+        guard !hasLoadedOnce else { return }
+        hasLoadedOnce = true
+        async let cats: Void = loadCategories()
+        async let items: Void = load(reset: true)
+        _ = await (cats, items)
+    }
+
+    private func loadCategories() async {
+        categories = (try? await service.categories(limit: 20)) ?? []
+    }
+
+    func load(reset: Bool) async {
+        if reset {
+            page = 1
+            hasMore = true
+        }
+        guard hasMore || reset else { return }
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+        do {
+            let results = try await service.browse(
+                query: searchText.isEmpty ? nil : searchText,
+                category: selectedCategory,
+                page: page,
+                limit: 20
+            )
+            if reset {
+                items = results
+            } else {
+                // The API paginates without dedup guarantees across pages; drop
+                // ids already on screen so SwiftUI's ForEach never sees a
+                // duplicate Identifiable and drops rows.
+                let known = Set(items.map(\.id))
+                items.append(contentsOf: results.filter { !known.contains($0.id) })
+            }
+            hasMore = results.count == 20
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func loadMoreIfNeeded(currentItem: CatalogItem) async {
+        guard !isLoading, hasMore, currentItem.id == items.last?.id else { return }
+        page += 1
+        await load(reset: false)
+    }
+
+    /// Resolves the current selection to (item, quantity) pairs in the order
+    /// they appear on screen, so the added items land in a predictable order.
+    func resolvedSelection() -> [(item: CatalogItem, quantity: Int)] {
+        items.compactMap { item in
+            guard let quantity = selection[item.id] else { return nil }
+            return (item, quantity)
+        }
+    }
+}
+
+struct PackCatalogBrowserSheet: View {
+    let packId: String
+    let packsViewModel: PacksViewModel
+    /// Called with the number of items added, so the caller can surface a toast.
+    var onAdded: ((Int) -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel = PackCatalogBrowserViewModel()
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Add from Catalog")
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                .searchable(
+                    text: $viewModel.searchText,
+                    placement: .navigationBarDrawer(displayMode: .always),
+                    prompt: "Search tents, packs, sleeping bags…"
+                )
+                #else
+                .searchable(text: $viewModel.searchText, prompt: "Search gear…")
+                #endif
+                .onChange(of: viewModel.searchText) { viewModel.onSearchTextChanged() }
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                            .accessibilityIdentifier("pack_catalog_cancel")
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        addButton
+                    }
+                }
+                .task { await viewModel.loadInitialIfNeeded() }
+                .safeAreaInset(edge: .bottom) {
+                    if viewModel.selectedCount > 0 {
+                        selectionBar
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 520, minHeight: 600)
+        #endif
+    }
+
+    private var addButton: some View {
+        Button {
+            Task { await addSelected() }
+        } label: {
+            if viewModel.isAdding {
+                ProgressView().controlSize(.small)
+            } else {
+                Text("Add\(viewModel.selectedCount > 0 ? " (\(viewModel.selectedCount))" : "")")
+                    .bold()
+            }
+        }
+        .disabled(!viewModel.canAdd)
+        .accessibilityIdentifier("pack_catalog_confirm_add")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        VStack(spacing: 0) {
+            if !viewModel.categories.isEmpty {
+                categoryChips
+            }
+            Divider()
+            resultsList
+        }
+    }
+
+    private var categoryChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                chip(label: "All", isSelected: viewModel.selectedCategory == nil) {
+                    viewModel.selectCategory(nil)
+                }
+                ForEach(viewModel.categories, id: \.self) { category in
+                    chip(label: category.capitalized, isSelected: viewModel.selectedCategory == category) {
+                        viewModel.selectCategory(
+                            viewModel.selectedCategory == category ? nil : category
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .accessibilityIdentifier("pack_catalog_categories")
+    }
+
+    private func chip(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.bold())
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(
+                    isSelected ? Color.accentColor : Color.accentColor.opacity(0.1),
+                    in: Capsule()
+                )
+                .foregroundStyle(isSelected ? .white : Color.accentColor)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var resultsList: some View {
+        if viewModel.isLoading && viewModel.items.isEmpty {
+            ProgressView("Loading gear…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.error, viewModel.items.isEmpty {
+            ErrorView(error, retry: { await viewModel.load(reset: true) })
+        } else if viewModel.items.isEmpty {
+            UnavailableStateView(
+                title: "No Gear Found",
+                subtitle: viewModel.searchText.isEmpty
+                    ? "No catalog items are available right now."
+                    : "Nothing matched “\(viewModel.searchText)”. Try a brand, model, or category.",
+                systemImage: "magnifyingglass"
+            )
+            .accessibilityIdentifier("pack_catalog_no_results")
+        } else {
+            List {
+                ForEach(viewModel.items) { item in
+                    PackCatalogItemRow(
+                        item: item,
+                        isSelected: viewModel.isSelected(item),
+                        quantity: viewModel.selection[item.id] ?? 1,
+                        onToggle: { viewModel.toggleSelection(item) },
+                        onQuantityChange: { viewModel.setQuantity($0, for: item) }
+                    )
+                    .task { await viewModel.loadMoreIfNeeded(currentItem: item) }
+                }
+                if viewModel.isLoading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .accessibilityIdentifier("pack_catalog_results_list")
+        }
+    }
+
+    private var selectionBar: some View {
+        HStack {
+            Text("\(viewModel.selectedCount) selected")
+                .font(.callout.bold())
+            Spacer()
+            Button("Clear") { viewModel.clearSelection() }
+                .font(.callout)
+                .accessibilityIdentifier("pack_catalog_clear")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
+    }
+
+    private func addSelected() async {
+        let selections = viewModel.resolvedSelection()
+        guard !selections.isEmpty else { return }
+        viewModel.isAdding = true
+        let result = await packsViewModel.addCatalogItems(selections, to: packId)
+        viewModel.isAdding = false
+
+        if result.failed > 0 && result.added == 0 {
+            viewModel.error = "Couldn't add \(result.failed == 1 ? "the item" : "those items"). Check your connection and try again."
+            return
+        }
+        onAdded?(result.added)
+        dismiss()
+    }
+}
+
+// MARK: - Row
+
+private struct PackCatalogItemRow: View {
+    let item: CatalogItem
+    let isSelected: Bool
+    let quantity: Int
+    let onToggle: () -> Void
+    let onQuantityChange: (Int) -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .accessibilityHidden(true)
+
+                RemoteImage(url: item.primaryImage, contentMode: .fill, cornerRadius: 8) {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(.fill.secondary)
+                        .overlay { Image(systemName: "photo").foregroundStyle(.tertiary) }
+                }
+                .frame(width: 48, height: 48)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.displayName)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(2)
+                    HStack(spacing: 8) {
+                        if let brand = item.displayBrand {
+                            Text(brand).font(.caption2.bold()).foregroundStyle(.tint)
+                        }
+                        if !item.displayWeight.isEmpty {
+                            Text(item.displayWeight)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let price = item.displayPrice {
+                            Text(price).font(.caption2.bold()).foregroundStyle(.green)
+                        }
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture(perform: onToggle)
+
+            if isSelected {
+                Stepper(
+                    "Quantity: \(quantity)",
+                    value: Binding(get: { quantity }, set: onQuantityChange),
+                    in: 1...99
+                )
+                .font(.caption)
+                .padding(.leading, 32)
+                .accessibilityIdentifier("pack_catalog_quantity_\(item.id)")
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityIdentifier("pack_catalog_item_\(item.id)")
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
@@ -205,7 +205,7 @@ struct PackCatalogBrowserSheet: View {
                     viewModel.selectCategory(nil)
                 }
                 ForEach(viewModel.categories, id: \.self) { category in
-                    chip(label: category.capitalized, isSelected: viewModel.selectedCategory == category) {
+                    chip(label: category.catalogCategoryDisplayName, isSelected: viewModel.selectedCategory == category) {
                         viewModel.selectCategory(
                             viewModel.selectedCategory == category ? nil : category
                         )

--- a/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
@@ -14,8 +14,14 @@ final class PackCatalogBrowserViewModel {
     var items: [CatalogItem] = []
     var categories: [String] = []
     var selectedCategory: String?
-    /// Catalog id → quantity. Presence means selected.
-    var selection: [Int: Int] = [:]
+    /// Catalog id → the selected item and how many of it. Presence means
+    /// selected.
+    ///
+    /// The item is held here, not looked up in `items`, because searching or
+    /// changing category replaces `items` wholesale. Resolving against the
+    /// visible list would silently drop anything selected under a previous
+    /// query — you would tick three things, search again, tap Add, and get one.
+    var selection: [Int: (item: CatalogItem, quantity: Int)] = [:]
     var isLoading = false
     /// True from the keystroke until fresh results land, spanning the debounce.
     /// Distinct from `isLoading`, which only covers the request itself and so
@@ -25,12 +31,13 @@ final class PackCatalogBrowserViewModel {
     var error: String?
     var hasLoadedOnce = false
 
-    private let service: CatalogService
+    private let service: any CatalogBrowsing
+    private let pageSize = 20
     private var page = 1
     private var hasMore = true
     private var searchTask: Task<Void, Never>?
 
-    init(service: CatalogService = .shared) {
+    init(service: any CatalogBrowsing = CatalogService.shared) {
         self.service = service
     }
 
@@ -42,15 +49,19 @@ final class PackCatalogBrowserViewModel {
 
     func toggleSelection(_ item: CatalogItem) {
         if selection[item.id] == nil {
-            selection[item.id] = 1
+            selection[item.id] = (item: item, quantity: 1)
         } else {
             selection.removeValue(forKey: item.id)
         }
     }
 
     func setQuantity(_ quantity: Int, for item: CatalogItem) {
-        guard selection[item.id] != nil else { return }
-        selection[item.id] = max(1, quantity)
+        guard let existing = selection[item.id] else { return }
+        selection[item.id] = (item: existing.item, quantity: max(1, quantity))
+    }
+
+    func quantity(for item: CatalogItem) -> Int {
+        selection[item.id]?.quantity ?? 1
     }
 
     func clearSelection() { selection.removeAll() }
@@ -73,9 +84,14 @@ final class PackCatalogBrowserViewModel {
     }
 
     func selectCategory(_ category: String?) {
+        // Cancel any in-flight debounce or reset load and take over `searchTask`.
+        // Otherwise a pending search can land after the category change and
+        // overwrite its results — whichever response finishes last wins, which
+        // is not necessarily the request the user made last.
+        searchTask?.cancel()
         selectedCategory = category
         isSearching = true
-        Task { await load(reset: true) }
+        searchTask = Task { await load(reset: true) }
     }
 
     func loadInitialIfNeeded() async {
@@ -109,8 +125,12 @@ final class PackCatalogBrowserViewModel {
                 query: searchText.isEmpty ? nil : searchText,
                 category: selectedCategory,
                 page: page,
-                limit: 20
+                limit: pageSize
             )
+            // A superseded request must not commit. Without this a cancelled
+            // search or category change still assigns its results when it
+            // finally returns, replacing whatever the user actually asked for.
+            guard !Task.isCancelled else { return }
             if reset {
                 items = results
             } else {
@@ -120,8 +140,11 @@ final class PackCatalogBrowserViewModel {
                 let known = Set(items.map(\.id))
                 items.append(contentsOf: results.filter { !known.contains($0.id) })
             }
-            hasMore = results.count == 20
+            hasMore = results.count == pageSize
         } catch {
+            // Give the page number back on a failed append, or the next scroll
+            // asks for page + 2 and that page's results are never fetched.
+            if !reset, page > 1 { page -= 1 }
             self.error = error.localizedDescription
         }
     }
@@ -132,21 +155,33 @@ final class PackCatalogBrowserViewModel {
         await load(reset: false)
     }
 
-    /// Resolves the current selection to (item, quantity) pairs in the order
-    /// they appear on screen, so the added items land in a predictable order.
+    /// Every selected item, including ones no longer in the visible list because
+    /// the query or category changed after they were ticked.
+    ///
+    /// Ordered by the on-screen list first so a normal add lands predictably,
+    /// then anything selected under an earlier query, so nothing is lost.
     func resolvedSelection() -> [(item: CatalogItem, quantity: Int)] {
-        items.compactMap { item in
-            guard let quantity = selection[item.id] else { return nil }
-            return (item, quantity)
+        var remaining = selection
+        var ordered: [(item: CatalogItem, quantity: Int)] = []
+        for item in items {
+            if let picked = remaining.removeValue(forKey: item.id) {
+                ordered.append(picked)
+            }
         }
+        // Stable order for the off-screen remainder, which a dictionary cannot
+        // give on its own.
+        ordered.append(contentsOf: remaining.values.sorted { $0.item.id < $1.item.id })
+        return ordered
     }
 }
 
 struct PackCatalogBrowserSheet: View {
     let packId: String
     let packsViewModel: PacksViewModel
-    /// Called with the number of items added, so the caller can surface a toast.
-    var onAdded: ((Int) -> Void)?
+    /// Called with how many items were added and how many failed, so the caller
+    /// can surface a toast that admits a partial failure rather than reporting
+    /// only the successes.
+    var onAdded: ((_ added: Int, _ failed: Int) -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = PackCatalogBrowserViewModel()
@@ -270,7 +305,7 @@ struct PackCatalogBrowserSheet: View {
                     PackCatalogItemRow(
                         item: item,
                         isSelected: viewModel.isSelected(item),
-                        quantity: viewModel.selection[item.id] ?? 1,
+                        quantity: viewModel.quantity(for: item),
                         onToggle: { viewModel.toggleSelection(item) },
                         onQuantityChange: { viewModel.setQuantity($0, for: item) }
                     )
@@ -330,7 +365,7 @@ struct PackCatalogBrowserSheet: View {
             viewModel.error = "Couldn't add \(result.failed == 1 ? "the item" : "those items"). Check your connection and try again."
             return
         }
-        onAdded?(result.added)
+        onAdded?(result.added, result.failed)
         dismiss()
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackCatalogBrowserSheet.swift
@@ -17,6 +17,10 @@ final class PackCatalogBrowserViewModel {
     /// Catalog id → quantity. Presence means selected.
     var selection: [Int: Int] = [:]
     var isLoading = false
+    /// True from the keystroke until fresh results land, spanning the debounce.
+    /// Distinct from `isLoading`, which only covers the request itself and so
+    /// leaves the first 400ms with no feedback at all.
+    var isSearching = false
     var isAdding = false
     var error: String?
     var hasLoadedOnce = false
@@ -54,8 +58,13 @@ final class PackCatalogBrowserViewModel {
     /// Debounced search. Unlike the catalog tab, an empty query is a valid
     /// browse (show popular gear) rather than a no-op, so the pack flow always
     /// has something on screen to pick from.
+    ///
+    /// `isSearching` flips immediately rather than when the request starts, so
+    /// the debounce window is covered too — otherwise typing looks like nothing
+    /// is happening for 400ms and then the list silently swaps underneath you.
     func onSearchTextChanged() {
         searchTask?.cancel()
+        isSearching = true
         searchTask = Task {
             try? await Task.sleep(for: .milliseconds(400))
             guard !Task.isCancelled else { return }
@@ -65,6 +74,7 @@ final class PackCatalogBrowserViewModel {
 
     func selectCategory(_ category: String?) {
         selectedCategory = category
+        isSearching = true
         Task { await load(reset: true) }
     }
 
@@ -88,7 +98,12 @@ final class PackCatalogBrowserViewModel {
         guard hasMore || reset else { return }
         isLoading = true
         error = nil
-        defer { isLoading = false }
+        defer {
+            isLoading = false
+            // Only a reset (search / category change) ends a search — paging
+            // to the next page must not clear it.
+            if reset { isSearching = false }
+        }
         do {
             let results = try await service.browse(
                 query: searchText.isEmpty ? nil : searchText,
@@ -235,7 +250,7 @@ struct PackCatalogBrowserSheet: View {
 
     @ViewBuilder
     private var resultsList: some View {
-        if viewModel.isLoading && viewModel.items.isEmpty {
+        if (viewModel.isLoading || viewModel.isSearching) && viewModel.items.isEmpty {
             ProgressView("Loading gear…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = viewModel.error, viewModel.items.isEmpty {
@@ -261,7 +276,10 @@ struct PackCatalogBrowserSheet: View {
                     )
                     .task { await viewModel.loadMoreIfNeeded(currentItem: item) }
                 }
-                if viewModel.isLoading {
+                // Paging spinner at the foot of the list. Only while appending —
+                // a search replaces the list, and its spinner belongs on top of
+                // the stale results, not below the fold.
+                if viewModel.isLoading && !viewModel.isSearching {
                     HStack {
                         Spacer()
                         ProgressView()
@@ -271,6 +289,19 @@ struct PackCatalogBrowserSheet: View {
             }
             .listStyle(.plain)
             .accessibilityIdentifier("pack_catalog_results_list")
+            // While a new search is in flight the visible rows are stale, so
+            // fade them and float a spinner over the top. Without this, typing
+            // looks like nothing happened until the list silently swaps.
+            .opacity(viewModel.isSearching ? 0.35 : 1)
+            .allowsHitTesting(!viewModel.isSearching)
+            .overlay {
+                if viewModel.isSearching {
+                    ProgressView()
+                        .controlSize(.large)
+                        .accessibilityIdentifier("pack_catalog_searching")
+                }
+            }
+            .animation(.easeInOut(duration: 0.15), value: viewModel.isSearching)
         }
     }
 

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -7,10 +7,18 @@ struct PackDetailView: View {
     let pack: Pack
     @Bindable var viewModel: PacksViewModel
 
+    init(pack: Pack, viewModel: PacksViewModel) {
+        self.pack = pack
+        self.viewModel = viewModel
+    }
+
     @State private var showingEditSheet = false
     @State private var showingAddItemSheet = false
     @State private var showingGapAnalysis = false
     @State private var showingWeightAnalysis = false
+    @State private var showingAskAI = false
+    @State private var showingCatalogBrowser = false
+    @State private var showingItemsScan = false
     @State private var editingItem: PackItem?
     @State private var detailItem: PackItem?
     @State private var error: String?
@@ -19,12 +27,62 @@ struct PackDetailView: View {
     @State private var itemPendingDeletion: PackItem?
     @State private var showingDeleteConfirmation = false
     @Environment(\.modelContext) private var modelContext
+    @State private var statusMessage: String?
+
+    // MARK: Packing mode
+
+    @State private var isPackingMode = false
+    @State private var packingFilter: PackingFilter = .all
+    private var packingStore = PackingModeStore.shared
+
+    enum PackingFilter: String, CaseIterable, Identifiable {
+        case all, unpacked, packed
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .all:      return "All"
+            case .unpacked: return "Unpacked"
+            case .packed:   return "Packed"
+            }
+        }
+    }
 
     private var currentPack: Pack {
         viewModel.packs.first { $0.id == pack.id } ?? pack
     }
 
     private var items: [PackItem] { currentPack.activeItems }
+
+    /// Items after the packing-mode filter. Outside packing mode this is every
+    /// item, so the normal browsing view is unaffected.
+    private var visibleItems: [PackItem] {
+        guard isPackingMode else { return items }
+        switch packingFilter {
+        case .all:
+            return items
+        case .packed:
+            return items.filter { packingStore.isPacked($0.id, in: currentPack.id) }
+        case .unpacked:
+            return items.filter { !packingStore.isPacked($0.id, in: currentPack.id) }
+        }
+    }
+
+    private var packedCount: Int {
+        packingStore.packedCount(in: currentPack.id, among: items.map(\.id))
+    }
+
+    private var packingProgress: Double {
+        guard !items.isEmpty else { return 0 }
+        return Double(packedCount) / Double(items.count)
+    }
+
+    private var progressTint: Color {
+        switch packingProgress {
+        case 1...:      return .green
+        case 0.5..<1:   return .blue
+        default:        return .orange
+        }
+    }
 
     private var packShareURL: URL? {
         URL(string: "https://packrat.world/packs/\(currentPack.id)")
@@ -33,10 +91,20 @@ struct PackDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                weightSummary
-                    .padding(.horizontal)
+                if isPackingMode {
+                    packingHeader
+                        .padding(.horizontal)
+                } else {
+                    weightSummary
+                        .padding(.horizontal)
 
-                PackWeightChart(pack: currentPack)
+                    PackWeightChart(pack: currentPack)
+
+                    if packedCount > 0 {
+                        packingResumeSummary
+                            .padding(.horizontal)
+                    }
+                }
 
                 if let error {
                     InlineErrorView(message: error)
@@ -44,17 +112,26 @@ struct PackDetailView: View {
                 }
 
                 LazyVStack(alignment: .leading, spacing: 0, pinnedViews: .sectionHeaders) {
-                    let groups = OrderedDictionary(grouping: items, by: { $0.category ?? "Uncategorized" })
+                    let groups = OrderedDictionary(grouping: visibleItems, by: { $0.category ?? "Uncategorized" })
                     ForEach(groups.keys.elements, id: \.self) { category in
                         Section {
                             ForEach(groups[category] ?? []) { item in
-                                PackItemRow(item: item) {
-                                    editingItem = item
-                                } onDelete: {
-                                    requestDelete(item)
-                                } onDetail: {
-                                    detailItem = item
-                                }
+                                PackItemRow(
+                                    item: item,
+                                    onEdit: { editingItem = item },
+                                    // Keep the confirmation flow from
+                                    // development rather than deleting inline.
+                                    onDelete: { requestDelete(item) },
+                                    onDetail: { detailItem = item },
+                                    packingState: isPackingMode
+                                        ? PackItemRow.PackingRowState(
+                                            isPacked: packingStore.isPacked(item.id, in: currentPack.id),
+                                            onTogglePacked: {
+                                                packingStore.toggle(itemId: item.id, in: currentPack.id)
+                                            }
+                                          )
+                                        : nil
+                                )
                                 Divider().padding(.leading)
                             }
                         } header: {
@@ -71,6 +148,18 @@ struct PackDetailView: View {
                             action: { showingAddItemSheet = true }
                         )
                         .frame(minHeight: 200)
+                    } else if visibleItems.isEmpty {
+                        // Packing filter matched nothing — distinct from an
+                        // empty pack, so don't offer "Add Item" here.
+                        EmptyStateView(
+                            packingFilter == .packed ? "Nothing Packed Yet" : "Everything's Packed",
+                            subtitle: packingFilter == .packed
+                                ? "Check items off as you put them in your bag."
+                                : "Every item in this pack is checked off. Nice.",
+                            systemImage: packingFilter == .packed ? "circle" : "checkmark.circle.fill"
+                        )
+                        .frame(minHeight: 200)
+                        .accessibilityIdentifier("pack_packing_filter_empty")
                     }
                 }
             }
@@ -81,45 +170,86 @@ struct PackDetailView: View {
         .navigationBarTitleDisplayMode(.large)
         #endif
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button("Add Item", systemImage: "plus") {
-                    showingAddItemSheet = true
+            if isPackingMode {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Done") { exitPackingMode() }
+                        .bold()
+                        .accessibilityIdentifier("pack_detail_done_packing")
                 }
-                .accessibilityIdentifier("pack_detail_add_item_button")
-                .keyboardShortcut("i", modifiers: .command)
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Menu {
-                    Button("Weight Analysis", systemImage: "chart.bar.fill") {
-                        showingWeightAnalysis = true
-                    }
-                    .disabled(items.isEmpty)
-
-                    Button("Gap Analysis", systemImage: "sparkles.magnifyingglass") {
-                        showingGapAnalysis = true
-                    }
-                    .disabled(items.isEmpty)
-
-                    if currentPack.isPublic == true, let shareURL = packShareURL {
-                        ShareLink(item: shareURL, subject: Text(currentPack.name),
-                                  message: Text("Check out my pack on PackRat")) {
-                            Label("Share", systemImage: "square.and.arrow.up")
+            } else {
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Button("Add Manually", systemImage: "square.and.pencil") {
+                            showingAddItemSheet = true
                         }
-                    }
+                        .accessibilityIdentifier("pack_detail_add_manually")
 
-                    Divider()
+                        Button("Scan Items from Photo", systemImage: "camera.viewfinder") {
+                            showingItemsScan = true
+                        }
+                        .accessibilityIdentifier("pack_detail_scan_photo")
 
-                    Button("Edit Pack", systemImage: "pencil") {
-                        showingEditSheet = true
+                        Button("Add from Catalog", systemImage: "magnifyingglass") {
+                            showingCatalogBrowser = true
+                        }
+                        .accessibilityIdentifier("pack_detail_add_from_catalog")
+                    } label: {
+                        Label("Add Item", systemImage: "plus")
+                    } primaryAction: {
+                        // Tapping (rather than long-pressing) keeps the old
+                        // one-tap manual-add behaviour that the UI tests and
+                        // muscle memory both rely on.
+                        showingAddItemSheet = true
                     }
-                    .accessibilityIdentifier("pack_detail_edit_pack")
-                    .keyboardShortcut("e", modifiers: .command)
-                } label: {
-                    Label("More", systemImage: "ellipsis.circle")
-                        .labelStyle(.iconOnly)
+                    .accessibilityIdentifier("pack_detail_add_item_button")
+                    .keyboardShortcut("i", modifiers: .command)
                 }
-                .accessibilityIdentifier("pack_detail_more_menu")
-                .accessibilityLabel("More")
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Button("Ask AI", systemImage: "sparkles") {
+                            showingAskAI = true
+                        }
+                        .accessibilityIdentifier("pack_detail_ask_ai")
+
+                        Button("Start Packing", systemImage: "checklist") {
+                            startPackingMode()
+                        }
+                        .disabled(items.isEmpty)
+                        .accessibilityIdentifier("pack_detail_start_packing")
+
+                        Divider()
+
+                        Button("Weight Analysis", systemImage: "chart.bar.fill") {
+                            showingWeightAnalysis = true
+                        }
+                        .disabled(items.isEmpty)
+
+                        Button("Gap Analysis", systemImage: "sparkles.magnifyingglass") {
+                            showingGapAnalysis = true
+                        }
+                        .disabled(items.isEmpty)
+
+                        if currentPack.isPublic == true, let shareURL = packShareURL {
+                            ShareLink(item: shareURL, subject: Text(currentPack.name),
+                                      message: Text("Check out my pack on PackRat")) {
+                                Label("Share", systemImage: "square.and.arrow.up")
+                            }
+                        }
+
+                        Divider()
+
+                        Button("Edit Pack", systemImage: "pencil") {
+                            showingEditSheet = true
+                        }
+                        .accessibilityIdentifier("pack_detail_edit_pack")
+                        .keyboardShortcut("e", modifiers: .command)
+                    } label: {
+                        Label("More", systemImage: "ellipsis.circle")
+                            .labelStyle(.iconOnly)
+                    }
+                    .accessibilityIdentifier("pack_detail_more_menu")
+                    .accessibilityLabel("More")
+                }
             }
         }
         .sheet(isPresented: $showingEditSheet) {
@@ -148,6 +278,27 @@ struct PackDetailView: View {
         } message: {
             Text(deleteItemAlertMessage)
         }
+        .sheet(isPresented: $showingAskAI) {
+            PackAskAISheet(pack: currentPack)
+        }
+        .sheet(isPresented: $showingCatalogBrowser) {
+            PackCatalogBrowserSheet(
+                packId: currentPack.id,
+                packsViewModel: viewModel,
+                onAdded: { count in
+                    statusMessage = "Added ^[\(count) item](inflect: true) from the catalog"
+                }
+            )
+        }
+        .sheet(isPresented: $showingItemsScan) {
+            PackItemsScanSheet(
+                packId: currentPack.id,
+                packsViewModel: viewModel,
+                onAdded: { count in
+                    statusMessage = "Added ^[\(count) item](inflect: true) from your photo"
+                }
+            )
+        }
         .navigationDestination(isPresented: $showingWeightAnalysis) {
             PackWeightAnalysisView(pack: currentPack)
         }
@@ -161,6 +312,123 @@ struct PackDetailView: View {
                 triggerShare = false
             }
         }
+        .safeAreaInset(edge: .bottom) {
+            if isPackingMode {
+                packingToolbar
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let statusMessage {
+                Text(statusMessage)
+                    .font(.callout.weight(.medium))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(.regularMaterial, in: Capsule())
+                    .shadow(radius: 8, y: 2)
+                    .padding(.bottom, 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .accessibilityIdentifier("pack_detail_status_toast")
+                    .task(id: statusMessage) {
+                        try? await Task.sleep(for: .seconds(2.5))
+                        withAnimation { self.statusMessage = nil }
+                    }
+            }
+        }
+        .animation(.spring(duration: 0.3), value: statusMessage)
+        .animation(.easeInOut(duration: 0.2), value: isPackingMode)
+    }
+
+    // MARK: - Packing mode
+
+    private func startPackingMode() {
+        packingFilter = .all
+        isPackingMode = true
+    }
+
+    private func exitPackingMode() {
+        isPackingMode = false
+        packingFilter = .all
+    }
+
+    /// Shown at the top of the list while packing: how far along you are.
+    private var packingHeader: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("\(packedCount) of \(items.count) packed")
+                    .font(.headline.monospacedDigit())
+                Spacer()
+                Text("\(Int(packingProgress * 100))%")
+                    .font(.subheadline.monospacedDigit().bold())
+                    .foregroundStyle(progressTint)
+            }
+
+            ProgressView(value: packingProgress)
+                .tint(progressTint)
+
+            Picker("Filter", selection: $packingFilter) {
+                ForEach(PackingFilter.allCases) { filter in
+                    Text(filter.label).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("pack_packing_filter")
+        }
+        .padding(14)
+        .background(progressTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityIdentifier("pack_packing_header")
+    }
+
+    /// Shown outside packing mode when a pass is already underway, so progress
+    /// isn't invisible until you re-enter the mode.
+    private var packingResumeSummary: some View {
+        Button { startPackingMode() } label: {
+            HStack(spacing: 12) {
+                Image(systemName: packedCount == items.count ? "checkmark.circle.fill" : "checklist")
+                    .font(.title3)
+                    .foregroundStyle(progressTint)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(packedCount == items.count ? "Pack is fully packed" : "Packing in progress")
+                        .font(.subheadline.weight(.medium))
+                    Text("\(packedCount) of \(items.count) items checked off")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+            .background(progressTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("pack_packing_resume")
+    }
+
+    private var packingToolbar: some View {
+        HStack {
+            Button("Reset", systemImage: "arrow.counterclockwise") {
+                packingStore.reset(packId: currentPack.id)
+            }
+            .disabled(packedCount == 0)
+            .accessibilityIdentifier("pack_packing_reset")
+
+            Spacer()
+
+            Button("Mark All Packed", systemImage: "checkmark.circle") {
+                for item in items {
+                    packingStore.setPacked(true, itemId: item.id, in: currentPack.id)
+                }
+            }
+            .disabled(packedCount == items.count)
+            .accessibilityIdentifier("pack_packing_mark_all")
+        }
+        .font(.callout)
+        .labelStyle(.titleAndIcon)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
     }
 
     private var deleteItemAlertTitle: String {
@@ -210,9 +478,12 @@ struct PackDetailView: View {
                 Rectangle().fill(Color.accentColor).frame(height: 2)
             }
         }
-        // Drop target: dragged item IDs get re-categorized here
+        // Drop target: dragged item IDs get re-categorized here. Disabled while
+        // packing — rows aren't draggable in that mode, and a stray drop
+        // shouldn't recategorize gear mid-checklist.
         .dropDestination(for: String.self) { itemIds, _ in
-            guard let itemId = itemIds.first,
+            guard !isPackingMode,
+                  let itemId = itemIds.first,
                   let item = items.first(where: { $0.id == itemId }),
                   item.category != category else { return false }
             Task {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -178,6 +178,14 @@ struct PackDetailView: View {
                 }
             } else {
                 ToolbarItem(placement: .primaryAction) {
+                    // A plain pull-down Menu: one tap opens it, every option is
+                    // visible. Deliberately *not* a `primaryAction` menu — that
+                    // variant hides the extra choices behind a long press, which
+                    // nothing on screen advertises, so most users would only ever
+                    // find "Add Manually". Expo shows the same three in a bottom
+                    // sheet; a pull-down menu is the iOS-idiomatic equivalent
+                    // (cf. AIPacksView, which swaps Expo's alert for
+                    // .confirmationDialog on the same reasoning).
                     Menu {
                         Button("Add Manually", systemImage: "square.and.pencil") {
                             showingAddItemSheet = true
@@ -195,14 +203,18 @@ struct PackDetailView: View {
                         .accessibilityIdentifier("pack_detail_add_from_catalog")
                     } label: {
                         Label("Add Item", systemImage: "plus")
-                    } primaryAction: {
-                        // Tapping (rather than long-pressing) keeps the old
-                        // one-tap manual-add behaviour that the UI tests and
-                        // muscle memory both rely on.
-                        showingAddItemSheet = true
                     }
                     .accessibilityIdentifier("pack_detail_add_item_button")
-                    .keyboardShortcut("i", modifiers: .command)
+                }
+                // ⌘I still goes straight to the manual form. Putting the
+                // shortcut on the Menu itself would just open the menu, which
+                // is a regression for keyboard and Mac users — so it lives on a
+                // hidden button instead.
+                ToolbarItem(placement: .automatic) {
+                    Button("Add Item Manually") { showingAddItemSheet = true }
+                        .keyboardShortcut("i", modifiers: .command)
+                        .hidden()
+                        .accessibilityHidden(true)
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Menu {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -292,8 +292,10 @@ struct PackDetailView: View {
             PackCatalogBrowserSheet(
                 packId: currentPack.id,
                 packsViewModel: viewModel,
-                onAdded: { count in
-                    statusMessage = "Added ^[\(count) item](inflect: true) from the catalog"
+                onAdded: { added, failed in
+                    statusMessage = addedStatusMessage(
+                        added: added, failed: failed, source: "the catalog"
+                    )
                 }
             )
         }
@@ -301,8 +303,10 @@ struct PackDetailView: View {
             PackItemsScanSheet(
                 packId: currentPack.id,
                 packsViewModel: viewModel,
-                onAdded: { count in
-                    statusMessage = "Added ^[\(count) item](inflect: true) from your photo"
+                onAdded: { added, failed in
+                    statusMessage = addedStatusMessage(
+                        added: added, failed: failed, source: "your photo"
+                    )
                 }
             )
         }
@@ -348,13 +352,33 @@ struct PackDetailView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                     .accessibilityIdentifier("pack_detail_status_toast")
                     .task(id: statusMessage) {
-                        try? await Task.sleep(for: .seconds(2.5))
-                        withAnimation { self.statusMessage = nil }
+                        let shown = statusMessage
+                        // `try?` would swallow the cancellation a replacing toast
+                        // causes, and the old task would then clear the new
+                        // message early. Bail on cancellation, and only clear
+                        // what this task actually put up.
+                        do {
+                            try await Task.sleep(for: .seconds(2.5))
+                        } catch {
+                            return
+                        }
+                        if self.statusMessage == shown {
+                            withAnimation { self.statusMessage = nil }
+                        }
                     }
             }
         }
         .animation(.spring(duration: 0.3), value: statusMessage)
         .animation(.easeInOut(duration: 0.2), value: isPackingMode)
+    }
+
+    /// Toast copy for a bulk add. A partial failure has to say so — reporting
+    /// only the successes leaves the user believing everything landed.
+    private func addedStatusMessage(added: Int, failed: Int, source: String) -> String {
+        if failed > 0 {
+            return "Added ^[\(added) item](inflect: true), ^[\(failed) item](inflect: true) couldn't be added"
+        }
+        return "Added ^[\(added) item](inflect: true) from \(source)"
     }
 
     // MARK: - Packing mode

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -177,7 +177,9 @@ struct PackDetailView: View {
                         .accessibilityIdentifier("pack_detail_done_packing")
                 }
             } else {
-                ToolbarItem(placement: .primaryAction) {
+                // One group rather than two separate ToolbarItems — these two
+                // controls belong together and a group states that directly.
+                ToolbarItemGroup(placement: .primaryAction) {
                     // A plain pull-down Menu: one tap opens it, every option is
                     // visible. Deliberately *not* a `primaryAction` menu — that
                     // variant hides the extra choices behind a long press, which
@@ -202,21 +204,14 @@ struct PackDetailView: View {
                         }
                         .accessibilityIdentifier("pack_detail_add_from_catalog")
                     } label: {
+                        // .iconOnly matches the More menu below, so the two
+                        // toolbar controls are declared consistently.
                         Label("Add Item", systemImage: "plus")
+                            .labelStyle(.iconOnly)
                     }
                     .accessibilityIdentifier("pack_detail_add_item_button")
-                }
-                // ⌘I still goes straight to the manual form. Putting the
-                // shortcut on the Menu itself would just open the menu, which
-                // is a regression for keyboard and Mac users — so it lives on a
-                // hidden button instead.
-                ToolbarItem(placement: .automatic) {
-                    Button("Add Item Manually") { showingAddItemSheet = true }
-                        .keyboardShortcut("i", modifiers: .command)
-                        .hidden()
-                        .accessibilityHidden(true)
-                }
-                ToolbarItem(placement: .primaryAction) {
+                    .accessibilityLabel("Add Item")
+
                     Menu {
                         Button("Ask AI", systemImage: "sparkles") {
                             showingAskAI = true
@@ -313,6 +308,18 @@ struct PackDetailView: View {
         }
         .navigationDestination(isPresented: $showingWeightAnalysis) {
             PackWeightAnalysisView(pack: currentPack)
+        }
+        // ⌘I opens the manual add form directly. It can't live on the Add Item
+        // toolbar Menu — the shortcut would merely open the menu — and a
+        // `.hidden()` toolbar button still reserves its layout footprint. A
+        // zero-size background button carries the shortcut without occupying
+        // space in the bar.
+        .background {
+            Button("Add Item Manually") { showingAddItemSheet = true }
+                .keyboardShortcut("i", modifiers: .command)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .accessibilityHidden(true)
         }
         .focusedSceneValue(\.sharePackAction, $triggerShare)
         .onChange(of: triggerShare) { _, new in

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemRow.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemRow.swift
@@ -11,8 +11,47 @@ struct PackItemRow: View {
     let onEdit: () -> Void
     let onDelete: () -> Void
     var onDetail: (() -> Void)? = nil
+    /// When non-nil the row is in packing mode: it shows a checkbox, and tapping
+    /// toggles packed rather than opening the item. Edit/delete/drag are
+    /// suppressed so a packing pass can't accidentally mutate the pack.
+    var packingState: PackingRowState? = nil
+
+    struct PackingRowState {
+        let isPacked: Bool
+        let onTogglePacked: () -> Void
+    }
 
     var body: some View {
+        if let packingState {
+            packingRow(packingState)
+        } else {
+            standardRow
+        }
+    }
+
+    private func packingRow(_ state: PackingRowState) -> some View {
+        Button(action: state.onTogglePacked) {
+            HStack(spacing: 12) {
+                Image(systemName: state.isPacked ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(state.isPacked ? Color.accentColor : Color.secondary)
+                    .accessibilityHidden(true)
+                // rowContent supplies its own horizontal padding; the checkbox
+                // sits inside that leading inset rather than adding to it.
+                rowContent
+                    .opacity(state.isPacked ? 0.45 : 1)
+            }
+            .padding(.leading, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("pack_item_row_\(item.id)")
+        .accessibilityLabel(item.name)
+        .accessibilityValue(state.isPacked ? "Packed" : "Not packed")
+        .accessibilityAddTraits(state.isPacked ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private var standardRow: some View {
         Button {
             onDetail?() ?? onEdit()
         } label: {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
@@ -79,7 +79,7 @@ final class PackItemsScanViewModel {
 struct PackItemsScanSheet: View {
     let packId: String
     let packsViewModel: PacksViewModel
-    var onAdded: ((Int) -> Void)?
+    var onAdded: ((_ added: Int, _ failed: Int) -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @Environment(AuthManager.self) private var authManager
@@ -238,7 +238,7 @@ struct PackItemsScanSheet: View {
             viewModel.phase = .failed("Couldn't add those items. Check your connection and try again.")
             return
         }
-        onAdded?(result.added)
+        onAdded?(result.added, result.failed)
         dismiss()
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
@@ -1,0 +1,314 @@
+import SwiftUI
+import PhotosUI
+
+/// Photo → detected gear → pack.
+///
+/// Mirrors Expo's `ItemsScanScreen`: pick a photo, the server's vision model
+/// names the gear it can see and matches each detection against the catalog,
+/// then you tick which ones to add. Everything is pre-selected because the
+/// common case is "yes, add all of these".
+@MainActor
+@Observable
+final class PackItemsScanViewModel {
+    enum Phase: Equatable {
+        case picking
+        case analyzing
+        case reviewing
+        case failed(String)
+    }
+
+    var phase: Phase = .picking
+    var detections: [DetectedItemWithMatches] = []
+    /// Indices into `detections` that the user wants to add.
+    var selectedIndices: Set<Int> = []
+    var isAdding = false
+
+    private let service: ImageDetectionService
+
+    init(service: ImageDetectionService = .shared) {
+        self.service = service
+    }
+
+    var selectedCount: Int { selectedIndices.count }
+    var canAdd: Bool { !selectedIndices.isEmpty && !isAdding }
+
+    func isSelected(_ index: Int) -> Bool { selectedIndices.contains(index) }
+
+    func toggle(_ index: Int) {
+        if selectedIndices.contains(index) {
+            selectedIndices.remove(index)
+        } else {
+            selectedIndices.insert(index)
+        }
+    }
+
+    func selectAll() { selectedIndices = Set(detections.indices) }
+    func selectNone() { selectedIndices.removeAll() }
+
+    func analyze(imageData: Data, userId: String) async {
+        phase = .analyzing
+        detections = []
+        selectedIndices = []
+        do {
+            let results = try await service.detectItems(imageData: imageData, userId: userId)
+            detections = results
+            // Pre-select everything, matching Expo's auto-select-all.
+            selectedIndices = Set(results.indices)
+            phase = .reviewing
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    func resolvedSelection() -> [DetectedItemWithMatches] {
+        detections.enumerated()
+            .filter { selectedIndices.contains($0.offset) }
+            .map(\.element)
+    }
+
+    /// Returns to the picker for a fresh photo. The analyzed image is deleted
+    /// from R2 server-side, so "try again" always means a new upload rather
+    /// than re-analyzing the previous key.
+    func reset() {
+        phase = .picking
+        detections = []
+        selectedIndices = []
+    }
+}
+
+struct PackItemsScanSheet: View {
+    let packId: String
+    let packsViewModel: PacksViewModel
+    var onAdded: ((Int) -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(AuthManager.self) private var authManager
+
+    @State private var viewModel = PackItemsScanViewModel()
+    @State private var photoItem: PhotosPickerItem?
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Scan Items")
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                            .accessibilityIdentifier("pack_scan_cancel")
+                    }
+                    if case .reviewing = viewModel.phase {
+                        ToolbarItem(placement: .primaryAction) {
+                            addButton
+                        }
+                    }
+                }
+                .onChange(of: photoItem) { _, item in
+                    guard let item else { return }
+                    Task {
+                        defer { photoItem = nil }
+                        guard let data = try? await item.loadTransferable(type: Data.self) else {
+                            viewModel.phase = .failed("Couldn't read that photo. Try another one.")
+                            return
+                        }
+                        guard let userId = authManager.currentUser?.id else {
+                            viewModel.phase = .failed("You need to be signed in to scan gear.")
+                            return
+                        }
+                        await viewModel.analyze(imageData: data, userId: userId)
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 520, minHeight: 600)
+        #endif
+    }
+
+    private var addButton: some View {
+        Button {
+            Task { await addSelected() }
+        } label: {
+            if viewModel.isAdding {
+                ProgressView().controlSize(.small)
+            } else {
+                Text("Add\(viewModel.selectedCount > 0 ? " (\(viewModel.selectedCount))" : "")").bold()
+            }
+        }
+        .disabled(!viewModel.canAdd)
+        .accessibilityIdentifier("pack_scan_confirm_add")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .picking:
+            pickerState
+        case .analyzing:
+            VStack(spacing: 14) {
+                ProgressView()
+                Text("Looking for gear in your photo…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("pack_scan_analyzing")
+        case .reviewing:
+            if viewModel.detections.isEmpty {
+                noResultsState
+            } else {
+                reviewList
+            }
+        case .failed(let message):
+            ErrorView(message, retry: { viewModel.reset() })
+        }
+    }
+
+    private var pickerState: some View {
+        UnavailableStateView(
+            title: "Scan Gear from a Photo",
+            subtitle: "Take or choose a photo of your gear laid out, and PackRat will identify the items and match them to the catalog.",
+            systemImage: "camera.viewfinder",
+            accessibilityIdentifier: "pack_scan_picker"
+        ) {
+            PhotosPicker(selection: $photoItem, matching: .images) {
+                Label("Choose Photo", systemImage: "photo.on.rectangle")
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("pack_scan_choose_photo")
+        }
+    }
+
+    private var noResultsState: some View {
+        UnavailableStateView(
+            title: "No Gear Detected",
+            subtitle: "Nothing recognisable turned up in that photo. Try a brighter shot with items spread out and not overlapping.",
+            systemImage: "questionmark.viewfinder",
+            accessibilityIdentifier: "pack_scan_no_results"
+        ) {
+            PhotosPicker(selection: $photoItem, matching: .images) {
+                Label("Try Another Photo", systemImage: "photo.on.rectangle")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var reviewList: some View {
+        List {
+            Section {
+                ForEach(Array(viewModel.detections.enumerated()), id: \.offset) { index, detection in
+                    DetectedItemRow(
+                        detection: detection,
+                        isSelected: viewModel.isSelected(index),
+                        onToggle: { viewModel.toggle(index) }
+                    )
+                }
+            } header: {
+                HStack {
+                    Text("^[\(viewModel.detections.count) item](inflect: true) found")
+                    Spacer()
+                    Button(viewModel.selectedCount == viewModel.detections.count ? "Select None" : "Select All") {
+                        if viewModel.selectedCount == viewModel.detections.count {
+                            viewModel.selectNone()
+                        } else {
+                            viewModel.selectAll()
+                        }
+                    }
+                    .font(.caption.bold())
+                    .textCase(nil)
+                    .accessibilityIdentifier("pack_scan_select_toggle")
+                }
+            } footer: {
+                Text("Items without a catalog match are added at 0 g — set their weight afterwards.")
+            }
+        }
+        .listStyle(.plain)
+        .accessibilityIdentifier("pack_scan_results_list")
+    }
+
+    private func addSelected() async {
+        let selections = viewModel.resolvedSelection()
+        guard !selections.isEmpty else { return }
+        viewModel.isAdding = true
+        let result = await packsViewModel.addDetectedItems(selections, to: packId)
+        viewModel.isAdding = false
+
+        if result.failed > 0 && result.added == 0 {
+            viewModel.phase = .failed("Couldn't add those items. Check your connection and try again.")
+            return
+        }
+        onAdded?(result.added)
+        dismiss()
+    }
+}
+
+// MARK: - Row
+
+private struct DetectedItemRow: View {
+    let detection: DetectedItemWithMatches
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    private var match: CatalogItem? { detection.primaryMatch }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .font(.title3)
+                .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(detection.detected.name)
+                    .font(.subheadline.weight(.medium))
+
+                HStack(spacing: 8) {
+                    if detection.detected.quantity > 1 {
+                        Text("×\(detection.detected.quantity)")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.secondary)
+                    }
+                    if !detection.detected.category.isEmpty {
+                        Text(detection.detected.category.capitalized)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    confidenceBadge
+                }
+
+                if let match {
+                    Label(
+                        "\(match.displayName)\(match.displayWeight.isEmpty ? "" : " · \(match.displayWeight)")",
+                        systemImage: "link"
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.tint)
+                    .lineLimit(1)
+                } else {
+                    Text("No catalog match — weight not set")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onToggle)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityIdentifier("pack_scan_item_\(detection.detected.name)")
+    }
+
+    @ViewBuilder
+    private var confidenceBadge: some View {
+        let confidence = detection.detected.confidence
+        if confidence > 0 {
+            Text("\(Int(confidence * 100))%")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(confidence >= 0.7 ? .green : .orange)
+        }
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackingModeStore.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackingModeStore.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Observation
+
+/// Device-local record of which items in a pack are checked off as packed.
+///
+/// There is deliberately no backend for this. `pack_items` has no `isPacked`
+/// column and no packing endpoint exists — Expo keeps the same state in a
+/// Legend-State observable persisted under the name `packingMode`
+/// (apps/expo/features/packs/store/packingMode.ts), local-only with no remote
+/// CRUD. This is the Swift counterpart, so a pack's packed state stays on the
+/// device that did the packing rather than syncing across a user's devices.
+///
+/// Shape matches Expo's: `[packId: [itemId: Bool]]`. Only `true` entries are
+/// stored; unchecking removes the key so the payload stays proportional to what
+/// is actually packed rather than to pack size.
+@Observable
+@MainActor
+final class PackingModeStore {
+    static let shared = PackingModeStore()
+
+    private static let defaultsKey = "packingMode"
+
+    private var state: [String: [String: Bool]] = [:]
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.state = Self.load(from: defaults)
+    }
+
+    // MARK: - Reads
+
+    /// The packed-item map for a pack. Absent keys mean "not packed".
+    func packedItems(in packId: String) -> [String: Bool] {
+        state[packId] ?? [:]
+    }
+
+    func isPacked(_ itemId: String, in packId: String) -> Bool {
+        state[packId]?[itemId] ?? false
+    }
+
+    /// Number of packed items in `packId` restricted to `itemIds`.
+    ///
+    /// Scoping to the pack's current items matters: an item deleted after being
+    /// checked off would otherwise keep inflating the count past the total and
+    /// push progress above 100%.
+    func packedCount(in packId: String, among itemIds: some Sequence<String>) -> Int {
+        let packed = state[packId] ?? [:]
+        return itemIds.reduce(into: 0) { count, id in
+            if packed[id] == true { count += 1 }
+        }
+    }
+
+    // MARK: - Writes
+
+    func setPacked(_ packed: Bool, itemId: String, in packId: String) {
+        var forPack = state[packId] ?? [:]
+        if packed {
+            forPack[itemId] = true
+        } else {
+            forPack.removeValue(forKey: itemId)
+        }
+        state[packId] = forPack.isEmpty ? nil : forPack
+        persist()
+    }
+
+    func toggle(itemId: String, in packId: String) {
+        setPacked(!isPacked(itemId, in: packId), itemId: itemId, in: packId)
+    }
+
+    /// Overwrites a pack's packed map wholesale — used by the sheet's Save,
+    /// which edits a working copy and commits it in one go.
+    func replace(packedItems: [String: Bool], in packId: String) {
+        let onlyPacked = packedItems.filter(\.value)
+        state[packId] = onlyPacked.isEmpty ? nil : onlyPacked
+        persist()
+    }
+
+    func reset(packId: String) {
+        state.removeValue(forKey: packId)
+        persist()
+    }
+
+    // MARK: - Persistence
+
+    private func persist() {
+        defaults.set(state, forKey: Self.defaultsKey)
+    }
+
+    private static func load(from defaults: UserDefaults) -> [String: [String: Bool]] {
+        // UserDefaults hands back `Any` for nested collections, so re-narrow
+        // rather than force-casting — a value written by an older build with a
+        // different shape should degrade to "nothing packed", not a crash.
+        guard let raw = defaults.dictionary(forKey: defaultsKey) else { return [:] }
+        return raw.reduce(into: [:]) { result, entry in
+            guard let inner = entry.value as? [String: Bool] else { return }
+            let onlyPacked = inner.filter(\.value)
+            if !onlyPacked.isEmpty { result[entry.key] = onlyPacked }
+        }
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -259,7 +259,8 @@ final class PacksViewModel {
         )
         let payload = PackItemMutationPayload(
             name: name, weight: weight, weightUnit: weightUnit, quantity: quantity,
-            category: category, consumable: consumable, worn: worn, notes: notes
+            category: category, consumable: consumable, worn: worn, notes: notes,
+            catalogItemId: catalogItemId, image: image
         )
         func queueCreate() {
             outbox.enqueue(
@@ -398,7 +399,12 @@ final class PacksViewModel {
                 category: category ?? current?.category,
                 consumable: consumable,
                 worn: worn,
-                notes: notes ?? current?.notes
+                notes: notes ?? current?.notes,
+                // Carry these over like every other field above. makeLocalItem
+                // defaults them to nil, so without this an edit to a
+                // catalog-added item erases its catalog link and image.
+                catalogItemId: current?.catalogItemId,
+                image: current?.image
             )
             let payload = PackItemMutationPayload(
                 name: name,
@@ -408,7 +414,9 @@ final class PacksViewModel {
                 category: category ?? current?.category,
                 consumable: consumable,
                 worn: worn,
-                notes: notes ?? current?.notes
+                notes: notes ?? current?.notes,
+                catalogItemId: current?.catalogItemId,
+                image: current?.image
             )
             func queueUpdate() {
                 outbox.enqueue(

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -250,10 +250,12 @@ final class PacksViewModel {
 
     func addItem(to packId: String, name: String, weight: Double?, weightUnit: String?,
                  quantity: Int?, category: String?, consumable: Bool, worn: Bool, notes: String?,
+                 catalogItemId: Int? = nil, image: String? = nil,
                  context: ModelContext? = nil) async throws {
         let localItem = makeLocalItem(
             packId: packId, name: name, weight: weight, weightUnit: weightUnit,
-            quantity: quantity, category: category, consumable: consumable, worn: worn, notes: notes
+            quantity: quantity, category: category, consumable: consumable, worn: worn, notes: notes,
+            catalogItemId: catalogItemId, image: image
         )
         let payload = PackItemMutationPayload(
             name: name, weight: weight, weightUnit: weightUnit, quantity: quantity,
@@ -275,7 +277,8 @@ final class PacksViewModel {
             do {
                 item = try await service.addItem(
                     to: packId, id: localItem.id, name: name, weight: weight, weightUnit: weightUnit,
-                    quantity: quantity, category: category, consumable: consumable, worn: worn, notes: notes
+                    quantity: quantity, category: category, consumable: consumable, worn: worn, notes: notes,
+                    catalogItemId: catalogItemId, image: image
                 )
             } catch {
                 item = localItem
@@ -291,6 +294,91 @@ final class PacksViewModel {
             packs[idx] = rebuildPack(packs[idx], items: items)
             upsertCachedPack(packs[idx], context: context)
         }
+    }
+
+    /// Adds several catalog items to a pack in one pass.
+    ///
+    /// Sequential rather than concurrent, matching Expo's `useBulkAddCatalogItems`:
+    /// each add mutates the same pack row server-side, so parallel writes race on
+    /// the pack's recomputed weights. Returns the number added — a partial
+    /// failure still keeps whatever succeeded rather than rolling back, so the
+    /// caller can report "added 3 of 5".
+    @discardableResult
+    func addCatalogItems(
+        _ selections: [(item: CatalogItem, quantity: Int)],
+        to packId: String,
+        context: ModelContext? = nil
+    ) async -> (added: Int, failed: Int) {
+        var added = 0
+        var failed = 0
+        for selection in selections {
+            let item = selection.item
+            do {
+                try await addItem(
+                    to: packId,
+                    name: item.name,
+                    weight: item.weight,
+                    // Catalog weight/unit are both optional — an item with no
+                    // published weight is added at 0 g for the user to fill in
+                    // rather than being skipped.
+                    weightUnit: item.weightUnit?.rawValue,
+                    quantity: selection.quantity,
+                    // Expo sends the item's own category or '' and lets the
+                    // server bucket it; keep the first catalog facet instead so
+                    // the pack's category grouping stays meaningful.
+                    category: item.categories?.first,
+                    consumable: false,
+                    worn: false,
+                    notes: nil,
+                    catalogItemId: item.id,
+                    image: item.primaryImage,
+                    context: context
+                )
+                added += 1
+            } catch {
+                failed += 1
+            }
+        }
+        return (added, failed)
+    }
+
+    /// Adds vision-detected items to a pack.
+    ///
+    /// Weight comes from the best catalog match when there is one — the vision
+    /// model returns a name/category/quantity but never a weight, so an
+    /// unmatched detection lands at 0 g for the user to fill in.
+    @discardableResult
+    func addDetectedItems(
+        _ detections: [DetectedItemWithMatches],
+        to packId: String,
+        context: ModelContext? = nil
+    ) async -> (added: Int, failed: Int) {
+        var added = 0
+        var failed = 0
+        for detection in detections {
+            let detected = detection.detected
+            let match = detection.primaryMatch
+            do {
+                try await addItem(
+                    to: packId,
+                    name: detected.name,
+                    weight: match?.weight,
+                    weightUnit: match?.weightUnit?.rawValue,
+                    quantity: detected.quantity,
+                    category: detected.category.isEmpty ? match?.categories?.first : detected.category,
+                    consumable: detected.consumable,
+                    worn: detected.worn,
+                    notes: detected.notes,
+                    catalogItemId: match?.id,
+                    image: match?.primaryImage,
+                    context: context
+                )
+                added += 1
+            } catch {
+                failed += 1
+            }
+        }
+        return (added, failed)
     }
 
     func updateItem(_ itemId: String, in packId: String, name: String, weight: Double?,
@@ -410,7 +498,9 @@ final class PacksViewModel {
         category: String?,
         consumable: Bool,
         worn: Bool,
-        notes: String?
+        notes: String?,
+        catalogItemId: Int? = nil,
+        image: String? = nil
     ) -> PackItem {
         let now = Date.iso8601Now()
         return PackItem(
@@ -424,9 +514,9 @@ final class PacksViewModel {
             category: category,
             consumable: consumable,
             worn: worn,
-            image: nil,
+            image: image,
             notes: notes,
-            catalogItemId: nil,
+            catalogItemId: catalogItemId,
             userId: nil,
             deleted: false,
             isAIGenerated: false,

--- a/apps/swift/Sources/PackRat/Models/Catalog.swift
+++ b/apps/swift/Sources/PackRat/Models/Catalog.swift
@@ -55,3 +55,35 @@ struct CatalogSearchResponse: Decodable, Sendable {
 private extension String {
     var nilIfEmpty: String? { isEmpty ? nil : self }
 }
+
+// MARK: - Category display names
+
+extension String {
+    /// Title-cases a raw catalog category for display.
+    ///
+    /// Catalog categories are scraped and arrive with HTML entities intact
+    /// ("hike &amp; camp"). Plain `.capitalized` would render that as
+    /// "Hike &Amp; Camp", so decode the handful of entities that actually occur
+    /// before capitalizing. Full HTML parsing via NSAttributedString is not an
+    /// option here — it must run on the main thread and is far too slow for a
+    /// list of chips.
+    var catalogCategoryDisplayName: String {
+        let decoded = replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+        // Capitalize per word so "&" and other separators survive intact.
+        return decoded
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .map { word in
+                // Leave symbols and already-uppercase acronyms alone.
+                word.contains(where: \.isLetter) && word != word.uppercased()
+                    ? word.capitalized
+                    : String(word)
+            }
+            .joined(separator: " ")
+    }
+}

--- a/apps/swift/Sources/PackRat/Models/Chat.swift
+++ b/apps/swift/Sources/PackRat/Models/Chat.swift
@@ -38,10 +38,53 @@ struct ChatMessage: Identifiable, Sendable {
 struct ChatRequest: Encodable {
     let messages: [ChatUIMessage]
     let date: String
+    let contextType: String?
+    let packId: String?
+    let itemId: String?
 
-    init(messages: [ChatMessage]) {
+    init(messages: [ChatMessage], context: ChatContext = .general) {
         self.messages = messages.map { ChatUIMessage(from: $0) }
         self.date = ISO8601DateFormatter().string(from: Date())
+        self.contextType = context.contextType
+        self.packId = context.packId
+        self.itemId = context.itemId
+    }
+}
+
+/// What the conversation is scoped to.
+///
+/// The server reads `contextType` + `packId` to decide whether to append the
+/// "helping with a pack with ID: …, use the getPackDetails tool" instruction to
+/// the system prompt (packages/api/src/routes/chat.ts). Note the chat route's
+/// body schema is `z.any()` — there is no server-side validation, so a wrong or
+/// missing field silently degrades to a generic chat rather than erroring.
+/// Keep this field set aligned with Expo's (apps/expo/app/(app)/ai-chat.tsx).
+enum ChatContext: Equatable, Sendable {
+    case general
+    case pack(id: String, name: String)
+    case item(id: String)
+
+    var contextType: String {
+        switch self {
+        case .general: return "general"
+        case .pack:    return "pack"
+        case .item:    return "item"
+        }
+    }
+
+    var packId: String? {
+        if case .pack(let id, _) = self { return id }
+        return nil
+    }
+
+    var itemId: String? {
+        if case .item(let id) = self { return id }
+        return nil
+    }
+
+    var packName: String? {
+        if case .pack(_, let name) = self { return name }
+        return nil
     }
 }
 

--- a/apps/swift/Sources/PackRat/Models/ImageDetection.swift
+++ b/apps/swift/Sources/PackRat/Models/ImageDetection.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// A gear item the vision model spotted in an uploaded photo.
+/// Mirrors `DetectedItemSchema` in packages/schemas/src/imageDetection.ts.
+struct DetectedItem: Codable, Sendable {
+    let name: String
+    let description: String
+    let quantity: Int
+    let category: String
+    let consumable: Bool
+    let worn: Bool
+    let notes: String?
+    let confidence: Double
+
+    enum CodingKeys: String, CodingKey {
+        case name, description, quantity, category, consumable, worn, notes, confidence
+    }
+
+    init(
+        name: String,
+        description: String = "",
+        quantity: Int = 1,
+        category: String = "",
+        consumable: Bool = false,
+        worn: Bool = false,
+        notes: String? = nil,
+        confidence: Double = 0
+    ) {
+        self.name = name
+        self.description = description
+        self.quantity = quantity
+        self.category = category
+        self.consumable = consumable
+        self.worn = worn
+        self.notes = notes
+        self.confidence = confidence
+    }
+
+    // Only `name` is truly required. Everything else carries a Zod default or is
+    // nullable server-side, so a missing field should fall back rather than fail
+    // the whole array's decode and lose every other detection in the photo.
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        name = try c.decode(String.self, forKey: .name)
+        description = (try? c.decode(String.self, forKey: .description)) ?? ""
+        quantity = (try? c.decode(Int.self, forKey: .quantity)) ?? 1
+        category = (try? c.decode(String.self, forKey: .category)) ?? ""
+        consumable = (try? c.decode(Bool.self, forKey: .consumable)) ?? false
+        worn = (try? c.decode(Bool.self, forKey: .worn)) ?? false
+        notes = try? c.decodeIfPresent(String.self, forKey: .notes)
+        confidence = (try? c.decode(Double.self, forKey: .confidence)) ?? 0
+    }
+}
+
+/// One detection plus the catalog items it was matched against.
+/// Mirrors `DetectedItemWithMatchesSchema`. The analyze route returns a bare
+/// array of these — not an object wrapper.
+struct DetectedItemWithMatches: Codable, Sendable, Identifiable {
+    let detected: DetectedItem
+    let catalogMatches: [CatalogItem]
+
+    /// Detections have no server-assigned id; index-independent identity comes
+    /// from the name, which is unique enough within a single photo's results.
+    var id: String { detected.name }
+
+    /// The best catalog match, when the matcher found one. Used to prefill
+    /// weight — the vision model does not estimate weight itself.
+    var primaryMatch: CatalogItem? { catalogMatches.first }
+}
+
+struct AnalyzeImageRequest: Encodable, Sendable {
+    let image: String
+    let matchLimit: Int?
+}

--- a/apps/swift/Sources/PackRat/Models/ImageDetection.swift
+++ b/apps/swift/Sources/PackRat/Models/ImageDetection.swift
@@ -55,13 +55,13 @@ struct DetectedItem: Codable, Sendable {
 /// One detection plus the catalog items it was matched against.
 /// Mirrors `DetectedItemWithMatchesSchema`. The analyze route returns a bare
 /// array of these — not an object wrapper.
-struct DetectedItemWithMatches: Codable, Sendable, Identifiable {
+/// Deliberately not `Identifiable`: detections carry no server id, and a photo
+/// can legitimately contain two of the same thing ("Trekking Pole" twice), so any
+/// id derived from the name would collide and make SwiftUI drop a row. The scan
+/// list is indexed by position instead.
+struct DetectedItemWithMatches: Codable, Sendable {
     let detected: DetectedItem
     let catalogMatches: [CatalogItem]
-
-    /// Detections have no server-assigned id; index-independent identity comes
-    /// from the name, which is unique enough within a single photo's results.
-    var id: String { detected.name }
 
     /// The best catalog match, when the matcher found one. Used to prefill
     /// weight — the vision model does not estimate weight itself.

--- a/apps/swift/Sources/PackRat/Models/Pack.swift
+++ b/apps/swift/Sources/PackRat/Models/Pack.swift
@@ -168,6 +168,38 @@ struct CreatePackItemRequest: Encodable {
     let consumable: Bool?
     let worn: Bool?
     let notes: String?
+    /// Links the pack item back to the catalog product it came from. Nil for
+    /// hand-entered items. Without it the server can't relate a packed item to
+    /// its catalog entry (prices, similar-item lookups).
+    let catalogItemId: Int?
+    /// R2 object key or absolute URL for the item's image.
+    let image: String?
+
+    init(
+        id: String,
+        name: String,
+        weight: Double? = nil,
+        weightUnit: String? = nil,
+        quantity: Int? = nil,
+        category: String? = nil,
+        consumable: Bool? = nil,
+        worn: Bool? = nil,
+        notes: String? = nil,
+        catalogItemId: Int? = nil,
+        image: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.weight = weight
+        self.weightUnit = weightUnit
+        self.quantity = quantity
+        self.category = category
+        self.consumable = consumable
+        self.worn = worn
+        self.notes = notes
+        self.catalogItemId = catalogItemId
+        self.image = image
+    }
 }
 
 struct UpdatePackItemRequest: Encodable {

--- a/apps/swift/Sources/PackRat/Persistence/PendingMutation.swift
+++ b/apps/swift/Sources/PackRat/Persistence/PendingMutation.swift
@@ -88,6 +88,38 @@ struct PackItemMutationPayload: Codable, Sendable {
     var consumable: Bool
     var worn: Bool
     var notes: String?
+    /// Kept on the payload so an item added from the catalog while offline still
+    /// reaches the server with its catalog link and image once the outbox
+    /// replays. Nil for hand-entered items.
+    ///
+    /// Optional with a default so payloads queued by an earlier build, which had
+    /// neither field, still decode instead of stranding in the outbox.
+    var catalogItemId: Int?
+    var image: String?
+
+    init(
+        name: String,
+        weight: Double? = nil,
+        weightUnit: String? = nil,
+        quantity: Int? = nil,
+        category: String? = nil,
+        consumable: Bool,
+        worn: Bool,
+        notes: String? = nil,
+        catalogItemId: Int? = nil,
+        image: String? = nil
+    ) {
+        self.name = name
+        self.weight = weight
+        self.weightUnit = weightUnit
+        self.quantity = quantity
+        self.category = category
+        self.consumable = consumable
+        self.worn = worn
+        self.notes = notes
+        self.catalogItemId = catalogItemId
+        self.image = image
+    }
 }
 
 /// Field set for a queued trip create/update. Dates are ISO-8601 strings so the

--- a/apps/swift/Sources/PackRat/Services/CatalogService.swift
+++ b/apps/swift/Sources/PackRat/Services/CatalogService.swift
@@ -1,6 +1,14 @@
 import Foundation
 
-final class CatalogService: Sendable {
+/// The catalog reads the pack-first browse sheet depends on. Exists so that
+/// sheet's view model can be driven by a stub in tests instead of reaching
+/// `CatalogService.shared` and issuing real requests.
+protocol CatalogBrowsing: Sendable {
+    func categories(limit: Int) async throws -> [String]
+    func browse(query: String?, category: String?, page: Int, limit: Int) async throws -> [CatalogItem]
+}
+
+final class CatalogService: CatalogBrowsing, Sendable {
     static let shared = CatalogService()
     private let api: APIClient
 

--- a/apps/swift/Sources/PackRat/Services/CatalogService.swift
+++ b/apps/swift/Sources/PackRat/Services/CatalogService.swift
@@ -16,8 +16,36 @@ final class CatalogService: Sendable {
         return try decodeCatalogItems(from: data)
     }
 
+    /// Embedding-backed search. The route is `/api/catalog/vector-search` —
+    /// there is no `/api/catalog/search` on the backend
+    /// (packages/api/src/routes/catalog/index.ts), which is what this used to
+    /// call, so every semantic search 404'd.
     func semanticSearch(query: String, limit: Int = 10) async throws -> [CatalogItem] {
         let endpoint = Endpoint(.get, "/api/catalog/vector-search", query: ["q": query, "limit": "\(limit)"])
+        let data = try await api.sendData(endpoint)
+        return try decodeCatalogItems(from: data)
+    }
+
+    /// Category facets for the browse sheet's filter chips. The route returns a
+    /// bare JSON array of strings (`CatalogCategoriesResponseSchema`), ordered
+    /// by item count descending.
+    func categories(limit: Int = 20) async throws -> [String] {
+        let endpoint = Endpoint(.get, "/api/catalog/categories", query: ["limit": "\(limit)"])
+        return try await api.send(endpoint, as: [String].self)
+    }
+
+    /// Paged browse/search. `category` is sent only when set so the unfiltered
+    /// browse case doesn't narrow to an empty facet.
+    func browse(
+        query: String?,
+        category: String?,
+        page: Int = 1,
+        limit: Int = 20
+    ) async throws -> [CatalogItem] {
+        var params = ["page": "\(page)", "limit": "\(limit)"]
+        if let query, !query.isEmpty { params["q"] = query }
+        if let category, !category.isEmpty { params["category"] = category }
+        let endpoint = Endpoint(.get, "/api/catalog", query: params)
         let data = try await api.sendData(endpoint)
         return try decodeCatalogItems(from: data)
     }

--- a/apps/swift/Sources/PackRat/Services/ChatService.swift
+++ b/apps/swift/Sources/PackRat/Services/ChatService.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 protocol ChatServicing: Sendable {
-    func sendMessage(messages: [ChatMessage]) async -> AsyncThrowingStream<String, Error>
+    func sendMessage(messages: [ChatMessage], context: ChatContext) async -> AsyncThrowingStream<String, Error>
+}
+
+extension ChatServicing {
+    func sendMessage(messages: [ChatMessage]) async -> AsyncThrowingStream<String, Error> {
+        await sendMessage(messages: messages, context: .general)
+    }
 }
 
 final class ChatService: ChatServicing {
@@ -10,8 +16,8 @@ final class ChatService: ChatServicing {
 
     init(api: APIClient = .shared) { self.api = api }
 
-    func sendMessage(messages: [ChatMessage]) async -> AsyncThrowingStream<String, Error> {
-        let endpoint = Endpoint(.post, "/api/chat", body: ChatRequest(messages: messages))
+    func sendMessage(messages: [ChatMessage], context: ChatContext = .general) async -> AsyncThrowingStream<String, Error> {
+        let endpoint = Endpoint(.post, "/api/chat", body: ChatRequest(messages: messages, context: context))
         return await api.stream(endpoint)
     }
 }

--- a/apps/swift/Sources/PackRat/Services/ImageDetectionService.swift
+++ b/apps/swift/Sources/PackRat/Services/ImageDetectionService.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Detects gear items in a photo and matches them against the catalog.
+///
+/// Three-step flow, matching Expo's
+/// (apps/expo/features/packs/hooks/useImageDetection.ts):
+///   1. presign + PUT the image to R2 (`UploadService`)
+///   2. POST the resulting object key to `/api/packs/analyze-image`
+///   3. the server analyzes it and **deletes the R2 object**
+///
+/// Step 3 makes analysis one-shot: re-analyzing the same photo needs a fresh
+/// upload, so callers must not retry step 2 with a spent key.
+final class ImageDetectionService: Sendable {
+    static let shared = ImageDetectionService()
+
+    private let api: APIClient
+    private let uploader: UploadService
+
+    init(api: APIClient = .shared, uploader: UploadService = .shared) {
+        self.api = api
+        self.uploader = uploader
+    }
+
+    /// Analyzes an already-uploaded R2 object key.
+    ///
+    /// `objectKey` must start with `{userId}-` or the route returns 403 — the
+    /// server checks the prefix to stop one user analyzing another's upload.
+    /// `UploadService` builds keys that way already.
+    func analyze(objectKey: String, matchLimit: Int = 1) async throws -> [DetectedItemWithMatches] {
+        let endpoint = Endpoint(
+            .post,
+            "/api/packs/analyze-image",
+            body: AnalyzeImageRequest(image: objectKey, matchLimit: matchLimit)
+        )
+        return try await api.send(endpoint, as: [DetectedItemWithMatches].self)
+    }
+
+    /// Uploads raw JPEG data, then analyzes it.
+    func detectItems(
+        imageData: Data,
+        userId: String,
+        matchLimit: Int = 1
+    ) async throws -> [DetectedItemWithMatches] {
+        let fileName = "\(userId)-\(UUID().uuidString).jpg"
+        let objectKey = try await uploader.upload(
+            data: imageData,
+            fileName: fileName,
+            mimeType: "image/jpeg"
+        )
+        return try await analyze(objectKey: objectKey, matchLimit: matchLimit)
+    }
+}

--- a/apps/swift/Sources/PackRat/Services/OutboxService.swift
+++ b/apps/swift/Sources/PackRat/Services/OutboxService.swift
@@ -217,7 +217,9 @@ final class OutboxService {
                     category: payload.category,
                     consumable: payload.consumable,
                     worn: payload.worn,
-                    notes: payload.notes
+                    notes: payload.notes,
+                    catalogItemId: payload.catalogItemId,
+                    image: payload.image
                 )
             case (.packItem, .update):
                 let payload: PackItemMutationPayload = try decode(mutation.payload)

--- a/apps/swift/Sources/PackRat/Services/PackService.swift
+++ b/apps/swift/Sources/PackRat/Services/PackService.swift
@@ -48,7 +48,7 @@ final class PackService: Sendable {
         try await api.sendDiscarding(endpoint)
     }
 
-    func addItem(to packId: String, id: String = UUID().uuidString.lowercased(), name: String, weight: Double? = nil, weightUnit: String? = nil, quantity: Int? = nil, category: String? = nil, consumable: Bool? = nil, worn: Bool? = nil, notes: String? = nil) async throws -> PackItem {
+    func addItem(to packId: String, id: String = UUID().uuidString.lowercased(), name: String, weight: Double? = nil, weightUnit: String? = nil, quantity: Int? = nil, category: String? = nil, consumable: Bool? = nil, worn: Bool? = nil, notes: String? = nil, catalogItemId: Int? = nil, image: String? = nil) async throws -> PackItem {
         let body = CreatePackItemRequest(
             id: id,
             name: name,
@@ -58,7 +58,9 @@ final class PackService: Sendable {
             category: category,
             consumable: consumable,
             worn: worn,
-            notes: notes
+            notes: notes,
+            catalogItemId: catalogItemId,
+            image: image
         )
         let endpoint = Endpoint(.post, "/api/packs/\(packId)/items", body: body)
         return try await api.send(endpoint)

--- a/apps/swift/Tests/PackRatTests/ChatViewModelTests.swift
+++ b/apps/swift/Tests/PackRatTests/ChatViewModelTests.swift
@@ -52,17 +52,22 @@ private enum MockChatError: LocalizedError {
     }
 }
 
-private struct MockChatService: ChatServicing {
+private final class MockChatService: ChatServicing, @unchecked Sendable {
     let chunks: [String]
     let error: (any Error)?
+
+    /// The context of the most recent `sendMessage` call, so tests can assert
+    /// the view model forwards its pack scoping to the transport.
+    private(set) var lastContext: ChatContext?
 
     init(chunks: [String], error: (any Error)? = nil) {
         self.chunks = chunks
         self.error = error
     }
 
-    func sendMessage(messages _: [ChatMessage]) async -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { continuation in
+    func sendMessage(messages _: [ChatMessage], context: ChatContext) async -> AsyncThrowingStream<String, Error> {
+        lastContext = context
+        return AsyncThrowingStream { continuation in
             for chunk in chunks {
                 continuation.yield(chunk)
             }

--- a/apps/swift/Tests/PackRatTests/PackParityTests.swift
+++ b/apps/swift/Tests/PackRatTests/PackParityTests.swift
@@ -98,6 +98,30 @@ struct ChatViewModelPackScopingTests {
         #expect(viewModel.messages.first?.content.contains("PackRat AI assistant") == true)
     }
 
+    /// The view model holding a `ChatContext` is not enough — it has to reach the
+    /// transport, or the request goes out unscoped and the server silently
+    /// answers as a general chat.
+    @Test("the pack context is forwarded to the transport")
+    func packContextReachesTheService() async throws {
+        let service = RecordingChatService()
+        let viewModel = ChatViewModel(
+            service: service,
+            context: .pack(id: "pack-7", name: "Ridge Line")
+        )
+
+        viewModel.inputText = "What's missing?"
+        viewModel.sendMessage()
+
+        // sendMessage spawns a Task; poll briefly rather than sleeping a fixed
+        // amount, so the test is neither flaky nor slower than it needs to be.
+        var attempts = 0
+        while service.lastContext == nil, attempts < 200 {
+            try await Task.sleep(for: .milliseconds(5))
+            attempts += 1
+        }
+        #expect(service.lastContext == .pack(id: "pack-7", name: "Ridge Line"))
+    }
+
     @Test("clearHistory keeps the pack greeting")
     func clearHistoryKeepsPackGreeting() {
         let viewModel = ChatViewModel(
@@ -116,94 +140,121 @@ private struct StubChatService: ChatServicing {
     }
 }
 
+/// Captures the context the view model sends, so a test can assert the pack
+/// scoping actually reaches the transport.
+private final class RecordingChatService: ChatServicing, @unchecked Sendable {
+    private(set) var lastContext: ChatContext?
+
+    func sendMessage(messages _: [ChatMessage], context: ChatContext) async -> AsyncThrowingStream<String, Error> {
+        lastContext = context
+        return AsyncThrowingStream { $0.finish() }
+    }
+}
+
 // MARK: - Packing mode
 
 @Suite("PackingModeStore")
 @MainActor
 struct PackingModeStoreTests {
     /// Each test gets its own suite-name UserDefaults so persistence is
-    /// exercised for real without leaking between tests or into the app domain.
-    private func makeStore() throws -> (PackingModeStore, UserDefaults) {
-        let defaults = try #require(UserDefaults(suiteName: "packing-test-\(UUID().uuidString)"))
-        return (PackingModeStore(defaults: defaults), defaults)
+    /// Runs `body` against a store backed by a throwaway suite, so persistence is
+    /// exercised for real without leaking between tests or into the app domain,
+    /// then removes the suite. Suites persist to disk, so leaving them behind
+    /// litters the test host with a plist per test per run.
+    private func withStore(
+        _ body: (PackingModeStore, UserDefaults) throws -> Void
+    ) throws {
+        let name = "packing-test-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        try body(PackingModeStore(defaults: defaults), defaults)
     }
 
     @Test("items start unpacked")
     func startsUnpacked() throws {
-        let (store, _) = try makeStore()
-        #expect(store.isPacked("i1", in: "p1") == false)
-        #expect(store.packedItems(in: "p1").isEmpty)
+        try withStore { store, _ in
+            #expect(store.isPacked("i1", in: "p1") == false)
+            #expect(store.packedItems(in: "p1").isEmpty)
+        }
     }
 
     @Test("toggle marks packed then unpacked")
     func toggleRoundTrip() throws {
-        let (store, _) = try makeStore()
-        store.toggle(itemId: "i1", in: "p1")
-        #expect(store.isPacked("i1", in: "p1"))
-        store.toggle(itemId: "i1", in: "p1")
-        #expect(store.isPacked("i1", in: "p1") == false)
+        try withStore { store, _ in
+            store.toggle(itemId: "i1", in: "p1")
+            #expect(store.isPacked("i1", in: "p1"))
+            store.toggle(itemId: "i1", in: "p1")
+            #expect(store.isPacked("i1", in: "p1") == false)
+        }
     }
 
     @Test("unpacking removes the key rather than storing false")
     func unpackingRemovesKey() throws {
-        let (store, _) = try makeStore()
-        store.setPacked(true, itemId: "i1", in: "p1")
-        store.setPacked(false, itemId: "i1", in: "p1")
-        #expect(store.packedItems(in: "p1").isEmpty)
+        try withStore { store, _ in
+            store.setPacked(true, itemId: "i1", in: "p1")
+            store.setPacked(false, itemId: "i1", in: "p1")
+            #expect(store.packedItems(in: "p1").isEmpty)
+        }
     }
 
     @Test("packs are scoped independently")
     func packsAreIndependent() throws {
-        let (store, _) = try makeStore()
-        store.setPacked(true, itemId: "shared-item", in: "p1")
-        #expect(store.isPacked("shared-item", in: "p1"))
-        #expect(store.isPacked("shared-item", in: "p2") == false)
+        try withStore { store, _ in
+            store.setPacked(true, itemId: "shared-item", in: "p1")
+            #expect(store.isPacked("shared-item", in: "p1"))
+            #expect(store.isPacked("shared-item", in: "p2") == false)
+        }
     }
 
     @Test("reset clears only the target pack")
     func resetIsScoped() throws {
-        let (store, _) = try makeStore()
-        store.setPacked(true, itemId: "i1", in: "p1")
-        store.setPacked(true, itemId: "i2", in: "p2")
-        store.reset(packId: "p1")
-        #expect(store.packedItems(in: "p1").isEmpty)
-        #expect(store.isPacked("i2", in: "p2"))
+        try withStore { store, _ in
+            store.setPacked(true, itemId: "i1", in: "p1")
+            store.setPacked(true, itemId: "i2", in: "p2")
+            store.reset(packId: "p1")
+            #expect(store.packedItems(in: "p1").isEmpty)
+            #expect(store.isPacked("i2", in: "p2"))
+        }
     }
 
     @Test("replace overwrites and drops false entries")
     func replaceDropsFalse() throws {
-        let (store, _) = try makeStore()
-        store.setPacked(true, itemId: "stale", in: "p1")
-        store.replace(packedItems: ["i1": true, "i2": false], in: "p1")
-        #expect(store.packedItems(in: "p1") == ["i1": true])
+        try withStore { store, _ in
+            store.setPacked(true, itemId: "stale", in: "p1")
+            store.replace(packedItems: ["i1": true, "i2": false], in: "p1")
+            #expect(store.packedItems(in: "p1") == ["i1": true])
+        }
     }
 
     /// Progress is computed against the pack's *current* items. An item checked
     /// off and later deleted must not keep counting, or progress exceeds 100%.
     @Test("packedCount ignores ids no longer in the pack")
     func packedCountIgnoresDeletedItems() throws {
-        let (store, _) = try makeStore()
-        store.setPacked(true, itemId: "i1", in: "p1")
-        store.setPacked(true, itemId: "deleted-item", in: "p1")
-        #expect(store.packedCount(in: "p1", among: ["i1", "i2"]) == 1)
+        try withStore { store, _ in
+            store.setPacked(true, itemId: "i1", in: "p1")
+            store.setPacked(true, itemId: "deleted-item", in: "p1")
+            #expect(store.packedCount(in: "p1", among: ["i1", "i2"]) == 1)
+        }
     }
 
     @Test("state survives a new store over the same defaults")
     func statePersists() throws {
-        let (store, defaults) = try makeStore()
-        store.setPacked(true, itemId: "i1", in: "p1")
+        try withStore { store, defaults in
+            store.setPacked(true, itemId: "i1", in: "p1")
 
-        let reloaded = PackingModeStore(defaults: defaults)
-        #expect(reloaded.isPacked("i1", in: "p1"))
+            let reloaded = PackingModeStore(defaults: defaults)
+            #expect(reloaded.isPacked("i1", in: "p1"))
+        }
     }
 
     @Test("a malformed persisted payload degrades to empty, not a crash")
     func malformedPayloadIsIgnored() throws {
-        let defaults = try #require(UserDefaults(suiteName: "packing-test-\(UUID().uuidString)"))
-        defaults.set(["p1": "not-a-dictionary"], forKey: "packingMode")
+        try withStore { _, defaults in
+            defaults.set(["p1": "not-a-dictionary"], forKey: "packingMode")
 
-        let store = PackingModeStore(defaults: defaults)
-        #expect(store.packedItems(in: "p1").isEmpty)
+            let store = PackingModeStore(defaults: defaults)
+            #expect(store.packedItems(in: "p1").isEmpty)
+        }
     }
 }
 
@@ -298,7 +349,7 @@ struct PackCatalogBrowserSearchStateTests {
     /// typing with no feedback at all.
     @Test("typing marks the view as searching immediately")
     func typingSetsSearchingBeforeDebounce() {
-        let viewModel = PackCatalogBrowserViewModel()
+        let viewModel = PackCatalogBrowserViewModel(service: StubCatalogService())
         #expect(viewModel.isSearching == false)
 
         viewModel.searchText = "tent"
@@ -310,11 +361,92 @@ struct PackCatalogBrowserSearchStateTests {
 
     @Test("changing category also shows the loader")
     func categoryChangeSetsSearching() {
-        let viewModel = PackCatalogBrowserViewModel()
+        let viewModel = PackCatalogBrowserViewModel(service: StubCatalogService())
         viewModel.selectCategory("shelter")
         #expect(viewModel.isSearching)
         #expect(viewModel.selectedCategory == "shelter")
     }
+
+    /// Selecting an item, then searching for something else, must not lose the
+    /// earlier pick — resolving against the visible list alone would drop it.
+    @Test("selections survive the result list being replaced")
+    func selectionSurvivesNewSearch() async {
+        let first = StubCatalogService.item(id: 1, name: "Tent")
+        let second = StubCatalogService.item(id: 2, name: "Stove")
+        let service = StubCatalogService(pages: [[first], [second]])
+        let viewModel = PackCatalogBrowserViewModel(service: service)
+
+        await viewModel.load(reset: true)
+        viewModel.toggleSelection(first)
+        #expect(viewModel.selectedCount == 1)
+
+        // Second load replaces `items` entirely, as a new query would.
+        await viewModel.load(reset: true)
+        viewModel.toggleSelection(second)
+
+        let resolved = viewModel.resolvedSelection()
+        #expect(resolved.count == 2)
+        #expect(Set(resolved.map(\.item.id)) == [1, 2])
+    }
+
+    /// A failed append used to consume the page number, so the next scroll asked
+    /// for page 3 and page 2's results were never fetched.
+    @Test("a failed page load gives the page number back")
+    func failedPageIsRetried() async {
+        // A full first page, so `hasMore` stays true and paging can continue.
+        let firstPage = (1...20).map { StubCatalogService.item(id: $0, name: "Item \($0)") }
+        let service = StubCatalogService(pages: [firstPage])
+        let viewModel = PackCatalogBrowserViewModel(service: service)
+        await viewModel.load(reset: true)
+
+        let last = try? #require(firstPage.last)
+        guard let last else { return }
+
+        service.shouldFail = true
+        await viewModel.loadMoreIfNeeded(currentItem: last)
+
+        service.shouldFail = false
+        service.requestedPages.removeAll()
+        await viewModel.loadMoreIfNeeded(currentItem: last)
+
+        // Page 2 is asked for again rather than being skipped for page 3.
+        #expect(service.requestedPages == [2])
+    }
+}
+
+/// In-memory stand-in for `CatalogService`, so these tests never touch the
+/// network. Reaching `CatalogService.shared` here made real requests to whatever
+/// `PACKRAT_ENV` pointed at, which fails or hangs depending on the machine.
+@MainActor
+private final class StubCatalogService: CatalogBrowsing, @unchecked Sendable {
+    var pages: [[CatalogItem]]
+    var shouldFail = false
+    var requestedPages: [Int] = []
+
+    init(pages: [[CatalogItem]] = []) {
+        self.pages = pages
+    }
+
+    static func item(id: Int, name: String) -> CatalogItem {
+        CatalogItem(
+            id: id, name: name, productUrl: "https://example.com/\(id)",
+            sku: "sku-\(id)", weight: 100, weightUnit: .g, description: nil,
+            categories: nil, images: nil, brand: nil, model: nil,
+            ratingValue: nil, color: nil, size: nil, price: nil,
+            availability: nil, seller: nil, reviewCount: nil
+        )
+    }
+
+    func categories(limit _: Int) async throws -> [String] { [] }
+
+    func browse(query _: String?, category _: String?, page: Int, limit _: Int) async throws -> [CatalogItem] {
+        requestedPages.append(page)
+        if shouldFail { throw StubError.failed }
+        let index = page - 1
+        return index < pages.count ? pages[index] : []
+    }
+
+    enum StubError: Error { case failed }
 }
 
 // MARK: - Catalog category display names

--- a/apps/swift/Tests/PackRatTests/PackParityTests.swift
+++ b/apps/swift/Tests/PackRatTests/PackParityTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import Testing
+@testable import PackRat
+
+// MARK: - Pack-scoped chat context
+
+@Suite("ChatContext")
+struct ChatContextTests {
+    @Test("pack context exposes packId and name, not itemId")
+    func packContextFields() {
+        let context = ChatContext.pack(id: "pack-1", name: "Sierra Overnight")
+        #expect(context.contextType == "pack")
+        #expect(context.packId == "pack-1")
+        #expect(context.packName == "Sierra Overnight")
+        #expect(context.itemId == nil)
+    }
+
+    @Test("general context sends no ids")
+    func generalContextFields() {
+        let context = ChatContext.general
+        #expect(context.contextType == "general")
+        #expect(context.packId == nil)
+        #expect(context.itemId == nil)
+        #expect(context.packName == nil)
+    }
+
+    @Test("item context exposes itemId only")
+    func itemContextFields() {
+        let context = ChatContext.item(id: "item-9")
+        #expect(context.contextType == "item")
+        #expect(context.itemId == "item-9")
+        #expect(context.packId == nil)
+    }
+}
+
+@Suite("ChatRequest encoding")
+struct ChatRequestEncodingTests {
+    private func encode(_ request: ChatRequest) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(request)
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// The chat route's body schema is `z.any()`, so a wrong field name fails
+    /// silently as a generic chat instead of erroring. These assertions are the
+    /// only thing standing between a typo and a broken pack context.
+    @Test("pack context is serialized as contextType + packId")
+    func packContextEncoded() throws {
+        let request = ChatRequest(
+            messages: [ChatMessage(role: .user, content: "What's missing?")],
+            context: .pack(id: "pack-42", name: "Desert Loop")
+        )
+        let dict = try encode(request)
+        #expect(dict["contextType"] as? String == "pack")
+        #expect(dict["packId"] as? String == "pack-42")
+        #expect(dict["date"] as? String != nil)
+    }
+
+    @Test("messages carry role, content and a text part")
+    func messagesEncoded() throws {
+        let request = ChatRequest(
+            messages: [ChatMessage(role: .user, content: "Hello")],
+            context: .general
+        )
+        let dict = try encode(request)
+        let messages = try #require(dict["messages"] as? [[String: Any]])
+        #expect(messages.count == 1)
+        #expect(messages[0]["role"] as? String == "user")
+        #expect(messages[0]["content"] as? String == "Hello")
+        let parts = try #require(messages[0]["parts"] as? [[String: Any]])
+        #expect(parts[0]["type"] as? String == "text")
+        #expect(parts[0]["text"] as? String == "Hello")
+    }
+
+    @Test("general context omits packId")
+    func generalContextOmitsPackId() throws {
+        let request = ChatRequest(messages: [], context: .general)
+        let dict = try encode(request)
+        #expect(dict["contextType"] as? String == "general")
+        #expect(dict["packId"] == nil)
+    }
+}
+
+@Suite("ChatViewModel pack scoping")
+@MainActor
+struct ChatViewModelPackScopingTests {
+    @Test("greeting names the pack when scoped to one")
+    func greetingNamesPack() {
+        let viewModel = ChatViewModel(
+            service: StubChatService(),
+            context: .pack(id: "p1", name: "Winter Hut Trip")
+        )
+        #expect(viewModel.messages.first?.content.contains("Winter Hut Trip") == true)
+    }
+
+    @Test("generic greeting when unscoped")
+    func genericGreeting() {
+        let viewModel = ChatViewModel(service: StubChatService(), context: .general)
+        #expect(viewModel.messages.first?.content.contains("PackRat AI assistant") == true)
+    }
+
+    @Test("clearHistory keeps the pack greeting")
+    func clearHistoryKeepsPackGreeting() {
+        let viewModel = ChatViewModel(
+            service: StubChatService(),
+            context: .pack(id: "p1", name: "Winter Hut Trip")
+        )
+        viewModel.clearHistory()
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages.first?.content.contains("Winter Hut Trip") == true)
+    }
+}
+
+private struct StubChatService: ChatServicing {
+    func sendMessage(messages _: [ChatMessage], context _: ChatContext) async -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+}
+
+// MARK: - Packing mode
+
+@Suite("PackingModeStore")
+@MainActor
+struct PackingModeStoreTests {
+    /// Each test gets its own suite-name UserDefaults so persistence is
+    /// exercised for real without leaking between tests or into the app domain.
+    private func makeStore() throws -> (PackingModeStore, UserDefaults) {
+        let defaults = try #require(UserDefaults(suiteName: "packing-test-\(UUID().uuidString)"))
+        return (PackingModeStore(defaults: defaults), defaults)
+    }
+
+    @Test("items start unpacked")
+    func startsUnpacked() throws {
+        let (store, _) = try makeStore()
+        #expect(store.isPacked("i1", in: "p1") == false)
+        #expect(store.packedItems(in: "p1").isEmpty)
+    }
+
+    @Test("toggle marks packed then unpacked")
+    func toggleRoundTrip() throws {
+        let (store, _) = try makeStore()
+        store.toggle(itemId: "i1", in: "p1")
+        #expect(store.isPacked("i1", in: "p1"))
+        store.toggle(itemId: "i1", in: "p1")
+        #expect(store.isPacked("i1", in: "p1") == false)
+    }
+
+    @Test("unpacking removes the key rather than storing false")
+    func unpackingRemovesKey() throws {
+        let (store, _) = try makeStore()
+        store.setPacked(true, itemId: "i1", in: "p1")
+        store.setPacked(false, itemId: "i1", in: "p1")
+        #expect(store.packedItems(in: "p1").isEmpty)
+    }
+
+    @Test("packs are scoped independently")
+    func packsAreIndependent() throws {
+        let (store, _) = try makeStore()
+        store.setPacked(true, itemId: "shared-item", in: "p1")
+        #expect(store.isPacked("shared-item", in: "p1"))
+        #expect(store.isPacked("shared-item", in: "p2") == false)
+    }
+
+    @Test("reset clears only the target pack")
+    func resetIsScoped() throws {
+        let (store, _) = try makeStore()
+        store.setPacked(true, itemId: "i1", in: "p1")
+        store.setPacked(true, itemId: "i2", in: "p2")
+        store.reset(packId: "p1")
+        #expect(store.packedItems(in: "p1").isEmpty)
+        #expect(store.isPacked("i2", in: "p2"))
+    }
+
+    @Test("replace overwrites and drops false entries")
+    func replaceDropsFalse() throws {
+        let (store, _) = try makeStore()
+        store.setPacked(true, itemId: "stale", in: "p1")
+        store.replace(packedItems: ["i1": true, "i2": false], in: "p1")
+        #expect(store.packedItems(in: "p1") == ["i1": true])
+    }
+
+    /// Progress is computed against the pack's *current* items. An item checked
+    /// off and later deleted must not keep counting, or progress exceeds 100%.
+    @Test("packedCount ignores ids no longer in the pack")
+    func packedCountIgnoresDeletedItems() throws {
+        let (store, _) = try makeStore()
+        store.setPacked(true, itemId: "i1", in: "p1")
+        store.setPacked(true, itemId: "deleted-item", in: "p1")
+        #expect(store.packedCount(in: "p1", among: ["i1", "i2"]) == 1)
+    }
+
+    @Test("state survives a new store over the same defaults")
+    func statePersists() throws {
+        let (store, defaults) = try makeStore()
+        store.setPacked(true, itemId: "i1", in: "p1")
+
+        let reloaded = PackingModeStore(defaults: defaults)
+        #expect(reloaded.isPacked("i1", in: "p1"))
+    }
+
+    @Test("a malformed persisted payload degrades to empty, not a crash")
+    func malformedPayloadIsIgnored() throws {
+        let defaults = try #require(UserDefaults(suiteName: "packing-test-\(UUID().uuidString)"))
+        defaults.set(["p1": "not-a-dictionary"], forKey: "packingMode")
+
+        let store = PackingModeStore(defaults: defaults)
+        #expect(store.packedItems(in: "p1").isEmpty)
+    }
+}
+
+// MARK: - Image detection decoding
+
+@Suite("DetectedItemWithMatches decoding")
+struct ImageDetectionDecodingTests {
+    private func decode(_ json: String) throws -> [DetectedItemWithMatches] {
+        let data = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode([DetectedItemWithMatches].self, from: data)
+    }
+
+    /// The analyze route returns a bare array, not an object wrapper.
+    @Test("decodes a bare array of detections")
+    func decodesBareArray() throws {
+        let results = try decode("""
+        [{"detected":{"name":"Rain Jacket","description":"Shell","quantity":1,
+          "category":"clothing","consumable":false,"worn":true,"confidence":0.92},
+          "catalogMatches":[]}]
+        """)
+        #expect(results.count == 1)
+        #expect(results[0].detected.name == "Rain Jacket")
+        #expect(results[0].detected.worn)
+        #expect(results[0].detected.confidence == 0.92)
+        #expect(results[0].primaryMatch == nil)
+    }
+
+    /// `consumable`/`worn` carry Zod defaults server-side and may be absent.
+    @Test("absent optional flags fall back to false")
+    func absentFlagsDefaultFalse() throws {
+        let results = try decode("""
+        [{"detected":{"name":"Tent","description":"","quantity":1,
+          "category":"shelter","confidence":0.5},"catalogMatches":[]}]
+        """)
+        #expect(results[0].detected.consumable == false)
+        #expect(results[0].detected.worn == false)
+    }
+
+    /// One malformed detection must not take the whole photo's results with it.
+    @Test("a detection missing non-essential fields still decodes")
+    func partialDetectionDecodes() throws {
+        let results = try decode("""
+        [{"detected":{"name":"Mystery Item"},"catalogMatches":[]}]
+        """)
+        #expect(results[0].detected.name == "Mystery Item")
+        #expect(results[0].detected.quantity == 1)
+        #expect(results[0].detected.category.isEmpty)
+    }
+
+    @Test("primaryMatch is the first catalog match")
+    func primaryMatchIsFirst() throws {
+        let results = try decode("""
+        [{"detected":{"name":"Sleeping Bag","description":"","quantity":1,
+          "category":"sleep","confidence":0.8},
+          "catalogMatches":[
+            {"id":11,"name":"Bag A","productUrl":"u","sku":"s1","weight":900,"weightUnit":"g"},
+            {"id":12,"name":"Bag B","productUrl":"u","sku":"s2","weight":800,"weightUnit":"g"}
+          ]}]
+        """)
+        #expect(results[0].primaryMatch?.id == 11)
+        #expect(results[0].catalogMatches.count == 2)
+    }
+}
+
+@Suite("AnalyzeImageRequest encoding")
+struct AnalyzeImageRequestTests {
+    @Test("sends the object key as `image`")
+    func encodesImageKey() throws {
+        let request = AnalyzeImageRequest(image: "user-1-abc.jpg", matchLimit: 1)
+        let data = try JSONEncoder().encode(request)
+        let dict = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(dict["image"] as? String == "user-1-abc.jpg")
+        #expect(dict["matchLimit"] as? Int == 1)
+    }
+
+    @Test("omits matchLimit when nil")
+    func omitsNilMatchLimit() throws {
+        let request = AnalyzeImageRequest(image: "user-1-abc.jpg", matchLimit: nil)
+        let data = try JSONEncoder().encode(request)
+        let dict = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(dict["matchLimit"] == nil)
+    }
+}
+
+// MARK: - Catalog linkage on created pack items
+
+@Suite("CreatePackItemRequest catalog linkage")
+struct CreatePackItemCatalogLinkageTests {
+    private func encode(_ request: CreatePackItemRequest) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(request)
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// Swift previously hardcoded `catalogItemId: nil`, so catalog-added items
+    /// lost the link back to the product they came from.
+    @Test("catalogItemId and image are sent when present")
+    func sendsCatalogLinkage() throws {
+        let request = CreatePackItemRequest(
+            id: "i1", name: "Tent", weight: 1200, weightUnit: "g",
+            quantity: 1, category: "shelter", consumable: false, worn: false,
+            notes: nil, catalogItemId: 77, image: "user-1-tent.jpg"
+        )
+        let dict = try encode(request)
+        #expect(dict["catalogItemId"] as? Int == 77)
+        #expect(dict["image"] as? String == "user-1-tent.jpg")
+    }
+
+    @Test("hand-entered items omit catalog fields entirely")
+    func omitsCatalogFieldsWhenAbsent() throws {
+        let request = CreatePackItemRequest(id: "i1", name: "Hand-written Item")
+        let dict = try encode(request)
+        #expect(dict["catalogItemId"] == nil)
+        #expect(dict["image"] == nil)
+        #expect(dict["name"] as? String == "Hand-written Item")
+    }
+}

--- a/apps/swift/Tests/PackRatTests/PackParityTests.swift
+++ b/apps/swift/Tests/PackRatTests/PackParityTests.swift
@@ -288,6 +288,40 @@ struct AnalyzeImageRequestTests {
     }
 }
 
+// MARK: - Catalog category display names
+
+@Suite("catalogCategoryDisplayName")
+struct CatalogCategoryDisplayNameTests {
+    /// Scraped categories arrive with HTML entities intact. Plain `.capitalized`
+    /// renders "hike &amp; camp" as the visibly broken "Hike &Amp; Camp".
+    @Test("decodes &amp; instead of capitalizing it")
+    func decodesAmpersand() {
+        #expect("hike &amp; camp".catalogCategoryDisplayName == "Hike & Camp")
+    }
+
+    @Test("title-cases plain categories")
+    func titleCasesPlain() {
+        #expect("sleeping bags".catalogCategoryDisplayName == "Sleeping Bags")
+        #expect("footwear".catalogCategoryDisplayName == "Footwear")
+    }
+
+    @Test("decodes the other entities that occur in catalog data")
+    func decodesOtherEntities() {
+        #expect("men&#39;s".catalogCategoryDisplayName == "Men's")
+        #expect("a &lt; b".catalogCategoryDisplayName == "A < B")
+    }
+
+    @Test("leaves acronyms uppercase")
+    func preservesAcronyms() {
+        #expect("UL gear".catalogCategoryDisplayName == "UL Gear")
+    }
+
+    @Test("empty string stays empty")
+    func emptyStaysEmpty() {
+        #expect("".catalogCategoryDisplayName == "")
+    }
+}
+
 // MARK: - Catalog linkage on created pack items
 
 @Suite("CreatePackItemRequest catalog linkage")

--- a/apps/swift/Tests/PackRatTests/PackParityTests.swift
+++ b/apps/swift/Tests/PackRatTests/PackParityTests.swift
@@ -288,6 +288,35 @@ struct AnalyzeImageRequestTests {
     }
 }
 
+// MARK: - Catalog browser search feedback
+
+@Suite("PackCatalogBrowserViewModel search state")
+@MainActor
+struct PackCatalogBrowserSearchStateTests {
+    /// The loader has to appear on the keystroke, not when the request starts —
+    /// the 400ms debounce sits in between, and covering only the request leaves
+    /// typing with no feedback at all.
+    @Test("typing marks the view as searching immediately")
+    func typingSetsSearchingBeforeDebounce() {
+        let viewModel = PackCatalogBrowserViewModel()
+        #expect(viewModel.isSearching == false)
+
+        viewModel.searchText = "tent"
+        viewModel.onSearchTextChanged()
+
+        // Synchronous check: no awaiting, so this is the debounce window.
+        #expect(viewModel.isSearching)
+    }
+
+    @Test("changing category also shows the loader")
+    func categoryChangeSetsSearching() {
+        let viewModel = PackCatalogBrowserViewModel()
+        viewModel.selectCategory("shelter")
+        #expect(viewModel.isSearching)
+        #expect(viewModel.selectedCategory == "shelter")
+    }
+}
+
 // MARK: - Catalog category display names
 
 @Suite("catalogCategoryDisplayName")

--- a/apps/swift/Tests/PackRatUITests/VisualScreenshotTests.swift
+++ b/apps/swift/Tests/PackRatUITests/VisualScreenshotTests.swift
@@ -522,7 +522,9 @@ final class VisualScreenshotTests: XCTestCase {
     private func capturePhoneExpandedPackStates() {
         captureTab("Packs", name: "home-before-81-data-pack-expanded")
         tapTextAndCapture("Alpine Weekend", name: "81-data-pack-detail-expanded")
-        tapAndCapture(identifier: "pack_detail_add_item_button", fallbackButton: "Add Item", name: "82-data-pack-add-item-sheet")
+        // Add Item is a pull-down menu (Add Manually / Scan / Catalog), not a
+        // button that opens the form directly, so capture the open menu.
+        openMenuAndCapture(identifier: "pack_detail_add_item_button", fallbackButton: "Add Item", name: "82-data-pack-add-item-menu")
         openMenuAndCapture(identifier: "pack_detail_more_menu", fallbackButton: "More", name: "83-data-pack-more-menu")
         captureTab("Packs", name: "home-before-84-data-pack-item-detail")
         tapTextAndCapture("Alpine Weekend", name: "84-data-pack-detail-before-item")
@@ -1023,7 +1025,9 @@ final class VisualScreenshotTests: XCTestCase {
     private func captureMacExpandedPackStates() {
         resetMacSampleDataSidebar("Packs")
         capture("81-data-pack-detail-expanded")
-        tapAndCapture(identifier: "pack_detail_add_item_button", fallbackButton: "Add Item", name: "82-data-pack-add-item-sheet")
+        // Add Item is a pull-down menu (Add Manually / Scan / Catalog), not a
+        // button that opens the form directly, so capture the open menu.
+        openMenuAndCapture(identifier: "pack_detail_add_item_button", fallbackButton: "Add Item", name: "82-data-pack-add-item-menu")
         resetMacSampleDataSidebar("Packs")
         scrollToElement(identifier: "pack_item_row_visual-item-shelter")
         if isPadVisualRun {

--- a/apps/swift/scripts/capture-visual-screenshots.ts
+++ b/apps/swift/scripts/capture-visual-screenshots.ts
@@ -507,9 +507,9 @@ function expandedStateRequirements(platform: Platform): ScreenshotRequirement[] 
       area: 'crud',
       flow: 'Pack detail expanded review baseline',
     }),
-    requirement('82-data-pack-add-item-sheet', {
-      area: 'crud',
-      flow: 'Pack item create sheet from pack detail',
+    requirement('82-data-pack-add-item-menu', {
+      area: 'modal',
+      flow: 'Pack detail add-item menu (manual / scan / catalog)',
     }),
     requirement('83-data-pack-more-menu', {
       area: 'modal',

--- a/docs/qa/pack-tools-beta-test-plan.md
+++ b/docs/qa/pack-tools-beta-test-plan.md
@@ -35,8 +35,7 @@ Two things are worth having ready:
 Open a pack. Everything below starts from the two buttons at the top right.
 
 - Tap the `+` button. Expect a menu with exactly three entries: Add Manually, Scan
-  Items from Photo, and Add from Catalog. One normal tap gets you there — pressing
-  and holding should never be necessary to find them.
+  Items from Photo, and Add from Catalog.
 - Tap Add Manually. The pack item form should open, the same one that has always
   been there.
 - Tap the `⋯` button. Expect Ask AI and Start Packing at the top, above Weight
@@ -52,7 +51,7 @@ starting from nothing.
 - Open `⋯` then Ask AI on a pack with gear in it. Expect the screen to be titled
   Ask AI, with the pack's name as the heading and a greeting that names that pack.
 - Look at the row of suggestions above the text box. They should be about the pack
-  in front of you — What's missing, Cut weight, Heaviest items — rather than
+  in front of you — What's missing, Cut weight, Heaviest items and not
   general packing prompts.
 - Tap Heaviest items and read the whole answer. It should name actual items from
   your pack with roughly the right weights. This is the one to spend time on: an
@@ -103,9 +102,7 @@ Use the gear photo from the setup above.
 - Tap `+` then Scan Items from Photo. Expect a Scan Items screen that explains what
   the photo should look like, with a Choose Photo button.
 - Choose your gear photo and wait. A spinner saying it is looking for gear should
-  give way to a list of what it found. A screenshot of the results next to the
-  original photo is the useful thing here, along with a note of how many it got
-  right, missed, or invented.
+  give way to a list of what it found.
 - Look at the list when it first appears. Expect every item already ticked, with
   the full count on the button at the top right.
 - Untick a couple. The count in the button should drop to match.
@@ -242,15 +239,7 @@ about passing here. What follows is what only the Mac does.
 
 ## Reporting
 
-Reports go to GitHub issues as usual. Say which pack and how many items were in it,
+Reports go to GitHub issues as usual. Mention how many items were in the pack you found an issue on,
 since most of these tools behave differently on a full pack than an empty one.
-
-Two things are worth a screenshot every time: any answer from Ask AI that does not
-appear to know what is in the pack, and the results of a photo scan alongside the
-photo that produced them.
-
-A scanned item arriving at 0 g with no catalog match is expected, and each photo is
-analysed once, so a second look at the same picture means choosing it again from
-your photo library.
 
 Anything merely annoying rather than broken is still worth reporting.

--- a/docs/qa/pack-tools-beta-test-plan.md
+++ b/docs/qa/pack-tools-beta-test-plan.md
@@ -1,467 +1,211 @@
-# Pack Tools (iOS) — Beta Tester Guide & Test Plan
-
-Thanks for helping test the new pack tools! This guide walks you through everything to
-try and how to report what you find. **You don't need to be technical** — every step is
-something you can see and tap on your phone. If a step doesn't match what you see,
-that's exactly the kind of thing we want to hear about.
-
-> This is a **separate plan** from the PackRat Pro subscription guide
-> (`revenuecat-beta-test-plan.md`). You don't need to have done that one first, and
-> nothing here involves buying anything.
-
----
-
-## 1. What you're testing
-
-Four new tools inside a pack on the **iPhone app**. Until now you could only add gear to
-a pack by typing it in by hand. Now there are three ways to add it and a way to tick it
-off as you pack your bag:
-
-| Tool | What it does |
-|---|---|
-| **Ask AI** | Chat about *this specific pack* — what's missing, how to cut weight |
-| **Add from Catalog** | Search our gear catalog and add several items at once |
-| **Scan Items from Photo** | Photograph your gear laid out; the app identifies it |
-| **Start Packing** | Tick items off as you put them in your bag, with a progress bar |
-
-These already exist in the Android/React Native app. This round is about the **iPhone
-(Swift) app**, where they are brand new — so treat everything here as untested.
-
-Your job: go through the tests, try to trip things up (tap fast, cancel halfway, go
-offline), and tell us what you saw.
-
----
-
-## 2. Before you start (one-time setup)
-
-1. **Install the app.** Tap the build link we sent you, install it, and open it.
-2. **Sign in to PackRat.** Use the test account we gave you, or create your own.
-   Most of these tools need an account — see the note in Section 5.
-3. **Make a pack with real gear in it.** Go to **Packs → New Pack**, then add at least
-   **6–8 items** by hand across a few categories (shelter, sleep, clothing, kitchen).
-   Several tests need a pack that isn't nearly empty.
-4. **Have a gear photo ready.** For the scanning tests, take a photo of some real gear
-   laid out on the floor or a bed — items spread out, not piled up, in good light.
-   4–6 recognisable things is ideal (tent, jacket, water bottle, stove, headtorch).
-   Save it to your camera roll before you start.
-5. **Note your device.** At the top of your report, write your phone model and its
-   software version (e.g. "iPhone 13, iOS 18.1").
-
-> 💡 Nothing here costs money and nothing is permanent — you can delete any test pack
-> afterwards.
-
----
-
-## 3. How to report each test
-
-For every test, copy this table into your report and fill it in:
-
-| Field | Your answer |
-|---|---|
-| Test ID | (e.g. C3) |
-| Result | Pass / Fail / Blocked / N-A |
-| What you saw | (short description) |
-| Screenshot | (attach one) |
-| Device / OS | (e.g. iPhone 13, iOS 18.1) |
-| Notes | (anything else) |
-
-- **Please attach a screenshot on every failure**, and on **every screen the AI or the
-  photo scanner produces** (even when it passes — we want to see what it said).
-- "Blocked" means you couldn't even attempt the test (e.g. the app crashed before you got
-  there). "N-A" means the test doesn't apply to your build.
-
----
-
-## 4. The tests
-
-Each test lists a **Setup** (the situation you should be in), the **Steps** to take, and
-the **Expected result** (what should happen). Report anything different.
-
-### A. Finding the new tools
-
-**A1 — The Add Item menu has three choices**
-- Setup: Open one of your packs.
-- Steps: **Tap** the **+ (Add Item)** button in the top right.
-- Expected: A menu drops down with exactly three options: **Add Manually**, **Scan Items
-  from Photo**, and **Add from Catalog**. One normal tap — you should never have to press
-  and hold to find these.
-
-**A2 — Adding by hand still works**
-- Setup: On the open Add Item menu.
-- Steps: Tap **Add Manually**.
-- Expected: The **Add Item** form opens — the same one you've always used.
-
-**A3 — The More menu has the new tools**
-- Setup: On a pack.
-- Steps: Tap the **⋯ (More)** button in the top right.
-- Expected: The menu starts with **Ask AI** and **Start Packing**, followed by the
-  existing Weight Analysis, Gap Analysis, and Edit Pack.
-
-**A4 — Packing is unavailable on an empty pack**
-- Setup: Create a brand-new pack and add **no** items.
-- Steps: Open **⋯ (More)**.
-- Expected: **Start Packing** is greyed out and can't be tapped. **Ask AI** is still
-  available.
-
-### B. Ask AI
-
-**B1 — It knows which pack you're in** 📸 *screenshot required*
-- Setup: On a pack that has gear in it.
-- Steps: Open **⋯ → Ask AI**.
-- Expected: A chat screen titled **Ask AI** opens. Your **pack's name** appears as the
-  heading, and the greeting mentions that pack by name. Screenshot this.
-
-**B2 — The suggested questions are about your pack**
-- Setup: On the Ask AI screen.
-- Steps: Look at the row of grey suggestion buttons above the text box.
-- Expected: They are pack-specific — things like **"What's missing?"**, **"Cut weight"**,
-  **"Heaviest items"** — not generic ones like "Ultralight tips" or "3-day hike gear".
-
-**B3 — It can actually see your gear** 📸 *screenshot required*
-- Setup: On the Ask AI screen for a pack with several items.
-- Steps: Tap **"Heaviest items"** and wait for the full reply.
-- Expected: The reply names **actual items from your pack** with roughly the right
-  weights. This is the most important test on the page — if it answers in generalities
-  and never names your gear, mark it **Fail** and screenshot the whole reply.
-
-**B4 — Ask your own question**
-- Setup: On the Ask AI screen.
-- Steps: Type something specific, e.g. *"Am I ready for rain?"*, and send.
-- Expected: A relevant answer that refers to your pack's contents.
-
-**B5 — Each pack has its own conversation**
-- Setup: Have a chat in Pack A, then close it.
-- Steps: Open a **different** pack → **⋯ → Ask AI**.
-- Expected: A fresh conversation greeting **Pack B** by name. Pack A's messages are
-  **not** carried over.
-
-**B6 — The general assistant still works**
-- Setup: Leave the pack entirely.
-- Steps: Tap the **Assistant** tab at the bottom of the screen.
-- Expected: The normal assistant, titled **AI Assistant**, with the general suggestions
-  ("Ultralight tips", etc.). It should be unaffected by anything above.
-
-### C. Add from Catalog
-
-**C1 — Browse without searching** 📸 *screenshot required*
-- Setup: On a pack.
-- Steps: Tap **+** → **Add from Catalog**.
-- Expected: A sheet titled **Add from Catalog** opens **already showing gear** — you
-  shouldn't have to search first to see anything. There's a search box and a row of
-  category buttons. Screenshot it.
-
-**C2 — Category names are written properly**
-- Setup: On the catalog sheet.
-- Steps: Read the category buttons, scrolling sideways through all of them.
-- Expected: They read like normal English — **"Hike & Camp"**, **"Footwear"**. Report
-  anything showing raw code such as `&Amp;`, `&amp;`, or `&#39;`.
-
-**C3 — Search finds things**
-- Setup: On the catalog sheet.
-- Steps: Type **tent** and wait a moment (it searches on its own after you stop typing).
-- Expected: The list updates to tents. You shouldn't need to press Return.
-
-**C4 — Filter by category**
-- Setup: On the catalog sheet.
-- Steps: Tap a category button, then tap the same one again.
-- Expected: First tap narrows the list to that category; second tap clears the filter.
-
-**C5 — Select several items at once**
-- Setup: On the catalog sheet.
-- Steps: Tap **three** different items (tap the row, not the small stepper).
-- Expected: Each shows a blue tick, a bar at the bottom says **"3 selected"**, and the
-  top-right button reads **Add (3)**.
-
-**C6 — Change how many of something**
-- Setup: With at least one item selected.
-- Steps: On a selected row, use the **Quantity** +/− stepper.
-- Expected: The number changes and won't go below 1.
-
-**C7 — Clear the selection**
-- Setup: With several items selected.
-- Steps: Tap **Clear** in the bottom bar.
-- Expected: All ticks clear, the bottom bar disappears, and **Add** greys out.
-
-**C8 — Add them to the pack**
-- Setup: With 2–3 items selected.
-- Steps: Tap **Add (n)**.
-- Expected: The sheet closes, a brief message says how many were added, and the new items
-  appear in your pack. The pack's **total weight goes up**.
-
-**C9 — Quantity is respected**
-- Setup: Add a single item with the quantity set to **3**.
-- Expected: The item appears in the pack showing **×3**.
-
-**C10 — Cancel adds nothing**
-- Setup: On the catalog sheet with items selected.
-- Steps: Tap **Cancel**.
-- Expected: The sheet closes and your pack is **unchanged**.
-
-**C11 — Scrolling loads more**
-- Setup: On the catalog sheet with no search text.
-- Steps: Scroll to the bottom of the list.
-- Expected: More gear loads automatically. Report any **duplicate items** appearing.
-
-### D. Scan Items from Photo
-
-> Use the gear photo you prepared in setup.
-
-**D1 — The starting screen explains itself**
-- Setup: On a pack.
-- Steps: Tap **+** → **Scan Items from Photo**.
-- Expected: A sheet titled **Scan Items** explaining what to do, with a **Choose Photo**
-  button.
-
-**D2 — It identifies your gear** 📸 *screenshot required*
-- Setup: On the Scan Items sheet.
-- Steps: Tap **Choose Photo**, pick your gear photo, and wait.
-- Expected: A spinner saying it's looking for gear, then a list of detected items.
-  Screenshot the results **next to** (or alongside) your original photo so we can judge
-  accuracy. Tell us how many it got right, missed, or invented.
-
-**D3 — Everything starts ticked**
-- Setup: On the results list.
-- Expected: Every detected item already has a blue tick, and the top-right button shows
-  the full count, e.g. **Add (5)**.
-
-**D4 — Untick what you don't want**
-- Setup: On the results list.
-- Steps: Tap a couple of items to untick them.
-- Expected: The ticks clear and the **Add (n)** count drops to match.
-
-**D5 — Select All / Select None**
-- Setup: On the results list.
-- Steps: Tap the **Select None** / **Select All** button in the list header, twice.
-- Expected: It clears everything, then re-selects everything, and the label swaps between
-  the two each time.
-
-**D6 — Matched vs unmatched items are marked**
-- Setup: On the results list.
-- Expected: Items we recognised show a **blue link line** with a catalog product and its
-  weight. Items we didn't show an **orange "No catalog match — weight not set"**. Both
-  are normal; we want to know the rough split.
-
-**D7 — Add them to the pack**
-- Setup: With a few items ticked.
-- Steps: Tap **Add (n)**.
-- Expected: The sheet closes, a message confirms how many were added, and they appear in
-  the pack. Unmatched ones will show **0 g** — that's expected, you'd set the weight
-  yourself later.
-
-**D8 — A photo with no gear in it**
-- Setup: On the Scan Items sheet.
-- Steps: Choose a photo with no gear at all (a landscape, a pet, a wall).
-- Expected: A friendly **"No Gear Detected"** screen offering to try another photo. It
-  must **not** crash, hang forever, or add nonsense to your pack.
-
-**D9 — Trying again needs a new photo**
-- Setup: After any scan.
-- Steps: Tap **Try Another Photo** and pick a different image.
-- Expected: It analyses the new photo normally. (Behind the scenes each photo can only be
-  analysed once — so this is worth confirming.)
-
-**D10 — Cancel mid-scan**
-- Setup: Start a scan and tap **Cancel** while the spinner is still going.
-- Expected: The sheet closes cleanly and nothing is added to your pack.
-
-### E. Start Packing
-
-**E1 — Entering packing mode** 📸 *screenshot required*
-- Setup: On a pack with several items.
-- Steps: Tap **⋯ → Start Packing**.
-- Expected: The screen changes: a progress card at the top reading **"0 of N packed / 0%"**,
-  a row of **All / Unpacked / Packed** buttons, a **circle** beside every item, a
-  **Done** button top-right, and a bottom bar with **Reset** and **Mark All Packed**.
-  The weight charts are hidden while packing. Screenshot it.
-
-**E2 — Reset starts disabled**
-- Setup: Just entered packing mode with nothing ticked.
-- Expected: **Reset** is greyed out.
-
-**E3 — Tick items off**
-- Setup: In packing mode.
-- Steps: Tap two or three items.
-- Expected: Each gets a filled blue tick and **fades slightly**. The counter and
-  percentage go up, and the progress bar grows.
-
-**E4 — Untick an item**
-- Setup: With items ticked.
-- Steps: Tap a ticked item again.
-- Expected: It un-ticks and the count goes back down.
-
-**E5 — The Packed filter**
-- Setup: In packing mode with some items ticked.
-- Steps: Tap **Packed**.
-- Expected: Only ticked items remain on screen, and the per-category counts update to
-  match.
-
-**E6 — The Unpacked filter**
-- Steps: Tap **Unpacked**.
-- Expected: Only un-ticked items show — this is your "what's left" list.
-
-**E7 — An empty filter explains itself**
-- Setup: Tick **every** item (or use **Mark All Packed**), then tap **Unpacked**.
-- Expected: A friendly **"Everything's Packed"** message — not a blank screen, and not an
-  "Add Item" prompt.
-
-**E8 — Mark All Packed**
-- Setup: In packing mode.
-- Steps: Tap **Mark All Packed**.
-- Expected: Every item ticks, the bar reads **100%**, and the button greys out.
-
-**E9 — Reset**
-- Setup: With items ticked.
-- Steps: Tap **Reset**.
-- Expected: Everything un-ticks and the counter returns to **0 of N**.
-
-**E10 — Leaving and coming back remembers your progress** 📸 *screenshot required*
-- Setup: Tick about half the items, then tap **Done**.
-- Steps: You're back on the normal pack screen. Look just under the weight charts.
-- Expected: A card reading **"Packing in progress — X of N items checked off"**. Tapping
-  it takes you straight back into packing mode with your ticks intact. Screenshot the card.
-
-**E11 — It survives closing the app**
-- Setup: With some items ticked, **fully close** the app (swipe it away) and reopen it.
-- Steps: Go back to that pack.
-- Expected: Your ticks are still there.
-
-**E12 — Each pack is tracked separately**
-- Setup: Tick items in Pack A.
-- Steps: Open Pack B and start packing.
-- Expected: Pack B starts at **0 of N**. Pack A's progress is untouched.
-
-**E13 — Adding gear mid-pack doesn't break the count**
-- Setup: In a pack with, say, 4 of 10 ticked.
-- Steps: Leave packing mode, add an item from the catalog, then look at the progress.
-- Expected: It becomes **4 of 11** — the total goes up, your ticks are kept, and the
-  percentage **never exceeds 100%**.
-
-**E14 — Deleting a packed item doesn't break the count**
-- Setup: Tick an item, leave packing mode, then delete that same item from the pack.
-- Expected: The count drops sensibly and **never shows more packed than the pack holds**
-  (e.g. never "5 of 4").
-
-**E15 — No accidental edits while packing**
-- Setup: In packing mode.
-- Steps: Try tapping an item, and try swiping a row sideways.
-- Expected: Tapping only ticks/unticks — it must **not** open the item's edit screen.
-  Swipe-to-delete should not appear.
-
-### F. Rough edges (please try to break it)
-
-**F1 — Offline**
-- Setup: Turn on Airplane Mode.
-- Steps: Try each of the four tools.
-- Expected: **Start Packing works fully offline** (it's stored on your phone). The other
-  three need a connection and should say so **politely** — no crash, no endless spinner,
-  no silent nothing.
-
-**F2 — Signed out**
-- Setup: Sign out (or use Guest mode).
-- Steps: Try **Ask AI**.
-- Expected: A clear message that an account is needed — not a crash or an empty screen.
-
-**F3 — Tap things twice, fast**
-- Steps: Double-tap **Add** on the catalog sheet; double-tap items rapidly in packing mode.
-- Expected: No duplicated items, no wrong counts, no crash.
-
-**F4 — Dark mode & rotation**
-- Steps: View all four tools in **dark mode**, and rotate the phone.
-- Expected: Everything is readable and correctly laid out. Nothing overlaps or gets cut off.
-
-**F5 — Very long names**
-- Setup: Add an item with a very long name (40+ characters).
-- Expected: It wraps or trims tidily in packing mode and in the catalog list.
-
-**F6 — A big pack**
-- Setup: A pack with **30+** items.
-- Expected: Packing mode still scrolls smoothly and the progress bar stays accurate.
-
----
-
-## 5. Things to know up front (so you don't report false alarms)
-
-- **Packing progress lives on your phone, not your account.** If you sign in on a
-  different device, your ticks won't follow you. That's by design for now — please don't
-  report it as a bug.
-- **Scanned items with no catalog match arrive at 0 g.** The photo tells us *what* the
-  gear is but not what it weighs, so you fill the weight in yourself. Expected, not a bug.
-- **Each photo is analysed once.** Scanning the same picture again means picking it fresh
-  from your camera roll.
-- **The AI can be wrong.** We're testing whether it can *see your actual pack contents*,
-  not whether its advice is perfect. Bad advice about real items = interesting. Confident
-  talk about gear you don't own = a bug worth reporting.
-- **The + button always opens a menu**, even though "Add Manually" is the most common
-  choice. That's deliberate — it keeps all three ways of adding gear visible instead of
-  hiding two of them behind a gesture.
-
----
-
-## 6. Final summary sheet
-
-| Test ID | Result (Pass / Fail / Blocked / N-A) | Notes |
-|---|---|---|
-| A1 | | |
-| A2 | | |
-| A3 | | |
-| A4 | | |
-| B1 | | |
-| B2 | | |
-| B3 | | |
-| B4 | | |
-| B5 | | |
-| B6 | | |
-| C1 | | |
-| C2 | | |
-| C3 | | |
-| C4 | | |
-| C5 | | |
-| C6 | | |
-| C7 | | |
-| C8 | | |
-| C9 | | |
-| C10 | | |
-| C11 | | |
-| D1 | | |
-| D2 | | |
-| D3 | | |
-| D4 | | |
-| D5 | | |
-| D6 | | |
-| D7 | | |
-| D8 | | |
-| D9 | | |
-| D10 | | |
-| E1 | | |
-| E2 | | |
-| E3 | | |
-| E4 | | |
-| E5 | | |
-| E6 | | |
-| E7 | | |
-| E8 | | |
-| E9 | | |
-| E10 | | |
-| E11 | | |
-| E12 | | |
-| E13 | | |
-| E14 | | |
-| E15 | | |
-| F1 | | |
-| F2 | | |
-| F3 | | |
-| F4 | | |
-| F5 | | |
-| F6 | | |
-
-**🚨 Showstoppers** — list anything here that:
-- lost gear from a pack, or lost your packing progress, or
-- added items you never asked for, or
-- crashed the app, or
-- left you stuck on a screen you couldn't get out of.
-
-**Also worth flagging separately:**
-- Photo scans that were mostly wrong (tell us what was in the photo).
-- AI answers that clearly couldn't see your pack.
-
-Thank you! 🎒
+# Pack tools on iPhone: beta tester guide
+
+Four new ways to work with a pack on the iPhone app: asking the assistant about
+the pack you are in, adding gear from the catalog, scanning gear from a photo, and
+ticking items off as you pack your bag.
+
+These already exist on Android. This round is about the iPhone app, where all four
+are new, so none of it has been through a beta pass yet.
+
+## Before you start
+
+Note the OS version you are on. Every report needs to say where it happened.
+
+Sign in before you start. Three of the four tools need an account, and the guide
+says where that matters.
+
+Two things are worth having ready:
+
+- A pack with real gear in it. Six to eight items across a few categories —
+  shelter, sleep, clothing, kitchen — gives the weights and the progress counts
+  something to work with. A nearly empty pack hides most of what these tools do.
+- A photo of gear laid out on the floor or a bed, saved to your camera roll. Items
+  spread out and not overlapping, in good light. Four to six recognisable things,
+  like a tent, a jacket, a water bottle, a stove and a headtorch.
+
+## Finding the tools
+
+Open a pack. Everything below starts from the two buttons at the top right.
+
+- Tap the `+` button. Expect a menu with exactly three entries: Add Manually, Scan
+  Items from Photo, and Add from Catalog. One normal tap gets you there — pressing
+  and holding should never be necessary to find them.
+- Tap Add Manually. The pack item form should open, the same one that has always
+  been there.
+- Tap the `⋯` button. Expect Ask AI and Start Packing at the top, above Weight
+  Analysis, Gap Analysis and Edit Pack.
+- Open `⋯` on a pack with no items in it. Start Packing should be greyed out, and
+  Ask AI should still work.
+
+## Ask AI
+
+This is the assistant, but pointed at the pack you are looking at rather than
+starting from nothing.
+
+- Open `⋯` then Ask AI on a pack with gear in it. Expect the screen to be titled
+  Ask AI, with the pack's name as the heading and a greeting that names that pack.
+- Look at the row of suggestions above the text box. They should be about the pack
+  in front of you — What's missing, Cut weight, Heaviest items — rather than
+  general packing prompts.
+- Tap Heaviest items and read the whole answer. It should name actual items from
+  your pack with roughly the right weights. This is the one to spend time on: an
+  answer that talks in generalities and never names your gear is the failure worth
+  reporting, and a screenshot of the full reply helps.
+- Ask something specific of your own, like whether the pack is ready for rain.
+  Expect the answer to refer to what is actually in it.
+- Have a conversation in one pack, close it, then open Ask AI on a different pack.
+  Expect a fresh conversation naming the second pack, with nothing carried over
+  from the first.
+- Leave the pack and open the Assistant tab at the bottom of the screen. That one
+  should still be titled AI Assistant with its general suggestions, unaffected by
+  any of the above.
+
+## Add from Catalog
+
+- Tap `+` then Add from Catalog. Expect gear on screen straight away rather than an
+  empty state waiting for a search, along with a search box and a row of category
+  buttons.
+- Read the category buttons, scrolling sideways through all of them. Expect
+  ordinary English — Hike & Camp, Footwear. Anything showing raw code like `&Amp;`
+  or `&#39;` is a bug.
+- Type "tent" and watch the list while it works. Expect the rows to dim with a
+  spinner over them while the new results load, and pressing Return should not be
+  necessary.
+- Tap a category button, then tap the same one again. The first tap narrows the
+  list to that category and the second clears it. Expect the same loading
+  treatment as a search on both.
+- Tap three different rows. Each should get a blue tick, a bar along the bottom
+  should read "3 selected", and the button at the top right should read "Add (3)".
+- Use the quantity stepper on a selected row. Expect the number to change, and not
+  to go below 1.
+- Tap Clear in the bottom bar. Every tick should clear, the bar should disappear,
+  and Add should grey out.
+- Select two or three items and tap Add. Expect the sheet to close, a brief line
+  confirming how many were added, the items to appear in the pack, and the pack's
+  total weight to go up.
+- Add a single item with its quantity set to 3. It should land in the pack showing
+  `×3`.
+- Select some items and tap Cancel instead. The pack should be exactly as it was.
+- Scroll to the bottom of the list with no search text. More gear should load on
+  its own. Duplicate rows appearing is worth reporting.
+
+## Scan Items from Photo
+
+Use the gear photo from the setup above.
+
+- Tap `+` then Scan Items from Photo. Expect a Scan Items screen that explains what
+  the photo should look like, with a Choose Photo button.
+- Choose your gear photo and wait. A spinner saying it is looking for gear should
+  give way to a list of what it found. A screenshot of the results next to the
+  original photo is the useful thing here, along with a note of how many it got
+  right, missed, or invented.
+- Look at the list when it first appears. Expect every item already ticked, with
+  the full count on the button at the top right.
+- Untick a couple. The count in the button should drop to match.
+- Tap Select None, then Select All. The first clears every tick, the second
+  restores them, and the button label swaps between the two each time.
+- Read down the list. Items matched to the catalog should show a blue line with the
+  product and its weight. Expect unmatched ones to say "No catalog match — weight
+  not set" in orange. Both are normal, and the rough split between them is worth
+  noting.
+- Tick a few and tap Add. Expect the sheet to close, a line confirming the count,
+  and the items to appear in the pack. Unmatched items arrive at 0 g, which is
+  expected rather than a bug.
+- Try a photo with no gear in it at all — a landscape, a pet, a wall. Expect a No
+  Gear Detected screen offering another photo, not a crash, an endless spinner, or
+  nonsense added to the pack.
+- Tap Try Another Photo and pick a different image. It should analyse the new one
+  normally.
+- Start a scan and tap Cancel while the spinner is still going. The sheet should
+  close and nothing should reach the pack.
+
+## Start Packing
+
+- Open `⋯` then Start Packing on a pack with several items. The screen should
+  change: a progress card reading "0 of N packed" and 0%, a row of All, Unpacked
+  and Packed buttons, a circle beside every item, a Done button at the top right,
+  and Reset and Mark All Packed along the bottom. The weight charts should be
+  hidden while you are packing.
+- Look at Reset before ticking anything. It should be greyed out.
+- Tap two or three items. Each should get a filled blue tick and fade slightly,
+  and expect the count, the percentage and the progress bar to all move.
+- Tap a ticked item again. It should untick and the count should drop.
+- Tap Packed. Expect only the ticked items to remain, with the per-category counts
+  updating to match.
+- Tap Unpacked. Only the unticked ones should show, which is the list of what is
+  left to pack.
+- Tick everything, or use Mark All Packed, then tap Unpacked. Expect an
+  "Everything's Packed" message rather than a blank screen or a prompt to add
+  items.
+- Tap Mark All Packed. Expect every item to tick, the bar to read 100%, and the
+  button to grey out.
+- Tap Reset. Everything should untick and the count should return to 0 of N.
+- Tick about half the items and tap Done. Back on the pack screen, just under the
+  weight charts, expect a card reading "Packing in progress" with the count.
+  Tapping it should take you straight back in with your ticks intact.
+- Force quit from the app switcher with some items ticked, then reopen and go back
+  to that pack. The ticks should still be there.
+- Tick items in one pack, then start packing a different one. The second should
+  start at 0 of N with the first untouched.
+- With four of ten ticked, leave packing mode, add an item from the catalog, then
+  look at the progress. Expect four of eleven: the total goes up, the ticks stay,
+  and the percentage never goes over 100%.
+- Tick an item, leave packing mode, then delete that same item from the pack. The
+  count should drop sensibly and should never show more packed than the pack holds.
+- While packing, tap an item and try swiping a row sideways. Tapping should only
+  tick and untick, never open the item for editing, and swipe to delete should not
+  appear.
+
+## Offline
+
+PackRat works without a connection, and these four tools split cleanly on that.
+Packing is kept on the device, so it works with no signal at all. The other three
+need the network.
+
+- Use the app for a few minutes so it has something cached, then turn on airplane
+  mode and open a pack.
+- Start Packing in airplane mode and tick items off. All of it should work exactly
+  as it does online, including the progress card and the filters.
+- Force quit while still in airplane mode, reopen, and go back to the pack. The
+  ticks should have survived.
+- Turn airplane mode off. Your packed items should still be as you left them.
+- Open Add from Catalog in airplane mode. Expect it to say plainly that it cannot
+  reach the network, rather than an endless spinner or an empty list with no
+  explanation.
+- Try Scan Items from Photo and Ask AI in airplane mode. Both should say clearly
+  that a connection is needed.
+- An orange banner reading "You're offline, showing cached data" should appear
+  across the top while you have no connection, and disappear once you are back
+  online.
+
+Packed items stay on the device rather than on the account. Signing in on another
+phone will not bring your ticks across, which is expected for now.
+
+## Things that break apps
+
+- Sign out, or use guest mode, and open Ask AI. Expect a clear message that an
+  account is needed rather than a crash or an empty screen.
+- Double tap Add on the catalog sheet, and tap items rapidly in packing mode.
+  Expect no duplicated items, no wrong counts and no crash.
+- Switch to dark mode and look over all four tools again. The text should stay
+  legible against the darker backgrounds.
+- Rotate the phone on each of them. Nothing should overlap or get cut off.
+- Add an item with a very long name, over forty characters, then look at it in
+  packing mode and in the catalog list. It should wrap or trim tidily.
+- Run packing mode on a pack with thirty or more items. Scrolling should stay
+  smooth and the progress count should stay accurate.
+
+## Reporting
+
+Reports go to GitHub issues as usual. Say which pack and how many items were in it,
+since most of these tools behave differently on a full pack than an empty one.
+
+Two things are worth a screenshot every time: any answer from Ask AI that does not
+appear to know what is in the pack, and the results of a photo scan alongside the
+photo that produced them.
+
+A scanned item arriving at 0 g with no catalog match is expected, and each photo is
+analysed once, so a second look at the same picture means choosing it again from the
+camera roll.
+
+Anything merely annoying rather than broken is still worth reporting.

--- a/docs/qa/pack-tools-beta-test-plan.md
+++ b/docs/qa/pack-tools-beta-test-plan.md
@@ -1,15 +1,20 @@
-# Pack tools on iPhone: beta tester guide
+# Pack tools on iPhone and Mac: beta tester guide
 
-Four new ways to work with a pack on the iPhone app: asking the assistant about
-the pack you are in, adding gear from the catalog, scanning gear from a photo, and
-ticking items off as you pack your bag.
+Four new ways to work with a pack: asking the assistant about the pack you are in,
+adding gear from the catalog, scanning gear from a photo, and ticking items off as
+you pack your bag.
 
-These already exist on Android. This round is about the iPhone app, where all four
-are new, so none of it has been through a beta pass yet.
+These already exist on Android. This round is about the iPhone and Mac apps, where
+all four are new, so none of it has been through a beta pass yet.
+
+All four are in both apps, reached the same way from the same two buttons. Most of
+this guide is written for iPhone. The Mac section at the end covers what differs
+there, and it is worth running the iPhone list on the Mac too.
 
 ## Before you start
 
-Note the OS version you are on. Every report needs to say where it happened.
+Note the OS version you are on and which of the two you tested. Every report needs
+to say where it happened.
 
 Sign in before you start. Three of the four tools need an account, and the guide
 says where that matters.
@@ -19,9 +24,11 @@ Two things are worth having ready:
 - A pack with real gear in it. Six to eight items across a few categories —
   shelter, sleep, clothing, kitchen — gives the weights and the progress counts
   something to work with. A nearly empty pack hides most of what these tools do.
-- A photo of gear laid out on the floor or a bed, saved to your camera roll. Items
+- A photo of gear laid out on the floor or a bed, in your photo library. Items
   spread out and not overlapping, in good light. Four to six recognisable things,
-  like a tent, a jacket, a water bottle, a stove and a headtorch.
+  like a tent, a jacket, a water bottle, a stove and a headtorch. On the Mac the
+  scanner reads from Photos, so the picture needs to be in your library there
+  rather than sitting loose in a folder.
 
 ## Finding the tools
 
@@ -179,7 +186,8 @@ need the network.
   online.
 
 Packed items stay on the device rather than on the account. Signing in on another
-phone will not bring your ticks across, which is expected for now.
+phone will not bring your ticks across, and the Mac keeps its own separate count
+from your phone, which is expected for now.
 
 ## Things that break apps
 
@@ -189,11 +197,48 @@ phone will not bring your ticks across, which is expected for now.
   Expect no duplicated items, no wrong counts and no crash.
 - Switch to dark mode and look over all four tools again. The text should stay
   legible against the darker backgrounds.
-- Rotate the phone on each of them. Nothing should overlap or get cut off.
+- Rotate the phone on each of them. Nothing should overlap or get cut off. The
+  Mac equivalent is resizing the window, which the Mac section covers.
 - Add an item with a very long name, over forty characters, then look at it in
   packing mode and in the catalog list. It should wrap or trim tidily.
 - Run packing mode on a pack with thirty or more items. Scrolling should stay
   smooth and the progress count should stay accurate.
+
+## Mac
+
+All four tools are in the Mac app as well, in the same places. Open a pack and the
+`+` and `⋯` buttons sit at the top right exactly as they do on the phone.
+
+Everything in the lists above is worth running here too. The Mac is a separate app
+with its own cache and its own packing counts, so passing on iPhone says nothing
+about passing here. What follows is what only the Mac does.
+
+- Work through the four tools once from the sidebar, the same way you did on the
+  phone. Expect each to open and behave as it did there.
+- Open a pack in its own window, then use `+` and `⋯` from that window. Both menus
+  should work the same as they do in the main window.
+- Resize the window narrow, then stretch it wide, with the catalog browser and the
+  scan results open. The rows and the category buttons should follow the width
+  without clipping or overlapping.
+- Open Ask AI on the Mac. Expect the pack's name as the heading and the same
+  pack-specific suggestions, and expect Return to send your question.
+- Scan Items from Photo reads from your Photos library rather than a file browser.
+  Choose your gear photo from there and expect the same list of detected items you
+  would get on the phone.
+- Run packing mode with two windows open on the same pack. Tick an item in one and
+  expect the other to catch up rather than showing a stale count.
+- Tick some items on the Mac, then look at the same pack on your phone. The counts
+  are deliberately separate, so expect them to differ. This one is a check that
+  neither device wipes the other, not that they agree.
+- Turn Wi-Fi off from the menu bar and run the offline list above. Packing should
+  work throughout, and the other three should say plainly that they cannot reach
+  the network.
+- Press Escape with the catalog browser, the scan sheet or Ask AI open. Each should
+  close.
+- Tab through the catalog browser and the scan list. Focus should move in an order
+  that makes sense, and it should always be clear which row or field you are on.
+- Try Cmd-C and Cmd-V in the catalog search box and in the Ask AI text field. Both
+  should behave the way they do in any other Mac app.
 
 ## Reporting
 
@@ -205,7 +250,7 @@ appear to know what is in the pack, and the results of a photo scan alongside th
 photo that produced them.
 
 A scanned item arriving at 0 g with no catalog match is expected, and each photo is
-analysed once, so a second look at the same picture means choosing it again from the
-camera roll.
+analysed once, so a second look at the same picture means choosing it again from
+your photo library.
 
 Anything merely annoying rather than broken is still worth reporting.

--- a/docs/qa/pack-tools-beta-test-plan.md
+++ b/docs/qa/pack-tools-beta-test-plan.md
@@ -1,0 +1,466 @@
+# Pack Tools (iOS) — Beta Tester Guide & Test Plan
+
+Thanks for helping test the new pack tools! This guide walks you through everything to
+try and how to report what you find. **You don't need to be technical** — every step is
+something you can see and tap on your phone. If a step doesn't match what you see,
+that's exactly the kind of thing we want to hear about.
+
+> This is a **separate plan** from the PackRat Pro subscription guide
+> (`revenuecat-beta-test-plan.md`). You don't need to have done that one first, and
+> nothing here involves buying anything.
+
+---
+
+## 1. What you're testing
+
+Four new tools inside a pack on the **iPhone app**. Until now you could only add gear to
+a pack by typing it in by hand. Now there are three ways to add it and a way to tick it
+off as you pack your bag:
+
+| Tool | What it does |
+|---|---|
+| **Ask AI** | Chat about *this specific pack* — what's missing, how to cut weight |
+| **Add from Catalog** | Search our gear catalog and add several items at once |
+| **Scan Items from Photo** | Photograph your gear laid out; the app identifies it |
+| **Start Packing** | Tick items off as you put them in your bag, with a progress bar |
+
+These already exist in the Android/React Native app. This round is about the **iPhone
+(Swift) app**, where they are brand new — so treat everything here as untested.
+
+Your job: go through the tests, try to trip things up (tap fast, cancel halfway, go
+offline), and tell us what you saw.
+
+---
+
+## 2. Before you start (one-time setup)
+
+1. **Install the app.** Tap the build link we sent you, install it, and open it.
+2. **Sign in to PackRat.** Use the test account we gave you, or create your own.
+   Most of these tools need an account — see the note in Section 5.
+3. **Make a pack with real gear in it.** Go to **Packs → New Pack**, then add at least
+   **6–8 items** by hand across a few categories (shelter, sleep, clothing, kitchen).
+   Several tests need a pack that isn't nearly empty.
+4. **Have a gear photo ready.** For the scanning tests, take a photo of some real gear
+   laid out on the floor or a bed — items spread out, not piled up, in good light.
+   4–6 recognisable things is ideal (tent, jacket, water bottle, stove, headtorch).
+   Save it to your camera roll before you start.
+5. **Note your device.** At the top of your report, write your phone model and its
+   software version (e.g. "iPhone 13, iOS 18.1").
+
+> 💡 Nothing here costs money and nothing is permanent — you can delete any test pack
+> afterwards.
+
+---
+
+## 3. How to report each test
+
+For every test, copy this table into your report and fill it in:
+
+| Field | Your answer |
+|---|---|
+| Test ID | (e.g. C3) |
+| Result | Pass / Fail / Blocked / N-A |
+| What you saw | (short description) |
+| Screenshot | (attach one) |
+| Device / OS | (e.g. iPhone 13, iOS 18.1) |
+| Notes | (anything else) |
+
+- **Please attach a screenshot on every failure**, and on **every screen the AI or the
+  photo scanner produces** (even when it passes — we want to see what it said).
+- "Blocked" means you couldn't even attempt the test (e.g. the app crashed before you got
+  there). "N-A" means the test doesn't apply to your build.
+
+---
+
+## 4. The tests
+
+Each test lists a **Setup** (the situation you should be in), the **Steps** to take, and
+the **Expected result** (what should happen). Report anything different.
+
+### A. Finding the new tools
+
+**A1 — The Add Item menu has three choices**
+- Setup: Open one of your packs.
+- Steps: **Press and hold** the **+ (Add Item)** button in the top right.
+- Expected: A menu appears with exactly three options: **Add Manually**, **Scan Items
+  from Photo**, and **Add from Catalog**.
+
+**A2 — A quick tap still adds by hand** 
+- Setup: On a pack.
+- Steps: **Tap** the **+** button normally (don't hold it).
+- Expected: The **Add Item** form opens straight away — the same one you've always used.
+  It should *not* make you pick from a menu first.
+
+**A3 — The More menu has the new tools**
+- Setup: On a pack.
+- Steps: Tap the **⋯ (More)** button in the top right.
+- Expected: The menu starts with **Ask AI** and **Start Packing**, followed by the
+  existing Weight Analysis, Gap Analysis, and Edit Pack.
+
+**A4 — Packing is unavailable on an empty pack**
+- Setup: Create a brand-new pack and add **no** items.
+- Steps: Open **⋯ (More)**.
+- Expected: **Start Packing** is greyed out and can't be tapped. **Ask AI** is still
+  available.
+
+### B. Ask AI
+
+**B1 — It knows which pack you're in** 📸 *screenshot required*
+- Setup: On a pack that has gear in it.
+- Steps: Open **⋯ → Ask AI**.
+- Expected: A chat screen titled **Ask AI** opens. Your **pack's name** appears as the
+  heading, and the greeting mentions that pack by name. Screenshot this.
+
+**B2 — The suggested questions are about your pack**
+- Setup: On the Ask AI screen.
+- Steps: Look at the row of grey suggestion buttons above the text box.
+- Expected: They are pack-specific — things like **"What's missing?"**, **"Cut weight"**,
+  **"Heaviest items"** — not generic ones like "Ultralight tips" or "3-day hike gear".
+
+**B3 — It can actually see your gear** 📸 *screenshot required*
+- Setup: On the Ask AI screen for a pack with several items.
+- Steps: Tap **"Heaviest items"** and wait for the full reply.
+- Expected: The reply names **actual items from your pack** with roughly the right
+  weights. This is the most important test on the page — if it answers in generalities
+  and never names your gear, mark it **Fail** and screenshot the whole reply.
+
+**B4 — Ask your own question**
+- Setup: On the Ask AI screen.
+- Steps: Type something specific, e.g. *"Am I ready for rain?"*, and send.
+- Expected: A relevant answer that refers to your pack's contents.
+
+**B5 — Each pack has its own conversation**
+- Setup: Have a chat in Pack A, then close it.
+- Steps: Open a **different** pack → **⋯ → Ask AI**.
+- Expected: A fresh conversation greeting **Pack B** by name. Pack A's messages are
+  **not** carried over.
+
+**B6 — The general assistant still works**
+- Setup: Leave the pack entirely.
+- Steps: Tap the **Assistant** tab at the bottom of the screen.
+- Expected: The normal assistant, titled **AI Assistant**, with the general suggestions
+  ("Ultralight tips", etc.). It should be unaffected by anything above.
+
+### C. Add from Catalog
+
+**C1 — Browse without searching** 📸 *screenshot required*
+- Setup: On a pack.
+- Steps: Press and hold **+** → **Add from Catalog**.
+- Expected: A sheet titled **Add from Catalog** opens **already showing gear** — you
+  shouldn't have to search first to see anything. There's a search box and a row of
+  category buttons. Screenshot it.
+
+**C2 — Category names are written properly**
+- Setup: On the catalog sheet.
+- Steps: Read the category buttons, scrolling sideways through all of them.
+- Expected: They read like normal English — **"Hike & Camp"**, **"Footwear"**. Report
+  anything showing raw code such as `&Amp;`, `&amp;`, or `&#39;`.
+
+**C3 — Search finds things**
+- Setup: On the catalog sheet.
+- Steps: Type **tent** and wait a moment (it searches on its own after you stop typing).
+- Expected: The list updates to tents. You shouldn't need to press Return.
+
+**C4 — Filter by category**
+- Setup: On the catalog sheet.
+- Steps: Tap a category button, then tap the same one again.
+- Expected: First tap narrows the list to that category; second tap clears the filter.
+
+**C5 — Select several items at once**
+- Setup: On the catalog sheet.
+- Steps: Tap **three** different items (tap the row, not the small stepper).
+- Expected: Each shows a blue tick, a bar at the bottom says **"3 selected"**, and the
+  top-right button reads **Add (3)**.
+
+**C6 — Change how many of something**
+- Setup: With at least one item selected.
+- Steps: On a selected row, use the **Quantity** +/− stepper.
+- Expected: The number changes and won't go below 1.
+
+**C7 — Clear the selection**
+- Setup: With several items selected.
+- Steps: Tap **Clear** in the bottom bar.
+- Expected: All ticks clear, the bottom bar disappears, and **Add** greys out.
+
+**C8 — Add them to the pack**
+- Setup: With 2–3 items selected.
+- Steps: Tap **Add (n)**.
+- Expected: The sheet closes, a brief message says how many were added, and the new items
+  appear in your pack. The pack's **total weight goes up**.
+
+**C9 — Quantity is respected**
+- Setup: Add a single item with the quantity set to **3**.
+- Expected: The item appears in the pack showing **×3**.
+
+**C10 — Cancel adds nothing**
+- Setup: On the catalog sheet with items selected.
+- Steps: Tap **Cancel**.
+- Expected: The sheet closes and your pack is **unchanged**.
+
+**C11 — Scrolling loads more**
+- Setup: On the catalog sheet with no search text.
+- Steps: Scroll to the bottom of the list.
+- Expected: More gear loads automatically. Report any **duplicate items** appearing.
+
+### D. Scan Items from Photo
+
+> Use the gear photo you prepared in setup.
+
+**D1 — The starting screen explains itself**
+- Setup: On a pack.
+- Steps: Press and hold **+** → **Scan Items from Photo**.
+- Expected: A sheet titled **Scan Items** explaining what to do, with a **Choose Photo**
+  button.
+
+**D2 — It identifies your gear** 📸 *screenshot required*
+- Setup: On the Scan Items sheet.
+- Steps: Tap **Choose Photo**, pick your gear photo, and wait.
+- Expected: A spinner saying it's looking for gear, then a list of detected items.
+  Screenshot the results **next to** (or alongside) your original photo so we can judge
+  accuracy. Tell us how many it got right, missed, or invented.
+
+**D3 — Everything starts ticked**
+- Setup: On the results list.
+- Expected: Every detected item already has a blue tick, and the top-right button shows
+  the full count, e.g. **Add (5)**.
+
+**D4 — Untick what you don't want**
+- Setup: On the results list.
+- Steps: Tap a couple of items to untick them.
+- Expected: The ticks clear and the **Add (n)** count drops to match.
+
+**D5 — Select All / Select None**
+- Setup: On the results list.
+- Steps: Tap the **Select None** / **Select All** button in the list header, twice.
+- Expected: It clears everything, then re-selects everything, and the label swaps between
+  the two each time.
+
+**D6 — Matched vs unmatched items are marked**
+- Setup: On the results list.
+- Expected: Items we recognised show a **blue link line** with a catalog product and its
+  weight. Items we didn't show an **orange "No catalog match — weight not set"**. Both
+  are normal; we want to know the rough split.
+
+**D7 — Add them to the pack**
+- Setup: With a few items ticked.
+- Steps: Tap **Add (n)**.
+- Expected: The sheet closes, a message confirms how many were added, and they appear in
+  the pack. Unmatched ones will show **0 g** — that's expected, you'd set the weight
+  yourself later.
+
+**D8 — A photo with no gear in it**
+- Setup: On the Scan Items sheet.
+- Steps: Choose a photo with no gear at all (a landscape, a pet, a wall).
+- Expected: A friendly **"No Gear Detected"** screen offering to try another photo. It
+  must **not** crash, hang forever, or add nonsense to your pack.
+
+**D9 — Trying again needs a new photo**
+- Setup: After any scan.
+- Steps: Tap **Try Another Photo** and pick a different image.
+- Expected: It analyses the new photo normally. (Behind the scenes each photo can only be
+  analysed once — so this is worth confirming.)
+
+**D10 — Cancel mid-scan**
+- Setup: Start a scan and tap **Cancel** while the spinner is still going.
+- Expected: The sheet closes cleanly and nothing is added to your pack.
+
+### E. Start Packing
+
+**E1 — Entering packing mode** 📸 *screenshot required*
+- Setup: On a pack with several items.
+- Steps: Tap **⋯ → Start Packing**.
+- Expected: The screen changes: a progress card at the top reading **"0 of N packed / 0%"**,
+  a row of **All / Unpacked / Packed** buttons, a **circle** beside every item, a
+  **Done** button top-right, and a bottom bar with **Reset** and **Mark All Packed**.
+  The weight charts are hidden while packing. Screenshot it.
+
+**E2 — Reset starts disabled**
+- Setup: Just entered packing mode with nothing ticked.
+- Expected: **Reset** is greyed out.
+
+**E3 — Tick items off**
+- Setup: In packing mode.
+- Steps: Tap two or three items.
+- Expected: Each gets a filled blue tick and **fades slightly**. The counter and
+  percentage go up, and the progress bar grows.
+
+**E4 — Untick an item**
+- Setup: With items ticked.
+- Steps: Tap a ticked item again.
+- Expected: It un-ticks and the count goes back down.
+
+**E5 — The Packed filter**
+- Setup: In packing mode with some items ticked.
+- Steps: Tap **Packed**.
+- Expected: Only ticked items remain on screen, and the per-category counts update to
+  match.
+
+**E6 — The Unpacked filter**
+- Steps: Tap **Unpacked**.
+- Expected: Only un-ticked items show — this is your "what's left" list.
+
+**E7 — An empty filter explains itself**
+- Setup: Tick **every** item (or use **Mark All Packed**), then tap **Unpacked**.
+- Expected: A friendly **"Everything's Packed"** message — not a blank screen, and not an
+  "Add Item" prompt.
+
+**E8 — Mark All Packed**
+- Setup: In packing mode.
+- Steps: Tap **Mark All Packed**.
+- Expected: Every item ticks, the bar reads **100%**, and the button greys out.
+
+**E9 — Reset**
+- Setup: With items ticked.
+- Steps: Tap **Reset**.
+- Expected: Everything un-ticks and the counter returns to **0 of N**.
+
+**E10 — Leaving and coming back remembers your progress** 📸 *screenshot required*
+- Setup: Tick about half the items, then tap **Done**.
+- Steps: You're back on the normal pack screen. Look just under the weight charts.
+- Expected: A card reading **"Packing in progress — X of N items checked off"**. Tapping
+  it takes you straight back into packing mode with your ticks intact. Screenshot the card.
+
+**E11 — It survives closing the app**
+- Setup: With some items ticked, **fully close** the app (swipe it away) and reopen it.
+- Steps: Go back to that pack.
+- Expected: Your ticks are still there.
+
+**E12 — Each pack is tracked separately**
+- Setup: Tick items in Pack A.
+- Steps: Open Pack B and start packing.
+- Expected: Pack B starts at **0 of N**. Pack A's progress is untouched.
+
+**E13 — Adding gear mid-pack doesn't break the count**
+- Setup: In a pack with, say, 4 of 10 ticked.
+- Steps: Leave packing mode, add an item from the catalog, then look at the progress.
+- Expected: It becomes **4 of 11** — the total goes up, your ticks are kept, and the
+  percentage **never exceeds 100%**.
+
+**E14 — Deleting a packed item doesn't break the count**
+- Setup: Tick an item, leave packing mode, then delete that same item from the pack.
+- Expected: The count drops sensibly and **never shows more packed than the pack holds**
+  (e.g. never "5 of 4").
+
+**E15 — No accidental edits while packing**
+- Setup: In packing mode.
+- Steps: Try tapping an item, and try swiping a row sideways.
+- Expected: Tapping only ticks/unticks — it must **not** open the item's edit screen.
+  Swipe-to-delete should not appear.
+
+### F. Rough edges (please try to break it)
+
+**F1 — Offline**
+- Setup: Turn on Airplane Mode.
+- Steps: Try each of the four tools.
+- Expected: **Start Packing works fully offline** (it's stored on your phone). The other
+  three need a connection and should say so **politely** — no crash, no endless spinner,
+  no silent nothing.
+
+**F2 — Signed out**
+- Setup: Sign out (or use Guest mode).
+- Steps: Try **Ask AI**.
+- Expected: A clear message that an account is needed — not a crash or an empty screen.
+
+**F3 — Tap things twice, fast**
+- Steps: Double-tap **Add** on the catalog sheet; double-tap items rapidly in packing mode.
+- Expected: No duplicated items, no wrong counts, no crash.
+
+**F4 — Dark mode & rotation**
+- Steps: View all four tools in **dark mode**, and rotate the phone.
+- Expected: Everything is readable and correctly laid out. Nothing overlaps or gets cut off.
+
+**F5 — Very long names**
+- Setup: Add an item with a very long name (40+ characters).
+- Expected: It wraps or trims tidily in packing mode and in the catalog list.
+
+**F6 — A big pack**
+- Setup: A pack with **30+** items.
+- Expected: Packing mode still scrolls smoothly and the progress bar stays accurate.
+
+---
+
+## 5. Things to know up front (so you don't report false alarms)
+
+- **Packing progress lives on your phone, not your account.** If you sign in on a
+  different device, your ticks won't follow you. That's by design for now — please don't
+  report it as a bug.
+- **Scanned items with no catalog match arrive at 0 g.** The photo tells us *what* the
+  gear is but not what it weighs, so you fill the weight in yourself. Expected, not a bug.
+- **Each photo is analysed once.** Scanning the same picture again means picking it fresh
+  from your camera roll.
+- **The AI can be wrong.** We're testing whether it can *see your actual pack contents*,
+  not whether its advice is perfect. Bad advice about real items = interesting. Confident
+  talk about gear you don't own = a bug worth reporting.
+- **A quick tap on + is meant to skip the menu** and go straight to the manual form.
+  That's deliberate.
+
+---
+
+## 6. Final summary sheet
+
+| Test ID | Result (Pass / Fail / Blocked / N-A) | Notes |
+|---|---|---|
+| A1 | | |
+| A2 | | |
+| A3 | | |
+| A4 | | |
+| B1 | | |
+| B2 | | |
+| B3 | | |
+| B4 | | |
+| B5 | | |
+| B6 | | |
+| C1 | | |
+| C2 | | |
+| C3 | | |
+| C4 | | |
+| C5 | | |
+| C6 | | |
+| C7 | | |
+| C8 | | |
+| C9 | | |
+| C10 | | |
+| C11 | | |
+| D1 | | |
+| D2 | | |
+| D3 | | |
+| D4 | | |
+| D5 | | |
+| D6 | | |
+| D7 | | |
+| D8 | | |
+| D9 | | |
+| D10 | | |
+| E1 | | |
+| E2 | | |
+| E3 | | |
+| E4 | | |
+| E5 | | |
+| E6 | | |
+| E7 | | |
+| E8 | | |
+| E9 | | |
+| E10 | | |
+| E11 | | |
+| E12 | | |
+| E13 | | |
+| E14 | | |
+| E15 | | |
+| F1 | | |
+| F2 | | |
+| F3 | | |
+| F4 | | |
+| F5 | | |
+| F6 | | |
+
+**🚨 Showstoppers** — list anything here that:
+- lost gear from a pack, or lost your packing progress, or
+- added items you never asked for, or
+- crashed the app, or
+- left you stuck on a screen you couldn't get out of.
+
+**Also worth flagging separately:**
+- Photo scans that were mostly wrong (tell us what was in the photo).
+- AI answers that clearly couldn't see your pack.
+
+Thank you! 🎒

--- a/docs/qa/pack-tools-beta-test-plan.md
+++ b/docs/qa/pack-tools-beta-test-plan.md
@@ -81,15 +81,15 @@ the **Expected result** (what should happen). Report anything different.
 
 **A1 — The Add Item menu has three choices**
 - Setup: Open one of your packs.
-- Steps: **Press and hold** the **+ (Add Item)** button in the top right.
-- Expected: A menu appears with exactly three options: **Add Manually**, **Scan Items
-  from Photo**, and **Add from Catalog**.
+- Steps: **Tap** the **+ (Add Item)** button in the top right.
+- Expected: A menu drops down with exactly three options: **Add Manually**, **Scan Items
+  from Photo**, and **Add from Catalog**. One normal tap — you should never have to press
+  and hold to find these.
 
-**A2 — A quick tap still adds by hand** 
-- Setup: On a pack.
-- Steps: **Tap** the **+** button normally (don't hold it).
-- Expected: The **Add Item** form opens straight away — the same one you've always used.
-  It should *not* make you pick from a menu first.
+**A2 — Adding by hand still works**
+- Setup: On the open Add Item menu.
+- Steps: Tap **Add Manually**.
+- Expected: The **Add Item** form opens — the same one you've always used.
 
 **A3 — The More menu has the new tools**
 - Setup: On a pack.
@@ -145,7 +145,7 @@ the **Expected result** (what should happen). Report anything different.
 
 **C1 — Browse without searching** 📸 *screenshot required*
 - Setup: On a pack.
-- Steps: Press and hold **+** → **Add from Catalog**.
+- Steps: Tap **+** → **Add from Catalog**.
 - Expected: A sheet titled **Add from Catalog** opens **already showing gear** — you
   shouldn't have to search first to see anything. There's a search box and a row of
   category buttons. Screenshot it.
@@ -208,7 +208,7 @@ the **Expected result** (what should happen). Report anything different.
 
 **D1 — The starting screen explains itself**
 - Setup: On a pack.
-- Steps: Press and hold **+** → **Scan Items from Photo**.
+- Steps: Tap **+** → **Scan Items from Photo**.
 - Expected: A sheet titled **Scan Items** explaining what to do, with a **Choose Photo**
   button.
 
@@ -391,8 +391,9 @@ the **Expected result** (what should happen). Report anything different.
 - **The AI can be wrong.** We're testing whether it can *see your actual pack contents*,
   not whether its advice is perfect. Bad advice about real items = interesting. Confident
   talk about gear you don't own = a bug worth reporting.
-- **A quick tap on + is meant to skip the menu** and go straight to the manual form.
-  That's deliberate.
+- **The + button always opens a menu**, even though "Add Manually" is the most common
+  choice. That's deliberate — it keeps all three ways of adding gear visible instead of
+  hiding two of them behind a gesture.
 
 ---
 


### PR DESCRIPTION
## Description

Brings the iOS/macOS Swift app's pack detail screen to parity with `apps/expo`, which
had four pack tools that Swift had none of. `PackDetailView` previously offered only Add
Item, Weight Analysis, Gap Analysis, Share and Edit.

| Tool | What it does |
|---|---|
| **Ask AI** | Chat scoped to *this* pack — `ChatRequest` now sends `contextType`/`packId`/`itemId` so the server attaches pack context and offers the `getPackDetails` tool. Title, greeting and suggestion chips adapt to the pack. |
| **Add from Catalog** | Pack-first multi-select browse sheet: category facets, debounced search, paging, per-item quantity. Complements the existing item-first `AddCatalogItemToPackSheet`. |
| **Scan Items from Photo** | `PhotosPicker` → R2 presign/upload → `POST /api/packs/analyze-image` → review sheet with everything pre-selected. Weight is prefilled from the best catalog match, since the vision model returns no weight. |
| **Start Packing** | Check items off with a progress bar, All/Unpacked/Packed filter, Reset / Mark All Packed, and a resume card outside the mode. |

### Three bugs fixed along the way

- **`CatalogService.semanticSearch` called a route that doesn't exist.** It hit
  `/api/catalog/search`; the real route is `/api/catalog/vector-search`
  (`packages/api/src/routes/catalog/index.ts`), so every semantic search 404'd.
  `development` independently landed the same fix while this branch was open — the
  rebase kept theirs.
- **Catalog-added pack items lost their provenance.** `catalogItemId` was hardcoded
  `nil`, so nothing linked a packed item back to its catalog product. Now `catalogItemId`
  and `image` are threaded through `CreatePackItemRequest` → `PackService` →
  `PacksViewModel`.
- **HTML entities rendered raw in category chips.** Catalog categories are scraped and
  arrive as `hike &amp; camp`, which `.capitalized` turned into the visible
  `Hike &Amp; Camp`. Only caught by looking at the running app.

### Design note: why the `+` button is a pull-down menu

The first version made `+` a `primaryAction` menu — tap to add manually, long-press for
Scan and Catalog. That hides two of the three ways to add gear behind a gesture nothing
on screen advertises, making both new features effectively undiscoverable. It is now a
plain pull-down menu: **one tap, all three options visible**. That is the iOS convention
for a multi-option add button and matches Expo's one-tap bottom sheet. It also follows
the precedent documented at the top of `AIPacksView.swift`, which swaps Expo's alert for
`.confirmationDialog` on the same "use the platform-idiomatic equivalent" reasoning.

⌘I moves to a hidden toolbar button so it still opens the manual form directly — on the
`Menu` it would merely have opened the menu.

### Packing state is device-local by design

There is no `isPacked` column on `pack_items` and no packing endpoint. Expo keeps the
same state in a local-only Legend-State store (`features/packs/store/packingMode.ts`);
`PackingModeStore` is the Swift counterpart, persisted to `UserDefaults`. Progress does
not follow a user across devices. Flagged in the beta test plan so testers don't file it
as a bug.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update

## Area(s) affected

- [x] iOS / macOS app (`apps/swift`)
- [x] QA docs (`docs/qa`)

<!-- No changes to apps/expo, packages/api, apps/landing, apps/guides, or CI. -->

## Testing

- [x] Added / updated unit tests
- [x] Manually tested on iOS

**Unit tests** — 199 passing in 54 suites (`PackRatTests`, iPhone 17 Pro sim). 31 new
across five suites:

- `ChatContext` / `ChatRequest` field mapping. The chat route's body schema is
  `z.any()`, so a typo'd field name silently degrades to a generic chat instead of
  erroring — these assertions are the only thing catching that.
- `PackingModeStore` semantics: per-pack scoping, persistence across instances, and a
  malformed-payload fallback. Includes the case where an item is checked off and later
  deleted, which must not push progress past 100%.
- `DetectedItemWithMatches` decoding — bare array, absent Zod-default flags, partial
  detections.
- `catalogCategoryDisplayName` entity decoding.
- `catalogItemId`/`image` linkage on created pack items.

**Builds** — `PackRat-iOS` and `PackRat-macOS` both succeed.

**Manual** — drove all four features on the iPhone 17 Pro simulator against the dev API
with a real 21-item pack:

- Ask AI opened pack-scoped with the pack name, gear-aware prompts, and a reply naming
  actual items from the pack.
- Catalog add took the pack 21 → 22 items and 7.98 → 8.19 kg; verified durable
  server-side after an app reinstall.
- Packing mode tracked 0% → 9%, filters and category recounts correct, progress survived
  relaunch.
- Scan sheet reached its photo picker. **Not covered:** an end-to-end scan against the
  live vision model — the simulator photo library had no suitable gear photo. Worth
  exercising on a real device before release; it is section D of the test plan.

## Screenshots / recordings

Captured during verification: the add-item menu, pack-scoped Ask AI, the catalog browser,
and packing mode at 2 of 21. Happy to attach on request.

## Docs

New `docs/qa/pack-tools-beta-test-plan.md` — 52 cases (A–F) in the same non-technical
voice and Setup/Steps/Expected shape as the existing RevenueCat guide. Deliberately a
**separate file** rather than an addition to `revenuecat-beta-test-plan.md`, which is
scoped to subscription purchasing and shares no setup with this. Section 5 pre-empts the
false alarms these features invite (device-local packing state, unmatched scans at 0 g,
one analysis per photo).

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — n/a, no schema change
- [ ] Feature flag added (if this is a new feature) — see note below
- [x] PR title follows conventional commits

**On the feature flag:** these four ship unflagged, matching how the same features ship
in `apps/expo` and how recent `apps/swift` features have landed. Say the word if you'd
rather they sat behind `AppFeatureFlags` for the beta.

## Rebase note

Rebased onto `origin/development` (`dc2c9a46d`) after 209 upstream commits, 93 of them
touching `apps/swift`. Five files conflicted against the new offline write outbox and the
delete-confirmation flow; upstream's architecture was kept in every case and these
features layered on top. Two compile errors surfaced that no conflict marker flagged —
`CatalogItem.weight` and `weightUnit` became optional upstream — fixed with optional
chaining, so a catalog item with no published weight is added at 0 g rather than failing.
All verification above was re-run after the rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added packing mode with progress tracking, packed-item toggles, resume, reset, and mark-all controls.
  * Added catalog browsing, multi-select additions, category filtering, search, and quantity controls.
  * Added photo scanning to detect gear and add matched items to packs.
  * Added pack-specific Ask AI chats with contextual suggestions and greetings.
  * Added manual, catalog, scan, and Ask AI options from pack details.
* **Documentation**
  * Added beta testing guidance for pack tools across iPhone and Mac.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->