### PR TITLE
fix(swift): make the macOS target shippable to TestFlight

### DIFF
--- a/apps/swift/Resources/Info-macOS.plist
+++ b/apps/swift/Resources/Info-macOS.plist
@@ -22,6 +22,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.travel</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/apps/swift/docs/macos-testflight.md
+++ b/apps/swift/docs/macos-testflight.md
@@ -1,0 +1,199 @@
+# Shipping the macOS app to TestFlight
+
+The native Swift app has a `PackRat-macOS` target that ships to TestFlight
+under the **production** App Store Connect record — `com.andrewbierman.packrat`,
+app id `6499243187`, the same record the Expo iPhone app ships from. One record
+hosts both platforms, so Mac testers find the build under TestFlight's **macOS**
+tab. (iOS builds of the Swift app go to a separate record,
+`com.andrewbierman.packrat.swift`, app id `6791633696`.)
+
+## Uploading
+
+> **`upload-testflight.ts` has no macOS lane.** The script is built around iOS
+> lanes (`--replacement` / `--side-by-side`) whose config module is iOS-specific
+> throughout — scheme selection, `PACKRAT_IOS_BUNDLE_IDENTIFIER`, IPA
+> verification. Adding a macOS lane means extending
+> `scripts/lib/testflight-config.ts`; until then, run the three steps below by
+> hand.
+
+Pick the API the build should talk to:
+
+| Scheme | Config | `PACKRAT_ENV` | API |
+|---|---|---|---|
+| `PackRat-macOS` | Release | `production` | `packrat-api...` |
+| `PackRat-macOS-Staging` | Staging | `dev` | `packrat-api-dev...` |
+
+A Release build writes testers' packs and trips into the **production**
+database; Staging keeps them off it. Both schemes use the same bundle id, so
+whichever you upload last is the build testers get on the macOS tab.
+
+Pick a build number above the highest already in App Store Connect. The
+convention is date-based (`2026081101` = 2026-08-11, revision 01). Note that a
+Unix timestamp — the default `upload-testflight.ts` uses for iOS — is *smaller*
+than these date-style numbers and would be rejected.
+
+```bash
+# 1. Archive (swap the scheme/config pair from the table above)
+xcodebuild archive -project apps/swift/PackRat.xcodeproj \
+  -scheme PackRat-macOS -configuration Release \
+  -destination 'generic/platform=macOS' \
+  -archivePath /tmp/PackRat-mac.xcarchive \
+  -allowProvisioningUpdates \
+  MARKETING_VERSION=2.2.0 CURRENT_PROJECT_VERSION=2026081101 \
+  DEVELOPMENT_TEAM=666HGMV2LU
+
+# 2. Export a signed .pkg using the manual-signing options below
+xcodebuild -exportArchive -archivePath /tmp/PackRat-mac.xcarchive \
+  -exportPath /tmp/PackRat-mac-export \
+  -exportOptionsPlist /tmp/ExportOptions-mac.plist
+
+# 3. Validate, then upload (--type osx; a macOS App Store export is a .pkg)
+set -a && . apps/swift/.env.local && set +a
+xcrun altool --validate-app --type osx \
+  --file /tmp/PackRat-mac-export/PackRat-macOS.pkg \
+  --username "$APPLE_ID" --password "$APPLE_APP_PASSWORD" \
+  --asc-provider "$APPLE_TEAM_ID"
+xcrun altool --upload-app --type osx \
+  --file /tmp/PackRat-mac-export/PackRat-macOS.pkg \
+  --username "$APPLE_ID" --password "$APPLE_APP_PASSWORD" \
+  --asc-provider "$APPLE_TEAM_ID"
+```
+
+Always `--validate-app` first. It runs the same asset and signing checks as the
+real upload but costs nothing, so a rejection is caught before a 25 MB transfer
+and is cleanly distinguishable from a transport failure.
+
+`ExportOptions-mac.plist` — note `signingStyle` is **manual** (see below):
+
+```xml
+<plist version="1.0"><dict>
+  <key>method</key><string>app-store-connect</string>
+  <key>teamID</key><string>666HGMV2LU</string>
+  <key>destination</key><string>export</string>
+  <key>signingStyle</key><string>manual</string>
+  <key>signingCertificate</key><string>Apple Distribution</string>
+  <key>installerSigningCertificate</key><string>3rd Party Mac Developer Installer</string>
+  <key>provisioningProfiles</key>
+  <dict><key>com.andrewbierman.packrat</key><string>PackRat macOS App Store</string></dict>
+  <key>uploadSymbols</key><true/>
+</dict></plist>
+```
+
+Roughly 10 minutes to archive and export, plus 5–15 minutes of Apple-side
+processing before the build appears in TestFlight.
+
+### The Apple ID belongs to two teams
+
+`altool` fails any *listing* command run without a provider:
+
+```
+ERROR: Username and app password authentication requires --provider-public-id,
+when attached to multiple providers.
+```
+
+It then prints the providers and their public IDs. For read commands pass
+`--provider-public-id f1c3497f-0df6-4b85-ad1c-55de20764ec5` (Bierman Collective
+LLC). For `--upload-app` / `--validate-app`, `--asc-provider` takes the provider
+*short name*, which for this team is the same string as the team ID
+(`666HGMV2LU`) — which is why `--asc-provider "$APPLE_TEAM_ID"` works.
+
+`altool` can also authenticate with an App Store Connect API key
+(`--apiKey <id> --apiIssuer <uuid>`) instead of an Apple ID and app-specific
+password. The key must sit in one of `./private_keys`, `~/private_keys`,
+`~/.private_keys`, or `~/.appstoreconnect/private_keys`. There is a key at
+`~/.appstoreconnect/private_keys/AuthKey_UL4PZ262H5.p8`, but the issuer UUID it
+needs is not recorded anywhere in the repo.
+
+## Signing: why macOS uses manual signing
+
+This machine has certificates in its keychain but **no Apple ID configured in
+Xcode's GUI**. Automatic signing asks Xcode's account system for profiles and
+fails with `No Accounts` / `No profiles for 'com.andrewbierman.packrat' were
+found`. The macOS export therefore names its certificates and profile
+explicitly. It needs three things to exist:
+
+| Thing | Value |
+|---|---|
+| App signing cert | `Apple Distribution: Bierman Collective LLC (666HGMV2LU)` |
+| Installer signing cert | `3rd Party Mac Developer Installer: Bierman Collective LLC` |
+| Provisioning profile | `PackRat macOS App Store` (MAC_APP_STORE, for `com.andrewbierman.packrat`) |
+
+Verify all three before archiving:
+
+```bash
+security find-identity -v | grep -E "Apple Distribution|Installer"
+for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.provisionprofile; do
+  security cms -D -i "$f" | plutil -p - | grep '"Name"'
+done
+```
+
+A macOS App Store export produces a **`.pkg`**, not a `.ipa`, and the `.pkg`
+must be signed by the *installer* certificate — a distinct cert from the one
+that signs the `.app`.
+
+If any of these are missing, create them through the App Store Connect API
+rather than the Xcode GUI. The API can create certificates from an `openssl`
+CSR (including `MAC_INSTALLER_DISTRIBUTION`), create `MAC_APP_STORE` profiles,
+and add a macOS platform to an existing app record by POSTing a `MAC_OS`
+`appStoreVersion`. Install a new profile into
+`~/Library/Developer/Xcode/UserData/Provisioning Profiles/`, and import a new
+certificate with `security import` (use `openssl pkcs12 -export -legacy`; the
+modern default encryption fails macOS keychain import with a misleading
+"wrong password" error).
+
+## "The build uploaded but there's no macOS tab in TestFlight"
+
+A build can be `VALID` and still be invisible to testers. Check its beta state:
+
+```
+GET /v1/builds/<id>/buildBetaDetail?fields[buildBetaDetails]=internalBuildState,externalBuildState
+```
+
+`MISSING_EXPORT_COMPLIANCE` means Apple is waiting on the encryption question
+and hides the build until it's answered — TestFlight shows no macOS tab at all,
+with nothing to explain why. `project.yml` sets
+`ITSAppUsesNonExemptEncryption: false` on the macOS target so this is answered
+at build time. To unblock a build that was already uploaded without it:
+
+```
+PATCH /v1/builds/<id>   {"data":{"type":"builds","id":"<id>",
+                          "attributes":{"usesNonExemptEncryption":false}}}
+```
+
+The state should flip to `IN_BETA_TESTING`. Internal groups get every build
+automatically — trying to POST an internal group to
+`/v1/builds/<id>/relationships/betaGroups` returns 422 and isn't needed.
+
+## Three things that will get an upload rejected
+
+All three are fixed in `project.yml`. They're documented here because the
+failure modes are non-obvious and each was hit for real.
+
+**Missing icon (90236).** The asset catalog must be listed under the target's
+`sources`, not `resources`. As a resource it is copied verbatim and `actool`
+never runs, so the app ships with no `Assets.car` and no `AppIcon.icns` even
+though the 1024×1024 PNG is present on disk.
+
+**Missing category (90242).** `LSApplicationCategoryType` is required for Mac
+App Store distribution. The build warns about this but still succeeds locally,
+so it is easy to miss until Apple rejects the upload.
+
+**Ad-hoc signing.** The target used `CODE_SIGN_IDENTITY: "-"` with an empty
+`DEVELOPMENT_TEAM`, which cannot produce a distributable build at all. E2E and
+CI still build unsigned by passing `CODE_SIGNING_REQUIRED=NO` on the
+`xcodebuild` command line, which overrides the project setting.
+
+To check a built app before spending an upload:
+
+```bash
+APP=/tmp/PackRat-mac.xcarchive/Products/Applications/PackRat-macOS.app
+ls "$APP/Contents/Resources/" | grep -E 'icns|Assets.car'   # want both
+plutil -p "$APP/Contents/Info.plist" | grep -iE 'icon|Category|Encryption'
+```
+
+## Sandbox
+
+The target is sandboxed (`com.apple.security.app-sandbox`) with only
+`com.apple.security.network.client`. Anything needing more — keychain sharing,
+file access outside the container — needs its entitlement added, or it will
+fail at runtime in a way that does not show up in a local unsandboxed run.

