### PR TITLE
fix: address PR #2685 review comments

### DIFF
--- a/apps/landing/app/support/page.tsx
+++ b/apps/landing/app/support/page.tsx
@@ -1,3 +1,4 @@
+import { siteConfig } from 'landing-app/config/site';
 import Link from 'next/link';
 
 export const metadata = {
@@ -25,8 +26,8 @@ export default function SupportPage() {
               <h3 className="text-xl font-medium mb-1">Email</h3>
               <p>
                 For any question, bug report, or feedback, email{' '}
-                <a className="underline" href="mailto:support@packratai.com">
-                  support@packratai.com
+                <a className="underline" href={siteConfig.support.mailto}>
+                  {siteConfig.support.email}
                 </a>
                 . We aim to reply within two business days.
               </p>

--- a/apps/landing/config/site.ts
+++ b/apps/landing/config/site.ts
@@ -366,8 +366,9 @@ export const siteConfig = {
     ],
   },
 
-  // Support contact — surfaced from MCP /health, the login page, and the connector listing.
-  // Email is the canonical channel; we don't run a separate support web page yet.
+  // Support contact — surfaced from MCP /health, the login page, the connector
+  // listing, and the /support page. Email is the canonical channel; render
+  // these values rather than hardcoding an address.
   support: {
     email: 'hello@packratai.com',
     mailto: 'mailto:hello@packratai.com',

--- a/packages/mcp/src/tools/packs.ts
+++ b/packages/mcp/src/tools/packs.ts
@@ -256,10 +256,17 @@ export function registerPackTools(agent: AgentContext): void {
         });
       }
       // The API returns a bare array; normalise into the `{ data, nextOffset }`
-      // envelope the declared outputSchema expects (same shape as list_packs).
+      // envelope the declared outputSchema expects.
+      //
+      // `nextOffset` is always null: this endpoint takes only `pack_id` and
+      // returns every item in one response, so there is never a next page.
+      // Don't route this through `withNextOffset` — passing `limit:
+      // items.length` would make its `items.length >= limit` check true for
+      // every response (including an empty pack), advertising a bogus
+      // continuation offset that a consumer could follow into a loop.
       const items = Array.isArray(result.data) ? result.data : [];
       return ok({
-        data: withNextOffset({ items, offset: 0, limit: items.length }),
+        data: { data: items, nextOffset: null },
         structured: true,
       });
     },


### PR DESCRIPTION
Addresses the CodeRabbit review comments on #2685 that land on code added in this release. Two findings, both valid.

## 1. `packrat_list_pack_items` advertised a bogus `nextOffset`

Real bug, not just a style nit. The handler passed `limit: items.length` into `withNextOffset`, whose continuation check is `items.length >= limit` — true for **every** response, including an empty pack, which returned `nextOffset: 0`. A consumer that follows `nextOffset` could call the tool repeatedly or duplicate items.

This endpoint accepts only `pack_id` and returns every item in one response, so there is never a next page. It now returns `nextOffset: null` directly instead of routing through `withNextOffset`. The comment explains the reasoning so it doesn't get "simplified" back into the helper later.

## 2. `/support` bypassed the canonical support contract

The page hardcoded `support@packratai.com`, but `apps/landing/config/site.ts` defines `siteConfig.support.email` as `hello@packratai.com` and `__tests__/legal.pages.test.ts` asserts that value. The page now renders `siteConfig.support.email` / `.mailto`.

⚠️ **Visible change:** the support page now shows **`hello@packratai.com`**, matching the canonical config and the address given in the Anthropic submission.

Also refreshes the now-stale comment in `site.ts` that said "we don't run a separate support web page yet."

## Not addressed here

The other 8 CodeRabbit findings on #2685 are on the Swift outbox / APIClient work from #2673, #2674 and #2676 — retry backoff and 429/408 classification, `local-` legacy ID migration, removing unreachable `throws`, `displayMessage` whitespace trimming. Several involve real design calls, so they're left to those authors rather than guessed at.

## Testing

- `bun test:mcp` — **1273 pass**, 23 skipped
- tsc + biome clean on all three files
- The one failing landing test (`terms-of-service` robots metadata) is **pre-existing on `development`** and unrelated — verified by re-running it with these changes stashed.
