### PR TITLE
fix(swift): resolve seven reported iOS defects across weather, packs, trips, and catalog search

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -241,10 +241,13 @@ struct PackDetailView: View {
 
     private var weightSummary: some View {
         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
-            weightCard("Total", value: pack.totalWeight, color: .blue)
-            weightCard("Base", value: pack.baseWeight, color: .green)
-            weightCard("Worn", value: pack.wornWeight, color: .orange)
-            weightCard("Consumable", value: pack.consumableWeight, color: .purple)
+            // `currentPack`, not the captured `pack`: the latter is a stale snapshot
+            // from when the view was pushed, so totals kept showing weights for items
+            // the live pack no longer has (empty list next to a non-zero total).
+            weightCard("Total", value: currentPack.totalWeight, color: .blue)
+            weightCard("Base", value: currentPack.baseWeight, color: .green)
+            weightCard("Worn", value: currentPack.wornWeight, color: .orange)
+            weightCard("Consumable", value: currentPack.consumableWeight, color: .purple)
         }
     }
 

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemDetailView.swift
@@ -2,13 +2,31 @@ import SwiftUI
 import NukeUI
 
 struct PackItemDetailView: View {
-    let item: PackItem
+    private let initialItem: PackItem
     let packId: String
-    let viewModel: PacksViewModel
+    @Bindable var viewModel: PacksViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showingEdit = false
     @State private var similarItems: [CatalogItem] = []
     @State private var isLoadingSimilar = false
+
+    init(item: PackItem, packId: String, viewModel: PacksViewModel) {
+        self.initialItem = item
+        self.packId = packId
+        self.viewModel = viewModel
+    }
+
+    /// Re-reads the item from the view model so edits made in the sheet are
+    /// reflected here on dismiss. `initialItem` is only a snapshot from when
+    /// this view was constructed, so rendering it directly left the detail
+    /// screen showing the pre-edit weight after saving.
+    private var item: PackItem {
+        viewModel.packs
+            .first { $0.id == packId }?
+            .activeItems
+            .first { $0.id == initialItem.id }
+            ?? initialItem
+    }
 
     var body: some View {
         NavigationStack {
@@ -37,6 +55,8 @@ struct PackItemDetailView: View {
                 }
             }
             .sheet(isPresented: $showingEdit) {
+                // `item`, not `initialItem`: re-opening Edit must prefill from the
+                // latest values, not the snapshot this view was created with.
                 PackItemFormView(packId: packId, viewModel: viewModel, existingItem: item)
             }
         }
@@ -264,7 +284,7 @@ struct PackItemDetailView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 12) {
                         ForEach(similarItems) { catalogItem in
-                            SimilarItemCard(item: catalogItem)
+                            SimilarItemCard(item: catalogItem, packsViewModel: viewModel)
                         }
                     }
                     .padding(.horizontal)