--- a/apps/swift/project.yml
+++ b/apps/swift/project.yml
@@ -147,7 +147,7 @@ targets:
       base:
         SWIFT_VERSION: "5.9"
         MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "2026080901"
+        CURRENT_PROJECT_VERSION: "2026081101"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 666HGMV2LU
         PACKRAT_IOS_BUNDLE_IDENTIFIER: com.andrewbierman.packrat
@@ -186,7 +186,7 @@ targets:
       base:
         SWIFT_VERSION: "5.9"
         MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "2026080901"
+        CURRENT_PROJECT_VERSION: "2026081101"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 666HGMV2LU
         PACKRAT_WATCH_BUNDLE_IDENTIFIER: com.andrewbierman.packrat.watchkitapp
@@ -203,8 +203,11 @@ targets:
     sources:
       - Sources/PackRat
       - Sources/PackRatShared
-      - path: Resources/Assets.xcassets
-        buildPhase: resources
+      # The catalog must go through actool, not a verbatim resource copy: as a
+      # plain resource the app ships with no Assets.car and no .icns, and the
+      # App Store upload fails with "Missing required icon" (90236). Listing it
+      # as a source (no buildPhase override) puts it in the compile phase.
+      - Resources/Assets.xcassets
       - path: Resources/PrivacyInfo.xcprivacy
         buildPhase: resources
     entitlements:
