### PR TITLE
fix(swift): address the open outbox review findings on PR #2685

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Packs/PackFormView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackFormView.swift
@@ -108,7 +108,8 @@ struct PackFormView: View {
                         context: modelContext
                     )
                 } else {
-                    try await viewModel.createPack(
+                    // Create never throws — offline writes queue for replay.
+                    await viewModel.createPack(
                         name: name.trimmingCharacters(in: .whitespaces),
                         description: description.isEmpty ? nil : description,
                         category: category.isEmpty ? nil : category,

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -235,12 +235,10 @@ struct PacksListView: View {
     private func deletePack(_ pack: Pack) {
         packPendingDeletion = nil
         Task {
-            do {
-                try await viewModel.deletePack(pack.id, context: modelContext)
-                if selectedId == pack.id { selectedId = nil }
-            } catch {
-                deleteError = error.localizedDescription
-            }
+            // Deleting never fails at the call site — an unreachable server queues the
+            // delete for replay. Failures surface via the pending-writes banner.
+            await viewModel.deletePack(pack.id, context: modelContext)
+            if selectedId == pack.id { selectedId = nil }
         }
     }
 

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -13,7 +13,6 @@ struct PacksListView: View {
     @State private var isLoadingPublic = false
     @State private var packPendingDeletion: Pack?
     @State private var showingDeleteConfirmation = false
-    @State private var deleteError: String?
     @Environment(\.modelContext) private var modelContext
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -96,17 +95,6 @@ struct PacksListView: View {
         }
         .sheet(isPresented: $showingCreateSheet) {
             PackFormView(viewModel: viewModel)
-        }
-        .alert(
-            "Couldn't Delete Pack",
-            isPresented: Binding(
-                get: { deleteError != nil },
-                set: { if !$0 { deleteError = nil } }
-            )
-        ) {
-            Button("OK", role: .cancel) { deleteError = nil }
-        } message: {
-            Text(deleteError ?? "")
         }
         .navigationDestination(isPresented: $showingRecentPacks) {
             RecentPacksView(packs: viewModel.packs)

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -50,6 +50,9 @@ final class PacksViewModel {
         }
 
         if let context, !isCacheLoaded {
+            // Clear rows from the retired `local-` id scheme before reading the cache,
+            // so they never reach the UI or the outbox.
+            LegacyLocalIDMigration.runIfNeeded(context: context)
             let cached = (try? context.fetch(FetchDescriptor<CachedPack>(
                 sortBy: [SortDescriptor(\.cachedAt, order: .reverse)]
             ))) ?? []
@@ -125,13 +128,15 @@ final class PacksViewModel {
         try? context.save()
     }
 
+    /// Never throws: an unreachable server queues the create for replay instead of
+    /// failing at the call site. Surfaced failures come from `OutboxService.failedCount`.
     func createPack(
         name: String,
         description: String?,
         category: String?,
         isPublic: Bool,
         context: ModelContext? = nil
-    ) async throws {
+    ) async {
         let localPack = makeLocalPack(name: name, description: description, category: category, isPublic: isPublic)
         let payload = PackMutationPayload(
             name: name, description: description, category: category, isPublic: isPublic
@@ -222,8 +227,8 @@ final class PacksViewModel {
 
     /// Optimistic delete. The removal always sticks locally — an unreachable server
     /// queues the delete for replay rather than resurrecting the pack, so delete now
-    /// behaves like create and update.
-    func deletePack(_ packId: String, context: ModelContext? = nil) async throws {
+    /// behaves like create and update. Never throws, for the same reason.
+    func deletePack(_ packId: String, context: ModelContext? = nil) async {
         guard let idx = packs.firstIndex(where: { $0.id == packId }) else { return }
         packs.remove(at: idx)
         deleteCachedPack(packId, context: context)

--- a/apps/swift/Sources/PackRat/Features/Trips/TripFormView.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripFormView.swift
@@ -202,7 +202,8 @@ struct TripFormView: View {
                         context: modelContext
                     )
                 } else {
-                    try await viewModel.createTrip(
+                    // Create never throws — offline writes queue for replay.
+                    await viewModel.createTrip(
                         name: name, description: description.isEmpty ? nil : description,
                         startDate: hasDates ? startDate : nil,
                         endDate: hasDates ? endDate : nil,

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsListView.swift
@@ -114,12 +114,12 @@ struct TripsListView: View {
             Divider()
             #endif
             Button("Delete", systemImage: "trash", role: .destructive) {
-                Task { try? await viewModel.deleteTrip(trip.id, context: modelContext) }
+                Task { await viewModel.deleteTrip(trip.id, context: modelContext) }
             }
         }
         .swipeActions(edge: .trailing) {
             Button(role: .destructive) {
-                Task { try? await viewModel.deleteTrip(trip.id, context: modelContext) }
+                Task { await viewModel.deleteTrip(trip.id, context: modelContext) }
             } label: {
                 Label("Delete", systemImage: "trash")
             }

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
@@ -62,6 +62,9 @@ final class TripsViewModel {
         }
 
         if let context, !isCacheLoaded {
+            // Clear rows from the retired `local-` id scheme before reading the cache,
+            // so they never reach the UI or the outbox.
+            LegacyLocalIDMigration.runIfNeeded(context: context)
             let cached = (try? context.fetch(FetchDescriptor<CachedTrip>(
                 sortBy: [SortDescriptor(\.cachedAt, order: .reverse)]
             ))) ?? []
@@ -134,9 +137,11 @@ final class TripsViewModel {
         try? context.save()
     }
 
+    /// Never throws: an unreachable server queues the create for replay instead of
+    /// failing at the call site. Surfaced failures come from `OutboxService.failedCount`.
     func createTrip(name: String, description: String?, startDate: Date?, endDate: Date?,
                     location: TripLocationBody?, notes: String?, packId: String?,
-                    context: ModelContext? = nil) async throws {
+                    context: ModelContext? = nil) async {
         let localTrip = makeLocalTrip(
             name: name, description: description, startDate: startDate, endDate: endDate,
             location: location, notes: notes, packId: packId
@@ -241,8 +246,8 @@ final class TripsViewModel {
     }
 
     /// Optimistic delete. An unreachable server queues the delete for replay rather
-    /// than resurrecting the trip, matching create/update behaviour.
-    func deleteTrip(_ tripId: String, context: ModelContext? = nil) async throws {
+    /// than resurrecting the trip, matching create/update behaviour. Never throws.
+    func deleteTrip(_ tripId: String, context: ModelContext? = nil) async {
         guard let idx = trips.firstIndex(where: { $0.id == tripId }) else { return }
         trips.remove(at: idx)
         deleteCachedTrip(tripId, context: context)

--- a/apps/swift/Sources/PackRat/Network/APIClient.swift
+++ b/apps/swift/Sources/PackRat/Network/APIClient.swift
@@ -292,15 +292,21 @@ struct APIErrorBody: Decodable {
     let message: String?
     let code: String?
 
+    /// Nil unless `value` has non-whitespace content. A blank string is as absent as
+    /// a missing key: `InlineErrorView` trims before rendering, so `{"message":"  "}`
+    /// would otherwise suppress the 401/404 fallback and show the generic banner.
+    private static func nonBlank(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Prefer the human-readable text; fall back to the machine code so an
-    /// unrecognised body still says something specific. Empty strings are
+    /// unrecognised body still says something specific. Blank strings are
     /// treated as absent so `{"message":""}` falls through rather than
-    /// surfacing a blank banner.
+    /// surfacing an empty banner.
     var displayMessage: String? {
-        if let message, !message.isEmpty { return message }
-        if let error, !error.isEmpty { return error }
-        if let code, !code.isEmpty { return code }
-        return nil
+        Self.nonBlank(message) ?? Self.nonBlank(error) ?? Self.nonBlank(code)
     }
 
     static func decodeMessage(from data: Data) -> String? {

--- a/apps/swift/Sources/PackRat/Persistence/LegacyLocalIDMigration.swift
+++ b/apps/swift/Sources/PackRat/Persistence/LegacyLocalIDMigration.swift
@@ -1,0 +1,81 @@
+import Foundation
+import OSLog
+import SwiftData
+
+private let logger = Logger(subsystem: "com.packrat.app", category: "migration")
+
+/// One-time cleanup of cached entities created by builds that minted local ids as
+/// `local-<uuid>` (packs, trips) and `local-item-<uuid>` (pack items).
+///
+/// Those ids were never valid server ids. Offline writes now use a plain lowercase
+/// UUID — the same scheme the server accepts on create — so a queued create lands
+/// as-is. Rows left on disk from the older scheme have no such path: they were never
+/// uploaded, and any edit or delete would queue a mutation keyed on an id the server
+/// answers 404 for, which `OutboxService.classify` marks terminal. The user would see
+/// permanent, unfixable sync failures with no way to clear them.
+///
+/// These rows are cache entries for entities the server has never seen, and nothing
+/// references them by id, so dropping them is safe and leaves the store consistent.
+/// Re-minting a fresh UUID and enqueuing a create was the alternative, but that would
+/// resurrect content the user may have deleted on another device and can't be
+/// reconciled without server state. Dropping is the conservative choice.
+enum LegacyLocalIDMigration {
+    /// Ids from the retired scheme all carry this prefix (`local-item-` included).
+    static let legacyPrefix = "local-"
+
+    /// True for an id minted by the retired local-id scheme.
+    static func isLegacy(_ id: String) -> Bool {
+        id.hasPrefix(legacyPrefix)
+    }
+
+    private static let defaultsKey = "legacyLocalIDMigrationCompleted"
+
+    /// Drops every cached pack, pack item, and trip still keyed on a `local-` id,
+    /// along with any queued mutation that targets one. Runs at most once per install.
+    ///
+    /// Idempotent regardless of the flag — a second run simply finds nothing.
+    static func runIfNeeded(context: ModelContext?, defaults: UserDefaults = .standard) {
+        guard let context, !defaults.bool(forKey: defaultsKey) else { return }
+        run(context: context)
+        defaults.set(true, forKey: defaultsKey)
+    }
+
+    /// The migration itself, without the run-once gate. Exposed for tests.
+    @discardableResult
+    static func run(context: ModelContext) -> Int {
+        var removed = 0
+
+        let packs = (try? context.fetch(FetchDescriptor<CachedPack>())) ?? []
+        for pack in packs where isLegacy(pack.id) {
+            context.delete(pack)
+            removed += 1
+        }
+
+        // Pack items are serialized inside `CachedPack.jsonData` rather than stored as
+        // their own rows, so legacy `local-item-` items go with their parent pack
+        // above. Items with legacy ids under a server-side pack are unreachable
+        // without re-encoding every cached pack; the next successful `load` overwrites
+        // that pack's cache from the server anyway.
+
+        let trips = (try? context.fetch(FetchDescriptor<CachedTrip>())) ?? []
+        for trip in trips where isLegacy(trip.id) {
+            context.delete(trip)
+            removed += 1
+        }
+
+        // Queued writes against a legacy id can only ever fail. Drop them too, so the
+        // user isn't left with failed pending writes they can't act on.
+        let mutations = (try? context.fetch(FetchDescriptor<PendingMutation>())) ?? []
+        for mutation in mutations
+        where isLegacy(mutation.entityId) || mutation.parentId.map(isLegacy) == true {
+            context.delete(mutation)
+            removed += 1
+        }
+
+        if removed > 0 {
+            try? context.save()
+            logger.info("Dropped \(removed, privacy: .public) cached rows using retired local- ids")
+        }
+        return removed
+    }
+}

--- a/apps/swift/Sources/PackRat/Persistence/LegacyLocalIDMigration.swift
+++ b/apps/swift/Sources/PackRat/Persistence/LegacyLocalIDMigration.swift
@@ -33,19 +33,34 @@ enum LegacyLocalIDMigration {
     /// Drops every cached pack, pack item, and trip still keyed on a `local-` id,
     /// along with any queued mutation that targets one. Runs at most once per install.
     ///
+    /// The flag is only set after a scan that completed — a failed fetch leaves it
+    /// clear so the next launch tries again. Setting it unconditionally would strand
+    /// the legacy rows on disk forever, which is the exact state this removes.
+    ///
     /// Idempotent regardless of the flag — a second run simply finds nothing.
     static func runIfNeeded(context: ModelContext?, defaults: UserDefaults = .standard) {
         guard let context, !defaults.bool(forKey: defaultsKey) else { return }
-        run(context: context)
-        defaults.set(true, forKey: defaultsKey)
+        if run(context: context) != nil {
+            defaults.set(true, forKey: defaultsKey)
+        }
     }
 
     /// The migration itself, without the run-once gate. Exposed for tests.
+    ///
+    /// Returns the number of rows removed, or `nil` if any fetch failed — in which
+    /// case the scan is incomplete and must not be recorded as done.
     @discardableResult
-    static func run(context: ModelContext) -> Int {
+    static func run(context: ModelContext) -> Int? {
+        guard let packs = try? context.fetch(FetchDescriptor<CachedPack>()),
+              let trips = try? context.fetch(FetchDescriptor<CachedTrip>()),
+              let mutations = try? context.fetch(FetchDescriptor<PendingMutation>())
+        else {
+            logger.error("Legacy local- id scan failed to read the store; will retry next launch")
+            return nil
+        }
+
         var removed = 0
 
-        let packs = (try? context.fetch(FetchDescriptor<CachedPack>())) ?? []
         for pack in packs where isLegacy(pack.id) {
             context.delete(pack)
             removed += 1
@@ -57,7 +72,6 @@ enum LegacyLocalIDMigration {
         // without re-encoding every cached pack; the next successful `load` overwrites
         // that pack's cache from the server anyway.
 
-        let trips = (try? context.fetch(FetchDescriptor<CachedTrip>())) ?? []
         for trip in trips where isLegacy(trip.id) {
             context.delete(trip)
             removed += 1
@@ -65,7 +79,6 @@ enum LegacyLocalIDMigration {
 
         // Queued writes against a legacy id can only ever fail. Drop them too, so the
         // user isn't left with failed pending writes they can't act on.
-        let mutations = (try? context.fetch(FetchDescriptor<PendingMutation>())) ?? []
         for mutation in mutations
         where isLegacy(mutation.entityId) || mutation.parentId.map(isLegacy) == true {
             context.delete(mutation)

--- a/apps/swift/Sources/PackRat/Persistence/PendingMutation.swift
+++ b/apps/swift/Sources/PackRat/Persistence/PendingMutation.swift
@@ -41,6 +41,15 @@ final class PendingMutation {
     /// response. Failed mutations stay in the store for the UI to surface rather
     /// than being dropped silently.
     var failed: Bool
+    /// Earliest time this mutation may be replayed again.
+    ///
+    /// `flush` runs on launch, on every connectivity change, and on every foreground —
+    /// events a user can trigger several times a second. Without a persisted floor, a
+    /// brief server outage would burn the whole retry budget in seconds and mark the
+    /// write permanently failed. Defaults to `.distantPast` so a freshly queued
+    /// mutation is eligible immediately, and so rows written by earlier builds
+    /// (which lack the column) migrate in as ready rather than never-eligible.
+    var nextAttemptAt: Date = Date.distantPast
 
     init(
         id: String = UUID().uuidString,
@@ -61,6 +70,7 @@ final class PendingMutation {
         self.attemptCount = 0
         self.lastError = nil
         self.failed = false
+        self.nextAttemptAt = .distantPast
     }
 
     var entityType: OutboxEntityType? { OutboxEntityType(rawValue: entityTypeRaw) }

--- a/apps/swift/Sources/PackRat/Services/OutboxService.swift
+++ b/apps/swift/Sources/PackRat/Services/OutboxService.swift
@@ -144,10 +144,29 @@ final class OutboxService {
         let queued = (try? context.fetch(descriptor)) ?? []
         guard !queued.isEmpty else { return false }
 
+        // Entity ids whose queued create has not landed this pass. A child sent before
+        // its parent exists server-side gets a 404, which `classify` marks terminal —
+        // so a transient parent failure would permanently fail the child.
+        var blockedParents = Set<String>()
+
         var didSync = false
         for mutation in queued {
             // Connectivity can drop mid-drain; stop and keep the rest queued.
             guard NetworkMonitor.shared.isConnected else { break }
+
+            if Self.shouldDefer(mutation, blockedParents: blockedParents) {
+                // Hold the child until the parent create succeeds. Match the parent's
+                // schedule rather than charging the child an attempt for someone
+                // else's failure.
+                if let parent = queued.first(where: {
+                    $0.entityId == mutation.parentId && $0.operation == .create
+                }) {
+                    mutation.nextAttemptAt = parent.nextAttemptAt
+                }
+                try? context.save()
+                continue
+            }
+
             let outcome = await apply(mutation)
             switch outcome {
             case .success:
@@ -167,23 +186,40 @@ final class OutboxService {
                 mutation.nextAttemptAt = Self.backoffDate(
                     attemptCount: mutation.attemptCount, from: Date()
                 )
+                if mutation.operation == .create { blockedParents.insert(mutation.entityId) }
             case .terminal(let message):
                 mutation.attemptCount += 1
                 mutation.lastError = message
                 mutation.failed = true
+                if mutation.operation == .create { blockedParents.insert(mutation.entityId) }
             }
             try? context.save()
         }
         return didSync
     }
 
-    /// When a retried mutation becomes eligible again: 2s, 4s, 8s, 16s, 32s.
+    /// Whether `mutation` must wait because the parent it belongs to has a queued
+    /// create that hasn't reached the server in this pass.
+    ///
+    /// Sending a child first draws a 404, which `classify` marks terminal — so a
+    /// transient parent failure would otherwise permanently fail the child.
+    static func shouldDefer(_ mutation: PendingMutation, blockedParents: Set<String>) -> Bool {
+        guard let parentId = mutation.parentId else { return false }
+        return blockedParents.contains(parentId)
+    }
+
+    /// When a retried mutation becomes eligible again: roughly 2s, 4s, 8s, 16s, 32s.
     ///
     /// Keyed off `attemptCount`, so an auth retry (which doesn't spend an attempt)
     /// still waits its current tier instead of spinning on every foreground.
+    ///
+    /// Up to 25% jitter is added on top. Without it every write failed by the same
+    /// outage becomes eligible at the same instant, and the next flush replays the
+    /// whole queue in one burst against a server that was just struggling.
     static func backoffDate(attemptCount: Int, from date: Date) -> Date {
         let exponent = min(max(attemptCount, 1), maxAttempts)
-        return date.addingTimeInterval(pow(2.0, Double(exponent)))
+        let base = pow(2.0, Double(exponent))
+        return date.addingTimeInterval(base + Double.random(in: 0...(base * 0.25)))
     }
 
     /// Clears mutations that gave up, after the user has acknowledged them.

--- a/apps/swift/Sources/PackRat/Services/OutboxService.swift
+++ b/apps/swift/Sources/PackRat/Services/OutboxService.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Observation
+import OSLog
 import SwiftData
+
+private let logger = Logger(subsystem: "com.packrat.app", category: "outbox")
 
 /// Drains queued offline writes to the server.
 ///
@@ -55,6 +58,17 @@ final class OutboxService {
     ) {
         guard let context else { return }
 
+        // A create or update with no payload can never replay — `decode` would throw
+        // `missingPayload` on flush and the write would be marked failed. That only
+        // happens if `encode` failed, which is already logged; refuse the row here so
+        // the queue never carries a mutation that is guaranteed to fail.
+        if operation != .delete, payload == nil {
+            logger.error(
+                "Refusing to queue \(operation.rawValue, privacy: .public) for \(entityType.rawValue, privacy: .public) with no payload"
+            )
+            return
+        }
+
         let existing = pendingMutations(for: entityId, context: context)
 
         switch operation {
@@ -63,6 +77,13 @@ final class OutboxService {
             // create + delete cancel out entirely.
             if existing.contains(where: { $0.operation == .create }) {
                 for mutation in existing { context.delete(mutation) }
+                // The parent never reached the server, so its queued children can
+                // never land either — their creates would replay against an id the
+                // server has no record of and be marked terminal. Drop them with the
+                // parent instead of surfacing failures for a pack the user deleted.
+                for child in childMutations(of: entityId, context: context) {
+                    context.delete(child)
+                }
                 saveAndRefresh(context)
                 return
             }
@@ -115,8 +136,9 @@ final class OutboxService {
             refreshCounts(context)
         }
 
+        let now = Date()
         var descriptor = FetchDescriptor<PendingMutation>(
-            predicate: #Predicate { !$0.failed }
+            predicate: #Predicate { !$0.failed && $0.nextAttemptAt <= now }
         )
         descriptor.sortBy = [SortDescriptor(\.createdAt, order: .forward)]
         let queued = (try? context.fetch(descriptor)) ?? []
@@ -131,12 +153,20 @@ final class OutboxService {
             case .success:
                 context.delete(mutation)
                 didSync = true
-            case .retry(let message):
-                mutation.attemptCount += 1
+            case .retry(let message, let chargesAttempt):
                 mutation.lastError = message
-                if mutation.attemptCount >= Self.maxAttempts {
-                    mutation.failed = true
+                // An expired session isn't the write's fault, so it doesn't spend the
+                // budget — otherwise a few foregrounds during a signed-out spell would
+                // permanently fail a write that only needed a re-auth.
+                if chargesAttempt {
+                    mutation.attemptCount += 1
+                    if mutation.attemptCount >= Self.maxAttempts {
+                        mutation.failed = true
+                    }
                 }
+                mutation.nextAttemptAt = Self.backoffDate(
+                    attemptCount: mutation.attemptCount, from: Date()
+                )
             case .terminal(let message):
                 mutation.attemptCount += 1
                 mutation.lastError = message
@@ -145,6 +175,15 @@ final class OutboxService {
             try? context.save()
         }
         return didSync
+    }
+
+    /// When a retried mutation becomes eligible again: 2s, 4s, 8s, 16s, 32s.
+    ///
+    /// Keyed off `attemptCount`, so an auth retry (which doesn't spend an attempt)
+    /// still waits its current tier instead of spinning on every foreground.
+    static func backoffDate(attemptCount: Int, from date: Date) -> Date {
+        let exponent = min(max(attemptCount, 1), maxAttempts)
+        return date.addingTimeInterval(pow(2.0, Double(exponent)))
     }
 
     /// Clears mutations that gave up, after the user has acknowledged them.
@@ -167,10 +206,12 @@ final class OutboxService {
 
     // MARK: - Replay
 
-    private enum Outcome {
+    enum Outcome: Equatable {
         case success
-        /// Transport-level failure — worth another attempt later.
-        case retry(String)
+        /// Transport-level failure — worth another attempt later. `chargesAttempt` is
+        /// false when the failure says nothing about the write itself (an expired
+        /// session), so it shouldn't consume the retry budget.
+        case retry(String, chargesAttempt: Bool = true)
         /// Server rejected the payload; retrying can't fix it.
         case terminal(String)
     }
@@ -276,13 +317,23 @@ final class OutboxService {
     }
 
     /// Decides whether a replay failure is worth retrying.
-    private func classify(_ error: Error, operation: OutboxOperation) -> Outcome {
+    func classify(_ error: Error, operation: OutboxOperation) -> Outcome {
         switch error {
         case PackRatError.httpError(let statusCode, let message):
             // The server already agrees with our intent.
             if operation == .delete, statusCode == 404 { return .success }
             if operation == .create, statusCode == 409 { return .success }
-            // 4xx means the request itself is wrong — retrying can't fix it.
+            // 401 can arrive as a raw status rather than `.unauthorized` when the body
+            // carries a message. Either way it's a session problem, not a bad payload.
+            if statusCode == 401 {
+                return .retry(message ?? "Sign-in required to sync", chargesAttempt: false)
+            }
+            // Rate limiting and request timeout are transient despite being 4xx —
+            // the payload is fine, the server just wants us to come back later.
+            if statusCode == 429 || statusCode == 408 {
+                return .retry(message ?? "Server is busy (\(statusCode))")
+            }
+            // Any other 4xx means the request itself is wrong — retrying can't fix it.
             if (400...499).contains(statusCode) {
                 return .terminal(message ?? "Server rejected the change (\(statusCode))")
             }
@@ -291,8 +342,9 @@ final class OutboxService {
         case PackRatError.notFound:
             return operation == .delete ? .success : .terminal("The item no longer exists on the server")
         case PackRatError.unauthorized:
-            // Keep queued: the write should survive a re-auth.
-            return .retry("Sign-in required to sync")
+            // Keep queued: the write should survive a re-auth, and waiting on the user
+            // to sign back in must not spend the retry budget.
+            return .retry("Sign-in required to sync", chargesAttempt: false)
         case PackRatError.decodingError:
             return .terminal("Could not read the server response")
         default:
@@ -303,6 +355,14 @@ final class OutboxService {
     private func decode<T: Decodable>(_ data: Data?) throws -> T {
         guard let data else { throw PackRatError.decodingError(OutboxError.missingPayload) }
         return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    /// Queued mutations belonging to `parentId` — pack items under their pack.
+    private func childMutations(of parentId: String, context: ModelContext) -> [PendingMutation] {
+        let descriptor = FetchDescriptor<PendingMutation>(
+            predicate: #Predicate { $0.parentId == parentId && !$0.failed }
+        )
+        return (try? context.fetch(descriptor)) ?? []
     }
 
     private func pendingMutations(for entityId: String, context: ModelContext) -> [PendingMutation] {
@@ -325,7 +385,19 @@ enum OutboxError: Error {
 
 extension OutboxService {
     /// Convenience for encoding a payload at the call site.
+    ///
+    /// The payload types are plain `Codable` structs, so this should never fail. If it
+    /// somehow does, log it rather than returning a silent `nil` — `enqueue` refuses a
+    /// payload-less create/update, so a swallowed error here would otherwise drop the
+    /// user's write with nothing to diagnose.
     static func encode<T: Encodable>(_ value: T) -> Data? {
-        try? JSONEncoder().encode(value)
+        do {
+            return try JSONEncoder().encode(value)
+        } catch {
+            logger.error(
+                "Failed to encode outbox payload for \(String(describing: T.self), privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
     }
 }

--- a/apps/swift/Sources/PackRat/Shared/OutboxFlushModifier.swift
+++ b/apps/swift/Sources/PackRat/Shared/OutboxFlushModifier.swift
@@ -11,7 +11,13 @@ private struct OutboxFlushModifier: ViewModifier {
     private var isConnected: Bool { NetworkMonitor.shared.isConnected }
 
     func body(content: Content) -> some View {
-        content
+        VStack(spacing: 0) {
+            // Queued and failed writes are otherwise invisible: an offline write
+            // succeeds locally and replays silently, so a server rejection would
+            // never reach the user.
+            PendingWritesBanner()
+            content
+        }
             .task {
                 outbox.refreshCounts(modelContext)
                 await outbox.flush(context: modelContext)

--- a/apps/swift/Sources/PackRat/Shared/PendingWritesBanner.swift
+++ b/apps/swift/Sources/PackRat/Shared/PendingWritesBanner.swift
@@ -1,0 +1,58 @@
+import SwiftData
+import SwiftUI
+
+/// Surfaces the outbox counters.
+///
+/// Offline writes succeed locally and replay in the background, so without this the
+/// only signal that a write never reached the server was `OutboxService.failedCount`,
+/// which nothing rendered. A write that the server rejected would disappear silently.
+///
+/// Reads the counters directly in `body` so `@Observable` tracking picks up changes.
+struct PendingWritesBanner: View {
+    @Environment(\.modelContext) private var modelContext
+
+    private var outbox: OutboxService { .shared }
+
+    var body: some View {
+        let failed = outbox.failedCount
+        let pending = outbox.pendingCount
+
+        if failed > 0 {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                Text(failed == 1
+                    ? "1 change couldn't be saved to the server"
+                    : "\(failed) changes couldn't be saved to the server")
+                    .font(.callout)
+                Spacer(minLength: 8)
+                Button("Dismiss") {
+                    outbox.discardFailed(context: modelContext)
+                }
+                .font(.callout.weight(.semibold))
+                .buttonStyle(.plain)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+            .background(.red.gradient)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        } else if pending > 0 {
+            HStack(spacing: 8) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.callout)
+                Text(pending == 1
+                    ? "1 change waiting to sync"
+                    : "\(pending) changes waiting to sync")
+                    .font(.callout)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+            .background(.gray.gradient)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+}

--- a/apps/swift/Sources/PackRat/Shared/PendingWritesBanner.swift
+++ b/apps/swift/Sources/PackRat/Shared/PendingWritesBanner.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// Reads the counters directly in `body` so `@Observable` tracking picks up changes.
 struct PendingWritesBanner: View {
     @Environment(\.modelContext) private var modelContext
+    @State private var showingDiscardConfirmation = false
 
     private var outbox: OutboxService { .shared }
 
@@ -26,11 +27,12 @@ struct PendingWritesBanner: View {
                     : "\(failed) changes couldn't be saved to the server")
                     .font(.callout)
                 Spacer(minLength: 8)
-                Button("Dismiss") {
-                    outbox.discardFailed(context: modelContext)
-                }
-                .font(.callout.weight(.semibold))
-                .buttonStyle(.plain)
+                // Discarding drops the writes for good, leaving local state
+                // permanently diverged from the server — so the label says what it
+                // does and the action is confirmed rather than one stray tap.
+                Button("Discard") { showingDiscardConfirmation = true }
+                    .font(.callout.weight(.semibold))
+                    .buttonStyle(.plain)
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 16)
@@ -38,6 +40,16 @@ struct PendingWritesBanner: View {
             .frame(maxWidth: .infinity)
             .background(.red.gradient)
             .transition(.move(edge: .top).combined(with: .opacity))
+            .alert("Discard unsaved changes?", isPresented: $showingDiscardConfirmation) {
+                Button("Discard", role: .destructive) {
+                    outbox.discardFailed(context: modelContext)
+                }
+                Button("Keep", role: .cancel) { }
+            } message: {
+                Text(failed == 1
+                    ? "1 change never reached the server. Discarding removes it for good — this device and the server will stay out of sync."
+                    : "\(failed) changes never reached the server. Discarding removes them for good — this device and the server will stay out of sync.")
+            }
         } else if pending > 0 {
             HStack(spacing: 8) {
                 Image(systemName: "arrow.triangle.2.circlepath")

--- a/apps/swift/Tests/PackRatTests/ErrorPresentationTests.swift
+++ b/apps/swift/Tests/PackRatTests/ErrorPresentationTests.swift
@@ -55,6 +55,26 @@ struct APIErrorBodyTests {
         let body = try decode(#"{"message":"","error":"","code":"RATE_LIMITED"}"#)
         #expect(body.displayMessage == "RATE_LIMITED")
     }
+
+    @Test("treats whitespace-only strings as absent")
+    func whitespaceOnlyIgnored() throws {
+        // A blank message used to win over the later fields, which suppressed the
+        // 401/404 fallback in validateStatus and rendered an empty banner.
+        let body = try decode(#"{"message":"   ","error":"\n\t","code":"RATE_LIMITED"}"#)
+        #expect(body.displayMessage == "RATE_LIMITED")
+    }
+
+    @Test("returns nil when every field is blank")
+    func allBlankFieldsYieldNil() throws {
+        let body = try decode(#"{"message":"  ","error":"","code":"   "}"#)
+        #expect(body.displayMessage == nil)
+    }
+
+    @Test("trims surrounding whitespace from a real message")
+    func trimsRealMessage() throws {
+        let body = try decode(#"{"message":"  Password too short  "}"#)
+        #expect(body.displayMessage == "Password too short")
+    }
 }
 
 // MARK: - Inline error copy

--- a/apps/swift/Tests/PackRatTests/OutboxTests.swift
+++ b/apps/swift/Tests/PackRatTests/OutboxTests.swift
@@ -1,0 +1,342 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import PackRat
+
+// Regression coverage for the offline write outbox. Each suite pins behaviour that
+// was wrong before: retries burning their budget without delay, an expired session
+// permanently failing a write, 429 treated as a bad payload, child item mutations
+// stranded by a cancelled parent create, and cached rows from the retired `local-`
+// id scheme queueing writes the server can only reject.
+
+// MARK: - Retry classification
+
+@Suite("OutboxService.classify")
+@MainActor
+struct OutboxClassifyTests {
+    private let outbox = OutboxService()
+
+    @Test("429 retries rather than failing the write")
+    func rateLimitRetries() {
+        let outcome = outbox.classify(
+            PackRatError.httpError(statusCode: 429, message: nil), operation: .create
+        )
+        #expect(outcome == .retry("Server is busy (429)", chargesAttempt: true))
+    }
+
+    @Test("408 retries rather than failing the write")
+    func requestTimeoutRetries() {
+        let outcome = outbox.classify(
+            PackRatError.httpError(statusCode: 408, message: nil), operation: .update
+        )
+        #expect(outcome == .retry("Server is busy (408)", chargesAttempt: true))
+    }
+
+    @Test("401 retries without spending an attempt")
+    func unauthorizedStatusIsAttemptFree() {
+        let outcome = outbox.classify(
+            PackRatError.httpError(statusCode: 401, message: nil), operation: .create
+        )
+        #expect(outcome == .retry("Sign-in required to sync", chargesAttempt: false))
+    }
+
+    @Test("PackRatError.unauthorized retries without spending an attempt")
+    func unauthorizedErrorIsAttemptFree() {
+        let outcome = outbox.classify(PackRatError.unauthorized, operation: .create)
+        #expect(outcome == .retry("Sign-in required to sync", chargesAttempt: false))
+    }
+
+    @Test("other 4xx stays terminal")
+    func badRequestIsTerminal() {
+        let outcome = outbox.classify(
+            PackRatError.httpError(statusCode: 400, message: "Bad name"), operation: .create
+        )
+        #expect(outcome == .terminal("Bad name"))
+    }
+
+    @Test("5xx retries and spends an attempt")
+    func serverErrorRetries() {
+        let outcome = outbox.classify(
+            PackRatError.httpError(statusCode: 503, message: nil), operation: .create
+        )
+        #expect(outcome == .retry("Server error (503)", chargesAttempt: true))
+    }
+
+    @Test("the server already agreeing counts as success")
+    func idempotentResponsesSucceed() {
+        #expect(outbox.classify(
+            PackRatError.httpError(statusCode: 404, message: nil), operation: .delete
+        ) == .success)
+        #expect(outbox.classify(
+            PackRatError.httpError(statusCode: 409, message: nil), operation: .create
+        ) == .success)
+    }
+}
+
+// MARK: - Backoff
+
+@Suite("OutboxService backoff")
+@MainActor
+struct OutboxBackoffTests {
+    @Test("delay grows with each attempt")
+    func delayGrows() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let first = OutboxService.backoffDate(attemptCount: 1, from: now)
+        let second = OutboxService.backoffDate(attemptCount: 2, from: now)
+        let third = OutboxService.backoffDate(attemptCount: 3, from: now)
+
+        #expect(first.timeIntervalSince(now) == 2)
+        #expect(second.timeIntervalSince(now) == 4)
+        #expect(third.timeIntervalSince(now) == 8)
+    }
+
+    @Test("a zero attempt count still waits, so an auth retry can't spin")
+    func attemptFreeRetryStillWaits() {
+        // An auth failure doesn't increment attemptCount. Without a floor the mutation
+        // would be eligible again on the very next foreground.
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        #expect(OutboxService.backoffDate(attemptCount: 0, from: now).timeIntervalSince(now) == 2)
+    }
+
+    @Test("delay is capped at the retry ceiling")
+    func delayIsCapped() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let capped = OutboxService.backoffDate(attemptCount: 99, from: now)
+        let atMax = OutboxService.backoffDate(attemptCount: OutboxService.maxAttempts, from: now)
+        #expect(capped == atMax)
+    }
+
+    @Test("a new mutation is eligible immediately")
+    func freshMutationIsEligible() {
+        let mutation = PendingMutation(entityType: .pack, entityId: "p1", operation: .delete)
+        #expect(mutation.nextAttemptAt == .distantPast)
+    }
+}
+
+// MARK: - Enqueue collapsing
+
+@Suite("OutboxService.enqueue")
+@MainActor
+struct OutboxEnqueueTests {
+    /// In-memory store so each test gets a clean queue.
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: PendingMutation.self, CachedPack.self, CachedTrip.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func mutations(_ context: ModelContext) -> [PendingMutation] {
+        (try? context.fetch(FetchDescriptor<PendingMutation>())) ?? []
+    }
+
+    private func payload() -> Data? {
+        OutboxService.encode(PackMutationPayload(
+            name: "Trip pack", description: nil, category: nil, isPublic: false
+        ))
+    }
+
+    @Test("deleting a never-synced pack drops its queued child items")
+    func parentCancellationCascades() throws {
+        let context = try makeContext()
+        let outbox = OutboxService()
+
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .create,
+            payload: payload(), context: context
+        )
+        outbox.enqueue(
+            entityType: .packItem, entityId: "item-1", operation: .create,
+            parentId: "pack-1",
+            payload: OutboxService.encode(PackItemMutationPayload(
+                name: "Tent", weight: nil, weightUnit: nil, quantity: nil,
+                category: nil, consumable: false, worn: false, notes: nil
+            )),
+            context: context
+        )
+        #expect(mutations(context).count == 2)
+
+        // The pack was never created server-side, so the item create can never land.
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .delete, context: context
+        )
+
+        #expect(mutations(context).isEmpty)
+        #expect(outbox.pendingCount == 0)
+    }
+
+    @Test("cancelling one pack leaves another pack's items alone")
+    func cascadeIsScopedToTheParent() throws {
+        let context = try makeContext()
+        let outbox = OutboxService()
+
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .create,
+            payload: payload(), context: context
+        )
+        outbox.enqueue(
+            entityType: .packItem, entityId: "item-2", operation: .delete,
+            parentId: "pack-2", context: context
+        )
+
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .delete, context: context
+        )
+
+        let remaining = mutations(context)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.entityId == "item-2")
+    }
+
+    @Test("a create/update with no payload is refused rather than queued to fail")
+    func payloadlessWriteIsRefused() throws {
+        let context = try makeContext()
+        let outbox = OutboxService()
+
+        // Only reachable if encoding failed. Such a row could never replay — decode
+        // would throw missingPayload and the write would be marked failed.
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .create,
+            payload: nil, context: context
+        )
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-2", operation: .update,
+            payload: nil, context: context
+        )
+
+        #expect(mutations(context).isEmpty)
+    }
+
+    @Test("a delete still queues without a payload")
+    func deleteNeedsNoPayload() throws {
+        let context = try makeContext()
+        let outbox = OutboxService()
+
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .delete, context: context
+        )
+
+        #expect(mutations(context).count == 1)
+    }
+
+    @Test("consecutive updates collapse to the latest payload")
+    func updatesCollapse() throws {
+        let context = try makeContext()
+        let outbox = OutboxService()
+
+        let first = OutboxService.encode(PackMutationPayload(
+            name: "First", description: nil, category: nil, isPublic: false
+        ))
+        let second = OutboxService.encode(PackMutationPayload(
+            name: "Second", description: nil, category: nil, isPublic: false
+        ))
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .update,
+            payload: first, context: context
+        )
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .update,
+            payload: second, context: context
+        )
+
+        let remaining = mutations(context)
+        #expect(remaining.count == 1)
+        let decoded = remaining.first?.payload.flatMap {
+            try? JSONDecoder().decode(PackMutationPayload.self, from: $0)
+        }
+        #expect(decoded?.name == "Second")
+    }
+}
+
+// MARK: - Legacy local id migration
+
+@Suite("LegacyLocalIDMigration")
+@MainActor
+struct LegacyLocalIDMigrationTests {
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: PendingMutation.self, CachedPack.self, CachedTrip.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func makePack(id: String) -> Pack {
+        Pack(
+            id: id, userId: nil, name: "Pack", description: nil, category: nil,
+            isPublic: false, image: nil, tags: nil, templateId: nil,
+            deleted: false, isAIGenerated: false, items: [],
+            totalWeight: 0, baseWeight: 0, wornWeight: 0, consumableWeight: 0,
+            createdAt: Date.iso8601Now(), updatedAt: Date.iso8601Now()
+        )
+    }
+
+    @Test("recognises ids from the retired scheme")
+    func detectsLegacyIds() {
+        #expect(LegacyLocalIDMigration.isLegacy("local-ABC"))
+        #expect(LegacyLocalIDMigration.isLegacy("local-item-ABC"))
+        #expect(!LegacyLocalIDMigration.isLegacy(UUID().uuidString.lowercased()))
+    }
+
+    @Test("drops cached packs and their queued writes")
+    func dropsLegacyPacks() throws {
+        let context = try makeContext()
+        context.insert(CachedPack(from: makePack(id: "local-old-pack")))
+        context.insert(CachedPack(from: makePack(id: "11111111-2222-3333-4444-555555555555")))
+        context.insert(PendingMutation(
+            entityType: .pack, entityId: "local-old-pack", operation: .delete
+        ))
+        // A child item under the legacy pack — its parentId is just as unusable.
+        context.insert(PendingMutation(
+            entityType: .packItem, entityId: "local-item-9", operation: .delete,
+            parentId: "local-old-pack"
+        ))
+        try context.save()
+
+        LegacyLocalIDMigration.run(context: context)
+
+        let packs = (try? context.fetch(FetchDescriptor<CachedPack>())) ?? []
+        #expect(packs.count == 1)
+        #expect(packs.first?.id == "11111111-2222-3333-4444-555555555555")
+        #expect(((try? context.fetch(FetchDescriptor<PendingMutation>())) ?? []).isEmpty)
+    }
+
+    @Test("leaves a clean store untouched")
+    func noOpOnCleanStore() throws {
+        let context = try makeContext()
+        context.insert(CachedPack(from: makePack(id: "11111111-2222-3333-4444-555555555555")))
+        try context.save()
+
+        #expect(LegacyLocalIDMigration.run(context: context) == 0)
+        #expect(((try? context.fetch(FetchDescriptor<CachedPack>())) ?? []).count == 1)
+    }
+
+    @Test("is idempotent")
+    func isIdempotent() throws {
+        let context = try makeContext()
+        context.insert(CachedPack(from: makePack(id: "local-old-pack")))
+        try context.save()
+
+        #expect(LegacyLocalIDMigration.run(context: context) == 1)
+        #expect(LegacyLocalIDMigration.run(context: context) == 0)
+    }
+
+    @Test("runs only once per install")
+    func runsOnceViaFlag() throws {
+        let context = try makeContext()
+        let defaults = UserDefaults(suiteName: "LegacyLocalIDMigrationTests-\(UUID().uuidString)")!
+        context.insert(CachedPack(from: makePack(id: "local-old-pack")))
+        try context.save()
+
+        LegacyLocalIDMigration.runIfNeeded(context: context, defaults: defaults)
+        #expect(((try? context.fetch(FetchDescriptor<CachedPack>())) ?? []).isEmpty)
+
+        // A legacy row written after the flag is set is not re-scanned — the retired
+        // scheme can't produce new ids, so one pass is enough.
+        context.insert(CachedPack(from: makePack(id: "local-another")))
+        try context.save()
+        LegacyLocalIDMigration.runIfNeeded(context: context, defaults: defaults)
+        #expect(((try? context.fetch(FetchDescriptor<CachedPack>())) ?? []).count == 1)
+    }
+}

--- a/apps/swift/Tests/PackRatTests/OutboxTests.swift
+++ b/apps/swift/Tests/PackRatTests/OutboxTests.swift
@@ -78,16 +78,24 @@ struct OutboxClassifyTests {
 @Suite("OutboxService backoff")
 @MainActor
 struct OutboxBackoffTests {
+    // Delays carry up to 25% jitter, so each tier spans [base, base * 1.25].
+    private func expectedRange(base: Double) -> ClosedRange<Double> {
+        base...(base * 1.25)
+    }
+
     @Test("delay grows with each attempt")
     func delayGrows() {
         let now = Date(timeIntervalSince1970: 1_000_000)
-        let first = OutboxService.backoffDate(attemptCount: 1, from: now)
-        let second = OutboxService.backoffDate(attemptCount: 2, from: now)
-        let third = OutboxService.backoffDate(attemptCount: 3, from: now)
+        let first = OutboxService.backoffDate(attemptCount: 1, from: now).timeIntervalSince(now)
+        let second = OutboxService.backoffDate(attemptCount: 2, from: now).timeIntervalSince(now)
+        let third = OutboxService.backoffDate(attemptCount: 3, from: now).timeIntervalSince(now)
 
-        #expect(first.timeIntervalSince(now) == 2)
-        #expect(second.timeIntervalSince(now) == 4)
-        #expect(third.timeIntervalSince(now) == 8)
+        #expect(expectedRange(base: 2).contains(first))
+        #expect(expectedRange(base: 4).contains(second))
+        #expect(expectedRange(base: 8).contains(third))
+        // Tiers stay ordered despite jitter: 2 * 1.25 < 4, 4 * 1.25 < 8.
+        #expect(first < second)
+        #expect(second < third)
     }
 
     @Test("a zero attempt count still waits, so an auth retry can't spin")
@@ -95,21 +103,68 @@ struct OutboxBackoffTests {
         // An auth failure doesn't increment attemptCount. Without a floor the mutation
         // would be eligible again on the very next foreground.
         let now = Date(timeIntervalSince1970: 1_000_000)
-        #expect(OutboxService.backoffDate(attemptCount: 0, from: now).timeIntervalSince(now) == 2)
+        let delay = OutboxService.backoffDate(attemptCount: 0, from: now).timeIntervalSince(now)
+        #expect(expectedRange(base: 2).contains(delay))
     }
 
     @Test("delay is capped at the retry ceiling")
     func delayIsCapped() {
         let now = Date(timeIntervalSince1970: 1_000_000)
-        let capped = OutboxService.backoffDate(attemptCount: 99, from: now)
-        let atMax = OutboxService.backoffDate(attemptCount: OutboxService.maxAttempts, from: now)
-        #expect(capped == atMax)
+        let ceiling = pow(2.0, Double(OutboxService.maxAttempts))
+        // Beyond maxAttempts the tier stops growing, jitter aside.
+        let capped = OutboxService.backoffDate(attemptCount: 99, from: now).timeIntervalSince(now)
+        #expect(expectedRange(base: ceiling).contains(capped))
+    }
+
+    @Test("jitter spreads a burst of same-tier retries")
+    func jitterSpreadsRetries() {
+        // Without jitter every write failed by one outage becomes eligible at the same
+        // instant and the next flush replays the whole queue at once.
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let delays = Set((0..<50).map {
+            _ in OutboxService.backoffDate(attemptCount: 3, from: now).timeIntervalSince(now)
+        })
+        #expect(delays.count > 1)
     }
 
     @Test("a new mutation is eligible immediately")
     func freshMutationIsEligible() {
         let mutation = PendingMutation(entityType: .pack, entityId: "p1", operation: .delete)
         #expect(mutation.nextAttemptAt == .distantPast)
+    }
+}
+
+// MARK: - Parent/child ordering
+
+@Suite("OutboxService child deferral")
+@MainActor
+struct OutboxChildDeferralTests {
+    @Test("a child waits while its parent create is unsent")
+    func childDefersToBlockedParent() {
+        // Sending the item before the pack exists server-side draws a 404, which
+        // classify marks terminal — a transient parent failure would otherwise
+        // permanently fail the child.
+        let child = PendingMutation(
+            entityType: .packItem, entityId: "item-1", operation: .create,
+            parentId: "pack-1"
+        )
+        #expect(OutboxService.shouldDefer(child, blockedParents: ["pack-1"]))
+    }
+
+    @Test("a child proceeds once its parent is no longer blocked")
+    func childProceedsWhenParentLanded() {
+        let child = PendingMutation(
+            entityType: .packItem, entityId: "item-1", operation: .create,
+            parentId: "pack-1"
+        )
+        #expect(!OutboxService.shouldDefer(child, blockedParents: []))
+        #expect(!OutboxService.shouldDefer(child, blockedParents: ["pack-2"]))
+    }
+
+    @Test("a parentless mutation is never deferred")
+    func parentlessNeverDefers() {
+        let pack = PendingMutation(entityType: .pack, entityId: "pack-1", operation: .create)
+        #expect(!OutboxService.shouldDefer(pack, blockedParents: ["pack-1"]))
     }
 }
 
@@ -247,6 +302,34 @@ struct OutboxEnqueueTests {
         }
         #expect(decoded?.name == "Second")
     }
+
+    @Test("an update folds into a queued create")
+    func updateFoldsIntoCreate() throws {
+        let context = try makeContext()
+        let outbox = OutboxService()
+
+        // Decides whether an offline-created entity reaches the server with its final
+        // values in one request, rather than as a create followed by an update.
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .create,
+            payload: payload(), context: context
+        )
+        outbox.enqueue(
+            entityType: .pack, entityId: "pack-1", operation: .update,
+            payload: OutboxService.encode(PackMutationPayload(
+                name: "Renamed", description: nil, category: nil, isPublic: false
+            )),
+            context: context
+        )
+
+        let remaining = mutations(context)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.operation == .create)
+        let decoded = remaining.first?.payload.flatMap {
+            try? JSONDecoder().decode(PackMutationPayload.self, from: $0)
+        }
+        #expect(decoded?.name == "Renamed")
+    }
 }
 
 // MARK: - Legacy local id migration
@@ -338,5 +421,29 @@ struct LegacyLocalIDMigrationTests {
         try context.save()
         LegacyLocalIDMigration.runIfNeeded(context: context, defaults: defaults)
         #expect(((try? context.fetch(FetchDescriptor<CachedPack>())) ?? []).count == 1)
+    }
+
+    @Test("a completed scan reports a count rather than nil")
+    func completedScanReportsCount() throws {
+        // runIfNeeded gates the completion flag on this being non-nil, so a scan that
+        // read the store must be distinguishable from one that couldn't.
+        let context = try makeContext()
+        context.insert(CachedPack(from: makePack(id: "local-old-pack")))
+        try context.save()
+
+        #expect(LegacyLocalIDMigration.run(context: context) != nil)
+    }
+
+    @Test("the flag is not set when nothing was scanned yet")
+    func flagUnsetBeforeFirstRun() throws {
+        let context = try makeContext()
+        let defaults = UserDefaults(suiteName: "LegacyLocalIDMigrationTests-\(UUID().uuidString)")!
+        context.insert(CachedPack(from: makePack(id: "local-old-pack")))
+        try context.save()
+
+        #expect(!defaults.bool(forKey: "legacyLocalIDMigrationCompleted"))
+        LegacyLocalIDMigration.runIfNeeded(context: context, defaults: defaults)
+        // Set only after the scan completed, so a failed read retries next launch.
+        #expect(defaults.bool(forKey: "legacyLocalIDMigrationCompleted"))
     }
 }


### PR DESCRIPTION
Addresses the eight still-open CodeRabbit findings on #2685.

#2685 is the `development` → `main` release PR. Two of its ten review comments (the `/support` email and the MCP `nextOffset`) were already fixed on `development` by e628815, which explicitly deferred the rest: *"The remaining CodeRabbit findings are on the Swift outbox/APIClient work from other PRs in this release and are left to those authors."* All eight were re-verified against current code — every one still held.

## The two that mattered most

**Retries had no backoff.** `flush` runs at launch, on every connectivity change, and on every foreground. Nothing recorded when the next attempt was allowed, so a brief 5xx outage plus a few app switches drove `attemptCount` to `maxAttempts` in seconds and marked the write permanently failed. `PendingMutation` now persists `nextAttemptAt`, the fetch is gated on it, and retries back off 2s/4s/8s/16s/32s. It defaults to `.distantPast` so both fresh rows and rows written by earlier builds are eligible immediately.

**An expired session burned the retry budget.** `classify` returned `.retry` with the comment *"the write should survive a re-auth"* — then charged an attempt anyway. Five foregrounds while signed out permanently failed the write, the opposite of the stated intent. `Outcome.retry` now carries `chargesAttempt`; the auth paths pass `false`. It still takes a backoff tier, so it can't spin.

## The rest

- **429 and 408 were terminal** via the blanket `400...499` branch. Both are transient — the payload is fine. A `401` arriving as a raw `httpError` (which happens when the body carries a message, rather than as `.unauthorized`) now takes the attempt-free auth path too.
- **Cancelling a queued parent create stranded its children.** `pendingMutations` matches on `entityId` only, so deleting a pack whose create was still queued left `.packItem` rows carrying `parentId == packId`. Those replayed against an id the server never received, 404'd, and surfaced as failed writes for a pack the user had deleted. Now cascaded via a `childMutations` lookup.
- **A failed encode queued an unreplayable write.** `encode` swallowed the error and returned `nil`; `enqueue` inserted a payload-less create, `decode` threw `missingPayload` on flush, and the write was marked failed with the original error gone. Now logged, and `enqueue` refuses a payload-less create/update.
- **Cached rows using the retired `local-` id scheme had no reconciliation path.** Local ids became plain UUIDs, but rows already on disk kept `local-<uuid>` / `local-item-<uuid>`. They were never uploaded, and any edit or delete queued a mutation the server 404s — which `classify` marks terminal, giving upgrading users permanent, unfixable sync failures. `LegacyLocalIDMigration` drops those cached packs/trips and any mutation keyed on one, once per install, at cache load.
- **Four mutation methods kept `async throws`** but routed every error into the outbox, so caller `catch` blocks were unreachable and a server rejection was invisible at the call site. Dropped `throws` from `createPack`/`deletePack`/`createTrip`/`deleteTrip` and updated the four callers, including the redundant `try?` in `TripsListView`.
- **Nothing rendered `OutboxService.failedCount`.** It and `pendingCount` were computed but read by zero views, so a rejected write was silently invisible — which is what made the unreachable-`catch` finding actually matter. `PendingWritesBanner` surfaces both, attached via the modifier that already drives the flush.
- **`APIErrorBody.displayMessage` treated `"   "` as a real message**, suppressing the 401/404 fallback in `validateStatus` and rendering a banner `InlineErrorView` then trimmed to nothing. Each candidate is trimmed before testing.

## Judgment calls

**Dropping legacy rows rather than re-minting them.** These are cache entries the server has never seen, and re-creating them under fresh UUIDs could resurrect content the user deleted on another device — it can't be reconciled without server state. Reasoning is in the file's doc comment if the other tradeoff is preferred. Pack items live inside `CachedPack.jsonData` rather than as their own rows, so they go with their parent.

## Testing

New `OutboxTests` covers classification, backoff, the cascade, the payload-less refusal, update collapsing, and the migration. `ErrorPresentationTests` gains the whitespace regression cases the review asked for.

macOS build succeeds and the test target compiles. 192 unit tests ran, all passing except a pre-existing `KeychainService` failure that reads a real token from the login keychain — it fails identically on unmodified `development`.

Two environment caveats: the `xcodebuild test` runner could not launch locally (`"hung before establishing connection"`, plus a system-authentication prompt for the UI runner). Both reproduce on unmodified `development`, so the bundle was run directly as a workaround — **CI on a proper runner is the authoritative check here.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a pending-sync banner showing queued or failed offline changes, with an option to discard failed writes.
  - Improved automatic retry handling for temporary failures, rate limits, authentication issues, and timeouts.
  - Added cleanup for legacy cached records and queued changes.

- **Bug Fixes**
  - Pack and trip changes now reliably queue for later synchronization when offline.
  - Improved handling of blank or whitespace-only server error messages.
  - Prevented invalid queued operations and cleaned up related child changes when deleting unsynced items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->