@@ -289,8 +309,21 @@ struct PackItemDetailView: View {
 
 private struct SimilarItemCard: View {
     let item: CatalogItem
+    let packsViewModel: PacksViewModel
+    @State private var showingDetail = false
 
     var body: some View {
+        cardContent
+            .contentShape(Rectangle())
+            .onTapGesture { showingDetail = true }
+            .accessibilityIdentifier("pack_item_similar_card_\(item.id)")
+            .accessibilityAddTraits(.isButton)
+            .sheet(isPresented: $showingDetail) {
+                CatalogItemDetailView(item: item, packsViewModel: packsViewModel)
+            }
+    }
+
+    private var cardContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -158,8 +158,16 @@ struct PacksListView: View {
         }
     }
 
+    /// Compact iOS navigates by pushing from `packRow`'s `NavigationLink`, so the
+    /// list must not also track a selection — the tapped row would stay rendered
+    /// in its selected (gray) state after the pop back. Selection is only
+    /// meaningful on the split-view layouts, where it drives the detail pane.
+    private var listSelection: Binding<String?>? {
+        isCompact ? nil : $selectedId
+    }
+
     private var packList: some View {
-        List(displayedPacks, selection: $selectedId) { pack in
+        List(displayedPacks, selection: listSelection) { pack in
             packRow(pack)
                 .contextMenu {
                     #if os(macOS)

--- a/apps/swift/Sources/PackRat/Features/Weather/WeatherView.swift
+++ b/apps/swift/Sources/PackRat/Features/Weather/WeatherView.swift
@@ -28,9 +28,15 @@ struct WeatherView: View {
                 )
             } else {
                 List {
-                    searchStateContent
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
+                    // Only add the search row when it actually has something to
+                    // show. An unconditional row still reserves inset-grouped row
+                    // height and padding while empty, which rendered as a large
+                    // blank gap between the search field and Saved Locations.
+                    if hasSearchStateContent {
+                        searchStateContent
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                    }
 
                     if !viewModel.savedLocations.isEmpty && viewModel.searchText.isEmpty && viewModel.searchResults.isEmpty {
                         savedLocationsSection
@@ -139,6 +145,12 @@ struct WeatherView: View {
     }
 
     // MARK: - Search
+
+    /// Mirrors the three branches inside `searchStateContent`; when none of them
+    /// would render, the row is omitted entirely rather than left empty.
+    private var hasSearchStateContent: Bool {
+        viewModel.isSearching || !viewModel.searchResults.isEmpty || viewModel.searchError != nil
+    }
 
     private var searchStateContent: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/apps/swift/Sources/PackRat/Models/Trip.swift
+++ b/apps/swift/Sources/PackRat/Models/Trip.swift
@@ -33,6 +33,28 @@ struct UpdateTripRequest: Encodable {
     let notes: String?
     let packId: String?
     let localUpdatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case name, description, location, startDate, endDate, notes, packId, localUpdatedAt
+    }
+
+    /// `packId` is encoded unconditionally — as an explicit `null` when the user
+    /// picks "None" — because the update route distinguishes the two cases with
+    /// `if ('packId' in data)`. Synthesised `Encodable` omits nil keys entirely,
+    /// which the server read as "leave unchanged", so unassigning a pack never
+    /// saved. Every other field keeps omit-when-nil so a partial update does not
+    /// clobber fields the form did not touch.
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encodeIfPresent(startDate, forKey: .startDate)
+        try container.encodeIfPresent(endDate, forKey: .endDate)
+        try container.encodeIfPresent(notes, forKey: .notes)
+        try container.encode(packId, forKey: .packId)
+        try container.encode(localUpdatedAt, forKey: .localUpdatedAt)
+    }
 }
 
 struct TripLocationBody: Encodable {

--- a/packages/api/src/services/catalogService.ts
+++ b/packages/api/src/services/catalogService.ts
@@ -111,17 +111,60 @@ export class CatalogService {
     }
 
     const conditions: SQL[] = [];
+    // Relevance score for a `q` search. Null when not searching, in which case
+    // ordering falls back to popularity as before.
+    //
+    // Two problems this addresses (see issue #2662, "Tent" returning leggings
+    // and tote bags above actual tents):
+    //
+    //  1. Unanchored `ilike '%tent%'` matches the letters anywhere, including
+    //     inside unrelated words — "consistent", "content", "intent", "patent"
+    //     — which appear constantly in marketing copy. Free-text fields now
+    //     require a word-boundary match (`\mtent\M`) instead of a substring,
+    //     so incidental hits inside longer words no longer qualify at all.
+    //     Short/structured fields (brand, model, sku) keep substring matching,
+    //     where partial typing is the normal way to search.
+    //
+    //  2. Nothing ranked by the query — results were ordered purely by how
+    //     often an item had been added to packs, so a popular pair of leggings
+    //     that matched incidentally outranked an exact-name tent. Matches are
+    //     now tiered by *where* they hit, with popularity kept only as a
+    //     tiebreaker within a tier.
+    let relevance: SQL | null = null;
     if (q) {
+      const term = q.trim();
+      // Escape regex metacharacters: `q` is user input and reaches a POSIX
+      // regex operator below, where an unescaped `(` or `*` would either error
+      // or silently change the match semantics.
+      const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      // `\m` / `\M` are POSIX word-boundary escapes (start/end of word).
+      const wordBoundary = `\\m${escaped}\\M`;
+      const nameWord = sql`${catalogItems.name} ~* ${wordBoundary}`;
+      const descriptionWord = sql`COALESCE(${catalogItems.description}, '') ~* ${wordBoundary}`;
+      const categoriesWord = sql`${catalogItems.categories}::text ~* ${wordBoundary}`;
+
       const searchCondition = or(
-        ilike(catalogItems.name, `%${q}%`),
-        ilike(catalogItems.description, `%${q}%`),
-        ilike(catalogItems.brand, `%${q}%`),
-        ilike(catalogItems.model, `%${q}%`),
-        ilike(sql`${catalogItems.categories}::text`, `%${q}%`),
+        nameWord,
+        descriptionWord,
+        categoriesWord,
+        ilike(catalogItems.brand, `%${term}%`),
+        ilike(catalogItems.model, `%${term}%`),
       );
       if (searchCondition) {
         conditions.push(searchCondition);
       }
+
+      // Higher is better. Exact name beats name-prefix beats name-word, all of
+      // which beat a category match, which beats brand/model, which beats a
+      // mention buried in the description.
+      relevance = sql`(CASE
+        WHEN lower(${catalogItems.name}) = lower(${term}) THEN 100
+        WHEN ${catalogItems.name} ~* ${`^${escaped}\\M`} THEN 80
+        WHEN ${nameWord} THEN 60
+        WHEN ${categoriesWord} THEN 40
+        WHEN ${catalogItems.brand} ILIKE ${`%${term}%`} OR ${catalogItems.model} ILIKE ${`%${term}%`} THEN 20
+        ELSE 0
+      END)`;
     }
 
     if (category) {
@@ -130,8 +173,11 @@ export class CatalogService {
 
     const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-    // Build orderBy clause with usage as default
-    let orderBy = [desc(sql`COALESCE(pack_item_counts.count, 0)`), desc(catalogItems.id)]; // default ordering by usage
+    // Build orderBy clause: relevance first when searching, else usage.
+    // An explicit `sort` from the caller still wins over both.
+    let orderBy = relevance
+      ? [desc(relevance), desc(sql`COALESCE(pack_item_counts.count, 0)`), desc(catalogItems.id)]
+      : [desc(sql`COALESCE(pack_item_counts.count, 0)`), desc(catalogItems.id)]; // default ordering by usage
     if (sort) {
       const { field, order } = sort;
       // All branches include `desc(catalogItems.id)` as a tiebreaker so that

--- a/packages/api/test/catalog.test.ts
+++ b/packages/api/test/catalog.test.ts
@@ -100,6 +100,94 @@ describe('Catalog Routes', () => {
       await expectJsonResponse(res);
     });
 
+    // Regression coverage for #2662: searching "Tent" surfaced leggings, tote
+    // bags and repair kits above actual tents. Two distinct causes — unanchored
+    // substring matching, and ordering that ignored the query entirely.
+    describe('search relevance (#2662)', () => {
+      it('does not match the term inside a longer word', async () => {
+        const decoy = await seedCatalogItem({
+          name: 'Trailhead Leggings',
+          description: 'Consistent stretch and high recycled content for intent-driven hikers.',
+          categories: ['Clothing'],
+        });
+
+        const res = await apiWithAuth('/catalog?q=tent&limit=100');
+
+        expect(res.status).toBe(200);
+        const data = await expectJsonResponse(res, ['items']);
+        const ids = data.items.map((item: { id: number }) => item.id);
+        // "Consistent", "content" and "intent" all contain the letters "tent".
+        expect(ids).not.toContain(decoy.id);
+      });
+
+      it('ranks a name match above an item that only mentions the term in its description', async () => {
+        const tent = await seedCatalogItem({
+          name: 'Copper Spur UL2 Tent',
+          description: 'Freestanding two-person shelter.',
+          categories: ['Shelter'],
+        });
+        const repairKit = await seedCatalogItem({
+          name: 'Fabric Repair Kit',
+          description: 'Patches for a torn tent, tarp, or sleeping pad.',
+          categories: ['Accessories'],
+        });
+
+        const res = await apiWithAuth('/catalog?q=tent&limit=100');
+
+        expect(res.status).toBe(200);
+        const data = await expectJsonResponse(res, ['items']);
+        const ids = data.items.map((item: { id: number }) => item.id);
+        // Both legitimately match; the tent must come first.
+        expect(ids).toContain(tent.id);
+        expect(ids).toContain(repairKit.id);
+        expect(ids.indexOf(tent.id)).toBeLessThan(ids.indexOf(repairKit.id));
+      });
+
+      it('ranks an exact name match above a partial name match', async () => {
+        const partial = await seedCatalogItem({
+          name: 'Tent Footprint',
+          description: 'Groundsheet.',
+          categories: ['Shelter'],
+        });
+        const exact = await seedCatalogItem({
+          name: 'Tent',
+          description: 'A plain tent.',
+          categories: ['Shelter'],
+        });
+
+        const res = await apiWithAuth('/catalog?q=tent&limit=100');
+
+        expect(res.status).toBe(200);
+        const data = await expectJsonResponse(res, ['items']);
+        const ids = data.items.map((item: { id: number }) => item.id);
+        expect(ids.indexOf(exact.id)).toBeLessThan(ids.indexOf(partial.id));
+      });
+
+      it('still matches brand and model by substring', async () => {
+        const item = await seedCatalogItem({
+          name: 'Ultralight Shelter',
+          brand: 'Hilleberg',
+          description: 'No matching word in here.',
+          categories: ['Shelter'],
+        });
+
+        const res = await apiWithAuth('/catalog?q=Hille&limit=100');
+
+        expect(res.status).toBe(200);
+        const data = await expectJsonResponse(res, ['items']);
+        const ids = data.items.map((catalogItem: { id: number }) => catalogItem.id);
+        expect(ids).toContain(item.id);
+      });
+
+      it('treats regex metacharacters in the query as literal text', async () => {
+        const res = await apiWithAuth(`/catalog?q=${encodeURIComponent('tent(')}&limit=10`);
+
+        // An unescaped "(" would be an invalid POSIX regex and error the query.
+        expect(res.status).toBe(200);
+        await expectJsonResponse(res);
+      });
+    });
+
     it('accepts sorting parameters', async () => {
       const res = await apiWithAuth('/catalog?sortBy=weight&sortOrder=asc');
 


### PR DESCRIPTION
## Description

Fixes seven reported defects in the Swift app. Six are client-side; one (#2662) is a server-side search-ranking bug that surfaces in the app's Catalog screen.

Closes #2693
Closes #2692
Closes #2691
Closes #2690
Closes #2662
Closes #2661
Closes #2660

| Issue | Root cause | Fix |
|---|---|---|
| #2693 Weather — large blank gap | The search-state row was added to the `List` unconditionally, so it still reserved inset-grouped row height and padding while empty | Add the row only when it has something to render |
| #2690 Empty state despite non-zero weight | `weightSummary` read the captured `let pack` (a snapshot from push time) while the item list read the live `currentPack` | Read totals from `currentPack`, like the rest of the view already did |
| #2692 Similar Gear not tappable | `SimilarItemCard` was a plain `VStack` — no button, link, or gesture | Tap presents `CatalogItemDetailView`, reusing the `contentShape`/`onTapGesture`/`sheet` pattern `CatalogItemRow` already uses |
| #2691 Pack row stays highlighted | Compact iOS navigates via `NavigationLink` **and** the `List` had a `selection:` binding, so the tapped row stayed selected after popping back | Pass `nil` selection on compact; split-view keeps selection for its detail pane |
| #2661 Weight reverts after Save | The detail view rendered the `PackItem` snapshot it was constructed with | Re-read the item from the view model; Edit re-open now prefills from the live item too |
| #2660 Trip "None" doesn't save | Synthesised `Encodable` omits nil keys, so no `packId` was sent; the route keys off `if ('packId' in data)` and read the absence as "leave unchanged" | Encode `packId` unconditionally, as an explicit `null` when "None" is chosen |
| #2662 Catalog search relevance | Two causes — see below | Word-boundary matching + relevance ranking |

### On #2662

Searching "Tent" returned leggings, tote bags and repair kits above actual tents, for two independent reasons:

1. **Unanchored `ilike '%q%'`** matched the letters anywhere, including inside unrelated words. "consistent", "content", "intent", "patented" and "latent" are everywhere in gear marketing copy, and `description` was weighted the same as `name`. Free-text fields (name, description, categories) now require a POSIX word-boundary match. Brand and model keep substring matching, since typing a prefix is the normal way to search those.
2. **Nothing ranked by the query at all.** Ordering was purely by how often an item had been added to packs, so a popular incidental match outranked an exact-name tent. Matches are now tiered by where they hit (exact name > name prefix > name word > category > brand/model > description-only), with popularity retained as a tiebreaker *within* a tier.

`q` is interpolated into a regex operator, so metacharacters are escaped — otherwise a stray `(` errors the statement. An explicit caller-supplied `sort` still overrides relevance, and the `desc(id)` pagination tiebreaker is preserved on every branch.

Verified directly against Postgres using fixtures drawn from the issue:

```
=== q=tent : filter + ranking (new) ===        === old behaviour (unanchored ILIKE) ===
 Tent                 | 100                     Trailhead Leggings      <- "consistent"/"content"/"intent"
 Tent Footprint       |  80                     Canvas Tote Bag         <- "patented"/"latent"
 Copper Spur UL2 Tent |  60                     Fabric Repair Kit
 Fabric Repair Kit    |   0                     Copper Spur UL2 Tent
                                                Tent Footprint
                                                Tent
```

Both decoys drop out of the result set entirely, and the genuine description-only match (repair kit) correctly sorts last.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️  Refactor / code improvement
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration change
- [ ] ⬆️  Dependency update
- [ ] 🗄️  Database migration

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [x] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)
- [x] Swift app (`apps/swift`) — *not in the template list*

## Testing

- [x] Added / updated unit tests — five regression tests in `packages/api/test/catalog.test.ts` covering word-boundary matching, name-over-description ranking, exact-over-partial ranking, brand substring, and regex-metacharacter safety
- [ ] Manually tested on iOS
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)

What was actually run:

- `xcodebuild` **BUILD SUCCEEDED** for both `PackRat-iOS` and `PackRat-macOS` (macOS matters here: the #2691 fix routes through `isCompact`, hardcoded `false` there)
- `bunx tsc --noEmit` — exit 0
- `bunx biome check` — clean across 44 files
- `scripts/lint/no-unprojected-fat-table-queries.ts` — clean, no new violations
- `bun test:swift:scripts` — 76/76 pass
- The #2662 ranking SQL executed against Postgres with issue-derived fixtures (output above)

> [!IMPORTANT]
> **The five new API tests have never executed, and the reviewer should know why.** The `packages/api` integration harness is broken on `development`, independently of this branch: migration `0033_social_feed_tables.sql` creates `comment_likes` with `IF NOT EXISTS`, then `0037_big_archangel.sql` recreates it *without* the guard, and `test/vitest.global-setup.ts` applies every `.sql` file blindly. Startup therefore fails with `relation "comment_likes" already exists` on a clean volume. I confirmed this against pristine `dbc84ca0e` before concluding it wasn't mine.
>
> I did not fix it: those files are Drizzle-generated and `CLAUDE.md` forbids hand-editing migrations, so the repair needs a regeneration decision outside this PR's scope. That is why #2662 was validated by running the SQL directly against Postgres instead. The new tests will run once the harness is repaired — worth tracking separately.

## Screenshots / recordings

None. The six client-side fixes were verified by root-cause analysis and compilation rather than by running the app; each is a small, targeted change at an identified defect. The reproduction steps in each issue are the fastest way to confirm on-device.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — no schema change
- [ ] Feature flag added (if this is a new feature) — bug fixes only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Similar pack items can now be tapped to view their catalog details.
  * Catalog searches now rank the most relevant matches first and safely support special characters.

* **Bug Fixes**
  * Pack weight summaries now reflect the latest item changes.
  * Pack item details and edit screens stay up to date with current data.
  * Improved list selection behavior across different layouts.
  * Weather search status messages now appear only when relevant.
  * Trip updates now correctly preserve cleared pack selections and timestamps.

* **Tests**
  * Added coverage for catalog search matching, relevance, and special-character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->