@@ -221,6 +224,13 @@ targets:
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSPrincipalClass: NSApplication
         NSHighResolutionCapable: true
+        # Required for Mac App Store distribution — the build warns and Apple
+        # rejects submissions without a category (90242).
+        LSApplicationCategoryType: public.app-category.travel
+        # Without this, an uploaded build sits at MISSING_EXPORT_COMPLIANCE and
+        # never appears in TestFlight — the macOS tab simply stays absent. The
+        # app only uses standard HTTPS, which is exempt. Matches PackRat-iOS.
+        ITSAppUsesNonExemptEncryption: false
         PACKRAT_ENV: $(PACKRAT_ENV)
         SENTRY_DSN: $(SENTRY_DSN)
         NSAppTransportSecurity:
@@ -248,12 +258,16 @@ targets:
       base:
         SWIFT_VERSION: "5.9"
         MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "2026080901"
-        CODE_SIGN_STYLE: Manual
-        DEVELOPMENT_TEAM: ""
-        CODE_SIGN_IDENTITY: "-"
-        CODE_SIGNING_REQUIRED: NO
-        PRODUCT_BUNDLE_IDENTIFIER: com.andrewbierman.packrat.mac
+        CURRENT_PROJECT_VERSION: "2026081101"
+        # Real distribution signing: the target previously used an ad-hoc
+        # identity with no team, which cannot produce a TestFlight build. E2E
+        # and CI still build unsigned by passing CODE_SIGNING_REQUIRED=NO etc.
+        # on the xcodebuild command line, which overrides these.
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 666HGMV2LU
+        # Ships under the production record so Mac testers get the build on
+        # TestFlight's macOS tab of the same app as the iPhone one.
+        PRODUCT_BUNDLE_IDENTIFIER: com.andrewbierman.packrat
         PACKRAT_DISPLAY_NAME: PackRat
         # Match iOS target so @testable import PackRat resolves on both platforms.
         PRODUCT_MODULE_NAME: PackRat
@@ -417,6 +431,18 @@ schemes:
       config: Debug
     archive:
       config: Release
+  # Mirrors PackRat-iOS-Staging: archives the Staging config so the build talks
+  # to the deployed DEV API (PACKRAT_ENV=dev) instead of production. Lets a
+  # macOS TestFlight build go to beta testers without writing to the production
+  # database.
+  PackRat-macOS-Staging:
+    build:
+      targets:
+        PackRat-macOS: all
+    run:
+      config: Staging
+    archive:
+      config: Staging
   PackRat-Watch:
     build:
       targets:


### PR DESCRIPTION
## Description

Makes the `PackRat-macOS` target capable of shipping to TestFlight, and
documents the upload path.

macOS TestFlight support was written on `feat/mac-testflight-upload` but never
merged, so `development` still could not produce a Mac build that Apple would
accept. Rather than merge that branch — it had drifted to an older marketing
version and reverted a Google client ID — this ports just the macOS fixes onto
current `development`.

Three defects, each with a non-obvious failure mode:

- **Missing icon (rejection 90236).** `Assets.xcassets` was listed with
  `buildPhase: resources`, so `actool` never ran and the app shipped with no
  `Assets.car` and no `AppIcon.icns`, despite the 1024×1024 PNG being on disk.
- **Missing category (rejection 90242).** No `LSApplicationCategoryType`.
  Required for Mac App Store distribution; the build only warns locally, so it
  surfaces as an Apple rejection.
- **Missing export compliance.** No `ITSAppUsesNonExemptEncryption`. A build
  uploads and validates fine, then sits at `MISSING_EXPORT_COMPLIANCE` and
  TestFlight shows *no macOS tab at all*, with nothing on screen explaining why.

Signing also moves from an ad-hoc identity (`CODE_SIGN_IDENTITY: "-"`, empty
`DEVELOPMENT_TEAM`) to real distribution signing, which is a prerequisite for
any distributable build. E2E and CI keep building unsigned by passing
`CODE_SIGNING_REQUIRED=NO` on the `xcodebuild` command line, which overrides
the project setting.

Two other changes:

- **Bundle id moves** from `com.andrewbierman.packrat.mac` to
  `com.andrewbierman.packrat`, so Mac testers get the build on the macOS tab of
  the production record (app `6499243187`), where the `MAC_OS` platform is
  already registered and where the `PackRat macOS App Store` provisioning
  profile points. Only a historical plan doc referenced the old id; no code
  depends on it.
- **Adds `PackRat-macOS-Staging`**, mirroring `PackRat-iOS-Staging`, so a macOS
  beta build can target the dev API instead of the production database.

Build numbers go to `2026081101`, above the 2.1.0 builds live in App Store
Connect. Note the date-based convention matters here: a Unix timestamp (what
`upload-testflight.ts` defaults to for iOS) is numerically *smaller* than
`20260809…` and would be rejected.

### Known gap

`upload-testflight.ts` still has **no macOS lane** — its config module is
iOS-specific throughout (scheme selection, `PACKRAT_IOS_BUNDLE_IDENTIFIER`, IPA
verification). The macOS archive/export/upload has to be run by hand;
`apps/swift/docs/macos-testflight.md` records the working commands. Adding a
real lane is a sensible follow-up.

## Type of change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update
- [x] 🔧 CI / configuration change

## Area(s) affected

- Native Swift app (`apps/swift`) — macOS target, schemes, docs

## Testing

Both platforms were archived, exported, validated and uploaded from this branch
at build `2026081101` / v2.2.0, Release config (production API):

| Platform | Listing | Result |
|---|---|---|
| iOS + Watch | `com.andrewbierman.packrat.swift` (app `6791633696`) | `UPLOAD SUCCEEDED`, UUID `22b57b10-f5e5-4644-b627-bc384936ed74` |
| macOS | `com.andrewbierman.packrat` (app `6499243187`, macOS tab) | `UPLOAD SUCCEEDED`, UUID `f3cbbc92-2514-49e5-8f2e-c937d4c94129` |

The macOS `.pkg` passed `altool --validate-app` before upload — Apple's own
asset and signing checks accepted the icon, category and signature. Exported as
a universal binary (x86_64 + arm64), 24.5 MB, signed
`Apple Distribution: Bierman Collective LLC`.

The archived app was also checked directly, which is the cheap pre-flight for
the two rejection modes above:

```
$ ls PackRat-macOS.app/Contents/Resources/ | grep -E 'icns|Assets.car'
AppIcon.icns
Assets.car
$ plutil -p PackRat-macOS.app/Contents/Info.plist | grep -iE 'Category|Encryption'
"ITSAppUsesNonExemptEncryption" => false
"LSApplicationCategoryType" => "public.app-category.travel"
```

- [x] `bun test:swift:scripts` — 76/76 pass
- [x] Manually tested on iOS (archived, exported, uploaded)
- [x] Manually tested on macOS (archived, exported, validated, uploaded)

One run of `testflight-upload-cli.test.ts` timed out at 5s while a macOS upload
was saturating the machine; it passes on four subsequent clean runs and on
unmodified `development`, so it is load-induced flake rather than a regression.

**Not verified:** post-upload build processing state. `altool` in Xcode 26 has
no build-listing command, and querying the ASC API needs the Bierman key, which
this environment could not read.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors — both changed files are
      YAML/Markdown, which Biome does not lint, so there is nothing in scope
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — n/a
- [ ] Feature flag added (if this is a new feature) — n/a
- [x] PR title follows conventional commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the macOS app’s App Store information, including its travel category and encryption declaration.
  * Improved macOS build and distribution support, including staging builds and automatic signing.
  * Updated platform build numbers across iOS, watchOS, and macOS.

* **Documentation**
  * Added comprehensive guidance for preparing, validating, and submitting the macOS app to TestFlight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->