### PR TITLE
feat(swift): ask AI about a pack item, and answer client-executed tool calls

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Chat/ChatView.swift
+++ b/apps/swift/Sources/PackRat/Features/Chat/ChatView.swift
@@ -21,13 +21,19 @@ struct ChatView: View {
     /// Pack-scoped chats are presented inside their own sheet, which supplies
     /// the "Ask AI" title — leaving the generic one here would override it.
     private var navigationTitleText: String {
-        viewModel.context.packName == nil ? "AI Assistant" : "Ask AI"
+        if viewModel.context.packName != nil { return "Ask AI" }
+        if let itemName = viewModel.context.itemName { return itemName }
+        return "AI Assistant"
     }
 
     /// The generic starter prompts assume no pack context. When scoped to a
-    /// pack, offer prompts that exercise the `getPackDetails` tool instead.
+    /// pack, offer prompts that exercise the `getPackDetails` tool instead; when
+    /// scoped to a single item, the item's own prompts come from `ChatContext`.
     private var activeSuggestions: [(String, String)] {
-        guard let packName = viewModel.context.packName else { return Self.suggestions }
+        guard let packName = viewModel.context.packName else {
+            let itemSuggestions = viewModel.context.itemSuggestions
+            return itemSuggestions.isEmpty ? Self.suggestions : itemSuggestions
+        }
         return [
             ("What's missing?", "Review “\(packName)” and tell me what essential gear is missing."),
             ("Cut weight", "How can I reduce the weight of “\(packName)”? Suggest the biggest wins."),
@@ -100,6 +106,16 @@ struct ChatView: View {
         }
     }
 
+    private var welcomeSubtitle: String {
+        if viewModel.context.packName != nil {
+            return "I can see this pack's contents — ask about gaps, weight, or what to leave behind"
+        }
+        if let itemName = viewModel.context.itemName {
+            return "Ask about \(itemName) — alternatives, weight savings, or how to care for it"
+        }
+        return "Ask me anything about gear, trips, or packing strategy"
+    }
+
     private var welcomeHeader: some View {
         VStack(spacing: 10) {
             Circle()
@@ -110,12 +126,10 @@ struct ChatView: View {
                         .font(.title2)
                         .foregroundStyle(Color.accentColor)
                 }
-            Text(viewModel.context.packName ?? "PackRat AI")
+            Text(viewModel.context.packName ?? viewModel.context.itemName ?? "PackRat AI")
                 .font(.title3.bold())
                 .multilineTextAlignment(.center)
-            Text(viewModel.context.packName == nil
-                 ? "Ask me anything about gear, trips, or packing strategy"
-                 : "I can see this pack's contents — ask about gaps, weight, or what to leave behind")
+            Text(welcomeSubtitle)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/apps/swift/Sources/PackRat/Features/Chat/ChatViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Chat/ChatViewModel.swift
@@ -19,14 +19,7 @@ final class ChatViewModel {
     init(service: any ChatServicing = ChatService.shared, context: ChatContext = .general) {
         self.service = service
         self.context = context
-        messages.append(ChatMessage(role: .assistant, content: Self.greeting(for: context)))
-    }
-
-    private static func greeting(for context: ChatContext) -> String {
-        if let packName = context.packName {
-            return "Ask me anything about “\(packName)” — what's missing, how to cut weight, or whether it suits your trip."
-        }
-        return "Hi! I'm your PackRat AI assistant. I can help you plan trips, build packing lists, research gear, and answer questions about outdoor adventures. What are you working on?"
+        messages.append(ChatMessage(role: .assistant, content: context.greeting))
     }
 
     var canSend: Bool { !inputText.trimmingCharacters(in: .whitespaces).isEmpty && !isStreaming }
@@ -37,6 +30,13 @@ final class ChatViewModel {
 
         inputText = ""
         error = nil
+
+        // The bubble shows exactly what was typed; the wire copy of the first
+        // message additionally carries the item's own details, which usually
+        // saves a `getPackItemDetails` round trip.
+        let isFirstUserMessage = !messages.contains { $0.role == .user }
+        let sentText = isFirstUserMessage ? context.primedFirstMessage(text) : text
+
         messages.append(ChatMessage(role: .user, content: text))
 
         let placeholder = ChatMessage(role: .assistant, content: "")
@@ -47,35 +47,30 @@ final class ChatViewModel {
         streamingTask = Task { @MainActor in
             defer { isStreaming = false }
             do {
-                let history = Array(messages.dropLast())
-                for try await chunk in await service.sendMessage(messages: history, context: context) {
-                    guard let data = chunk.data(using: .utf8),
-                          let parsed = try? JSONDecoder().decode(UIStreamChunk.self, from: data)
-                    else { continue }
+                var history = Array(messages.dropLast())
+                if sentText != text, let lastIdx = history.indices.last {
+                    history[lastIdx].content = sentText
+                }
 
-                    switch parsed.type {
-                    case "text-delta":
-                        if let delta = parsed.delta {
-                            appendToPlaceholder(id: placeholderId, text: delta)
-                        }
-                    case "tool-input-start":
-                        if let callId = parsed.toolCallId, let name = parsed.toolName {
-                            addToolInvocation(to: placeholderId, invocation: ToolInvocation(toolCallId: callId, toolName: name))
-                        }
-                    case "tool-input-available":
-                        if let callId = parsed.toolCallId, let inputData = parsed.rawInputData {
-                            updateToolInput(id: placeholderId, callId: callId, data: inputData)
-                        }
-                    case "tool-output-available":
-                        if let callId = parsed.toolCallId, let outputData = parsed.rawOutputData {
-                            updateToolOutput(id: placeholderId, callId: callId, data: outputData)
-                        }
-                    default:
-                        break
-                    }
+                // A turn can end waiting on a client-executed tool. Answer it and
+                // resume, bounded so a misbehaving model can't loop forever.
+                for _ in 0..<Self.maxToolRoundTrips {
+                    try await streamTurn(history: history, placeholderId: placeholderId)
+
+                    guard let pending = pendingClientToolCall(in: placeholderId) else { break }
+                    answerClientTool(pending, in: placeholderId)
+
+                    guard let assistant = messages.first(where: { $0.id == placeholderId }) else { break }
+                    history.append(assistant)
+                    clearPlaceholderToolState(placeholderId)
                 }
             } catch is CancellationError {
                 // User cancelled — leave the partial response in place
+            } catch let urlError as URLError where urlError.code == .cancelled {
+                // URLSession reports cancellation as NSURLErrorCancelled (-999),
+                // not CancellationError, so it needs its own arm. Without it a
+                // cancelled request looks like a failure and wipes the message
+                // the user just sent.
             } catch {
                 self.error = error.localizedDescription
                 messages.removeAll { $0.id == placeholderId }
@@ -91,13 +86,83 @@ final class ChatViewModel {
 
     func clearHistory() {
         cancelStreaming()
+        error = nil
         messages.removeAll()
+        // Re-seed with the scoped greeting so a cleared pack or item chat still
+        // reads as being about that pack or item.
         messages.append(ChatMessage(
             role: .assistant,
-            content: context.packName == nil
+            content: context == .general
                 ? "Chat cleared. What can I help you with?"
-                : Self.greeting(for: context)
+                : context.greeting
         ))
+    }
+
+    /// Client-executed tools: declared server-side with no `execute`, so the
+    /// model blocks until the client sends the result back.
+    /// See `packages/api/src/utils/ai/tools.ts`.
+    private static let clientExecutedTools: Set<String> = ["getPackItemDetails", "getPackDetails"]
+    private static let maxToolRoundTrips = 3
+
+    /// Streams one turn into the placeholder message.
+    private func streamTurn(history: [ChatMessage], placeholderId: UUID) async throws {
+        for try await chunk in await service.sendMessage(messages: history, context: context) {
+            guard let data = chunk.data(using: .utf8),
+                  let parsed = try? JSONDecoder().decode(UIStreamChunk.self, from: data)
+            else { continue }
+
+            switch parsed.type {
+            case "text-delta":
+                if let delta = parsed.delta {
+                    appendToPlaceholder(id: placeholderId, text: delta)
+                }
+            case "tool-input-start":
+                if let callId = parsed.toolCallId, let name = parsed.toolName {
+                    addToolInvocation(to: placeholderId, invocation: ToolInvocation(toolCallId: callId, toolName: name))
+                }
+            case "tool-input-available":
+                if let callId = parsed.toolCallId, let inputData = parsed.rawInputData {
+                    updateToolInput(id: placeholderId, callId: callId, data: inputData)
+                }
+            case "tool-output-available":
+                if let callId = parsed.toolCallId, let outputData = parsed.rawOutputData {
+                    updateToolOutput(id: placeholderId, callId: callId, data: outputData)
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    /// A tool the server expects *us* to execute, still awaiting its result.
+    private func pendingClientToolCall(in placeholderId: UUID) -> ToolInvocation? {
+        messages.first { $0.id == placeholderId }?
+            .toolInvocations
+            .first { $0.state == .running && Self.clientExecutedTools.contains($0.toolName) }
+    }
+
+    /// Fills in a client-executed tool's result from local data.
+    private func answerClientTool(_ invocation: ToolInvocation, in placeholderId: UUID) {
+        guard Self.clientExecutedTools.contains(invocation.toolName) else { return }
+
+        let notFound = invocation.toolName == "getPackDetails" ? "Pack not found" : "Item not found"
+        let output: [String: Any] = if let payload = context.toolPayload {
+            ["success": true, "data": payload]
+        } else {
+            ["success": false, "error": notFound]
+        }
+
+        let data = (try? JSONSerialization.data(withJSONObject: output)) ?? Data("{}".utf8)
+        updateToolOutput(id: placeholderId, callId: invocation.id, data: data)
+    }
+
+    /// Drops tool invocations from the live placeholder once they've been folded
+    /// into the outgoing history, so the same call isn't answered twice.
+    private func clearPlaceholderToolState(_ placeholderId: UUID) {
+        guard let idx = messages.firstIndex(where: { $0.id == placeholderId }) else { return }
+        var updated = messages[idx]
+        updated.toolInvocations.removeAll()
+        messages[idx] = updated
     }
 
     private func appendToPlaceholder(id: UUID, text: String) {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackAskAISheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackAskAISheet.swift
@@ -16,7 +16,7 @@ struct PackAskAISheet: View {
     init(pack: Pack) {
         self.pack = pack
         _viewModel = State(initialValue: ChatViewModel(
-            context: .pack(id: pack.id, name: pack.name)
+            context: .pack(id: pack.id, name: pack.name, details: pack.aiContextSummary)
         ))
     }
 

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemAskAISheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemAskAISheet.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Item-scoped wrapper around `ChatView`.
+///
+/// The item counterpart to `PackAskAISheet`. Mirrors Expo, which routes to
+/// `/ai-chat` with `{ itemId, itemName, contextType: 'item' }`
+/// (apps/expo/features/packs/screens/PackItemDetailScreen.tsx `navigateToChat`).
+///
+/// The view model is held in `@State` so it is created once per presentation:
+/// building it inline in the `.sheet` closure instead lets SwiftUI rebuild it on
+/// any re-render — dismissing the keyboard is enough — which cancels the
+/// in-flight streaming request and drops the transcript.
+struct PackItemAskAISheet: View {
+    let item: PackItem
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel: ChatViewModel
+
+    init(item: PackItem) {
+        self.item = item
+        _viewModel = State(initialValue: ChatViewModel(
+            context: .item(
+                id: item.id,
+                name: item.name,
+                details: item.aiContextSummary,
+                fields: item.aiToolFields
+            )
+        ))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ChatView(viewModel: viewModel)
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                            .accessibilityIdentifier("pack_item_ask_ai_done")
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 520, minHeight: 600)
+        #endif
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemDetailView.swift
@@ -6,7 +6,9 @@ struct PackItemDetailView: View {
     let packId: String
     @Bindable var viewModel: PacksViewModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(AuthManager.self) private var authManager
     @State private var showingEdit = false
+    @State private var showingAskAI = false
     @State private var similarItems: [CatalogItem] = []
     @State private var isLoadingSimilar = false
 
@@ -37,6 +39,7 @@ struct PackItemDetailView: View {
                     if let notes = item.notes, !notes.isEmpty {
                         notesSection(notes)
                     }
+                    askAISection
                     similarSection
                 }
                 .padding(.bottom, 24)
@@ -53,6 +56,9 @@ struct PackItemDetailView: View {
                     Button("Edit", systemImage: "pencil") { showingEdit = true }
                         .accessibilityIdentifier("pack_item_detail_edit_button")
                 }
+            }
+            .sheet(isPresented: $showingAskAI) {
+                PackItemAskAISheet(item: item)
             }
             .sheet(isPresented: $showingEdit) {
                 // `item`, not `initialItem`: re-opening Edit must prefill from the
@@ -261,6 +267,30 @@ struct PackItemDetailView: View {
     }
 
     // MARK: - Similar Items
+
+    /// Opens a chat scoped to this item, mirroring the Expo app's "Ask AI about
+    /// this item" action on `PackItemDetailScreen`.
+    ///
+    /// Hidden for guests: the chat API requires an account, so the sheet would
+    /// only render `ChatView`'s guest placeholder.
+    @ViewBuilder
+    private var askAISection: some View {
+        if authManager.isAuthenticated {
+            Button {
+                showingAskAI = true
+            } label: {
+                Label("Ask AI about this item", systemImage: "sparkles")
+                    .font(.callout.bold())
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color.accentColor.opacity(0.12), in: Capsule())
+                    .foregroundStyle(Color.accentColor)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+            .accessibilityIdentifier("pack_item_detail_ask_ai_button")
+        }
+    }
 
     private var similarSection: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/apps/swift/Sources/PackRat/Models/Chat.swift
+++ b/apps/swift/Sources/PackRat/Models/Chat.swift
@@ -61,8 +61,14 @@ struct ChatRequest: Encodable {
 /// Keep this field set aligned with Expo's (apps/expo/app/(app)/ai-chat.tsx).
 enum ChatContext: Equatable, Sendable {
     case general
-    case pack(id: String, name: String)
-    case item(id: String)
+    /// `details` carries the pack's contents for the same reason the item case
+    /// does — `getPackDetails` is also client-executed.
+    case pack(id: String, name: String, details: String? = nil)
+    /// `name` titles the screen and phrases the suggestion chips. `details` and
+    /// `fields` carry the item's own data, which is needed because
+    /// `getPackItemDetails` is declared server-side *without* an `execute` — the
+    /// AI SDK expects the client to answer it (see `ChatViewModel`).
+    case item(id: String, name: String = "", details: String? = nil, fields: [String: String] = [:])
 
     var contextType: String {
         switch self {
@@ -73,18 +79,88 @@ enum ChatContext: Equatable, Sendable {
     }
 
     var packId: String? {
-        if case .pack(let id, _) = self { return id }
+        if case .pack(let id, _, _) = self { return id }
         return nil
     }
 
     var itemId: String? {
-        if case .item(let id) = self { return id }
+        if case .item(let id, _, _, _) = self { return id }
         return nil
     }
 
     var packName: String? {
-        if case .pack(_, let name) = self { return name }
+        if case .pack(_, let name, _) = self { return name }
         return nil
+    }
+
+    var itemName: String? {
+        if case .item(_, let name, _, _) = self, !name.isEmpty { return name }
+        return nil
+    }
+
+    /// Plain-text dump of the item's fields, prepended to the first user message
+    /// so the model usually has what it needs without a tool round trip.
+    var primingDetails: String? {
+        switch self {
+        case .general:                        return nil
+        case .pack(_, _, let details):        return details
+        case .item(_, _, let details, _):     return details
+        }
+    }
+
+    /// Structured data used to answer a client-executed `getPackItemDetails` or
+    /// `getPackDetails` call. Nil means "not found".
+    var toolPayload: [String: String]? {
+        switch self {
+        case .general:
+            return nil
+        case .pack(let id, let name, let details):
+            // getPackDetails is client-executed too; without the contents the
+            // model answers "I couldn't retrieve your pack".
+            var payload = ["id": id, "name": name]
+            if let details, !details.isEmpty { payload["contents"] = details }
+            return payload
+        case .item(let id, let name, _, let fields):
+            guard fields.isEmpty else { return fields }
+            return ["id": id, "name": name]
+        }
+    }
+
+    /// Builds the text sent for the first user message. Later messages go
+    /// verbatim — the details are already in the history the API receives.
+    func primedFirstMessage(_ userMessage: String) -> String {
+        guard let primingDetails, !primingDetails.isEmpty else { return userMessage }
+        return """
+        \(primingDetails)
+
+        \(userMessage)
+        """
+    }
+
+    /// Opening assistant message. Mirrors `getContextualGreeting` in
+    /// `packages/api/src/utils/chatContextHelpers.ts` so both clients read alike.
+    var greeting: String {
+        if let packName {
+            return "Ask me anything about “\(packName)” — what's missing, how to cut weight, or whether it suits your trip."
+        }
+        if let itemName {
+            return "I see you're looking at \(itemName). What would you like to know about it?"
+        }
+        return "Hi! I'm your PackRat AI assistant. I can help you plan trips, build packing lists, research gear, and answer questions about outdoor adventures. What are you working on?"
+    }
+
+    /// Item-scoped chips, as `(label, prompt)` pairs. Mirrors the item arm of
+    /// `getContextualSuggestions` on the API side. Pack and general chips live
+    /// in `ChatView`, which owns the equivalent lists for those scopes.
+    var itemSuggestions: [(String, String)] {
+        guard let itemName else { return [] }
+        return [
+            ("Tell me more", "Tell me more about \(itemName)"),
+            ("Alternatives", "What are alternatives to \(itemName)?"),
+            ("Cut weight", "How can I reduce the weight of my \(itemName)?"),
+            ("Worth bringing?", "Is \(itemName) worth bringing on a short trip?"),
+            ("How to care", "How should I care for and maintain my \(itemName)?"),
+        ]
     }
 }
 
@@ -92,17 +168,63 @@ struct ChatUIMessage: Encodable {
     let id: String
     let role: String
     let content: String
-    let parts: [ChatUITextPart]
+    let parts: [ChatUIPart]
 
     init(from msg: ChatMessage) {
         self.id = msg.id.uuidString
         self.role = msg.role.rawValue
         self.content = msg.content
-        self.parts = [ChatUITextPart(text: msg.content)]
+
+        var parts: [ChatUIPart] = []
+        if !msg.content.isEmpty {
+            parts.append(.text(msg.content))
+        }
+        // Replay answered client-executed tool calls so the server can resume a
+        // turn that stopped to wait on one.
+        for invocation in msg.toolInvocations where invocation.state == .complete {
+            parts.append(.tool(invocation))
+        }
+        if parts.isEmpty {
+            parts.append(.text(""))
+        }
+        self.parts = parts
     }
 }
 
-struct ChatUITextPart: Encodable {
-    let type = "text"
-    let text: String
+/// One entry in a UIMessage's `parts` array. Text is `{type:"text"}`; an
+/// answered tool call is `{type:"tool-<name>", state:"output-available", …}`,
+/// which is the shape `convertToModelMessages` reads on the API side.
+enum ChatUIPart: Encodable {
+    case text(String)
+    case tool(ToolInvocation)
+
+    private enum CodingKeys: String, CodingKey {
+        case type, text, toolCallId, state, input, output
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let text):
+            try c.encode("text", forKey: .type)
+            try c.encode(text, forKey: .text)
+        case .tool(let invocation):
+            try c.encode("tool-\(invocation.toolName)", forKey: .type)
+            try c.encode(invocation.id, forKey: .toolCallId)
+            try c.encode("output-available", forKey: .state)
+            try c.encode(invocation.inputJSON, forKey: .input)
+            try c.encode(invocation.outputJSON, forKey: .output)
+        }
+    }
+}
+
+extension ToolInvocation {
+    /// Decoded `input`, so it re-encodes as JSON rather than an opaque string.
+    var inputJSON: JSONValue {
+        inputData.flatMap { try? JSONDecoder().decode(JSONValue.self, from: $0) } ?? .object([:])
+    }
+
+    var outputJSON: JSONValue {
+        outputData.flatMap { try? JSONDecoder().decode(JSONValue.self, from: $0) } ?? .null
+    }
 }

--- a/apps/swift/Sources/PackRat/Models/Pack.swift
+++ b/apps/swift/Sources/PackRat/Models/Pack.swift
@@ -10,6 +10,40 @@ extension Pack {
         guard let g = grams, g > 0 else { return "0 g" }
         return g >= 1000 ? String(format: "%.2f kg", g / 1000) : String(format: "%.0f g", g)
     }
+
+    /// The pack's contents as plain text, used to answer the client-executed
+    /// `getPackDetails` tool and to prime the first message of a pack chat.
+    /// Without it the model replies that it couldn't retrieve the pack.
+    var aiContextSummary: String {
+        var lines = ["Here are the contents of the pack I'm asking about:"]
+        lines.append("- Name: \(name)")
+        if let description, !description.isEmpty {
+            lines.append("- Description: \(description)")
+        }
+        if let category {
+            lines.append("- Category: \(category.rawValue)")
+        }
+        lines.append("- Total weight: \(formattedWeight(totalWeight))")
+        lines.append("- Base weight: \(formattedWeight(baseWeight))")
+
+        let items = activeItems
+        lines.append("- Item count: \(items.count)")
+        if items.isEmpty {
+            lines.append("- Items: none yet")
+        } else {
+            lines.append("- Items:")
+            for item in items {
+                var parts = ["  - \(item.name)"]
+                parts.append("qty \(item.quantity)")
+                parts.append(item.displayWeight.isEmpty ? "weight not set" : item.displayWeight)
+                parts.append("category \(item.category ?? "uncategorized")")
+                if item.worn { parts.append("worn") }
+                if item.consumable { parts.append("consumable") }
+                lines.append(parts.joined(separator: ", "))
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
 }
 
 extension PackItem {
@@ -27,6 +61,48 @@ extension PackItem {
         case .oz: return weight * 28.3495
         case .lb: return weight * 453.592
         }
+    }
+
+    /// The item's facts as plain text, prepended to the first message of an
+    /// item-scoped chat so the model usually doesn't need a tool round trip.
+    var aiContextSummary: String {
+        var lines = ["Here are the details of the pack item I'm asking about:"]
+        lines.append("- Name: \(name)")
+        if let description, !description.isEmpty {
+            lines.append("- Description: \(description)")
+        }
+        lines.append("- Weight: \(displayWeight.isEmpty ? "not set" : displayWeight)")
+        lines.append("- Quantity: \(quantity)")
+        lines.append("- Category: \(category ?? "uncategorized")")
+        lines.append("- Worn: \(worn ? "yes" : "no")")
+        lines.append("- Consumable: \(consumable ? "yes" : "no")")
+        if let notes, !notes.isEmpty {
+            lines.append("- Notes: \(notes)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Structured form of `aiContextSummary`, returned as the result of a
+    /// client-executed `getPackItemDetails` call.
+    var aiToolFields: [String: String] {
+        var fields: [String: String] = [
+            "id": id,
+            "name": name,
+            "quantity": "\(quantity)",
+            "category": category ?? "uncategorized",
+            "worn": worn ? "true" : "false",
+            "consumable": consumable ? "true" : "false",
+        ]
+        if weight > 0 {
+            fields["weight"] = displayWeight
+        }
+        if let description, !description.isEmpty {
+            fields["description"] = description
+        }
+        if let notes, !notes.isEmpty {
+            fields["notes"] = notes
+        }
+        return fields
     }
 }
 

--- a/apps/swift/Tests/PackRatTests/ChatViewModelTests.swift
+++ b/apps/swift/Tests/PackRatTests/ChatViewModelTests.swift
@@ -44,6 +44,214 @@ struct ChatStreamViewModelTests {
     }
 }
 
+@Suite("ChatViewModel item context")
+@MainActor
+struct ChatItemContextViewModelTests {
+    private func itemContext(details: String? = nil, fields: [String: String] = [:]) -> ChatContext {
+        .item(id: "item-42", name: "Down Quilt", details: details, fields: fields)
+    }
+
+    @Test("item context opens with a greeting naming the item")
+    func itemContextGreetsWithItemName() {
+        let viewModel = ChatViewModel(service: MockChatService(chunks: []), context: itemContext())
+
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages.first?.role == .assistant)
+        #expect(viewModel.messages.first?.content == "I see you're looking at Down Quilt. What would you like to know about it?")
+    }
+
+    @Test("sendMessage forwards the item scoping to the transport")
+    func sendMessageForwardsItemContext() async throws {
+        let service = MockChatService(chunks: [#"{"type":"text-delta","id":"m","delta":"ok"}"#])
+        let viewModel = ChatViewModel(service: service, context: itemContext())
+
+        viewModel.inputText = "How can I cut weight?"
+        viewModel.sendMessage()
+        try await waitUntil { !viewModel.isStreaming }
+
+        #expect(service.lastContext?.contextType == "item")
+        #expect(service.lastContext?.itemId == "item-42")
+        #expect(service.lastContext?.packId == nil)
+    }
+
+    @Test("first message is primed with item details, later messages are not")
+    func firstMessageCarriesItemDetails() async throws {
+        let service = MockChatService(chunks: [#"{"type":"text-delta","id":"m","delta":"ok"}"#])
+        let viewModel = ChatViewModel(
+            service: service,
+            context: itemContext(details: "- Name: Down Quilt\n- Weight: 700 g")
+        )
+
+        viewModel.inputText = "How can I cut weight?"
+        viewModel.sendMessage()
+        try await waitUntil { !viewModel.isStreaming }
+
+        // The visible bubble stays exactly what was typed…
+        let bubble = try #require(viewModel.messages.first { $0.role == .user })
+        #expect(bubble.content == "How can I cut weight?")
+
+        // …while the wire copy carries the details the tool would have returned.
+        let sent = try #require(service.lastMessages?.last)
+        #expect(sent.content.contains("- Weight: 700 g"))
+        #expect(sent.content.contains("How can I cut weight?"))
+
+        viewModel.inputText = "And the quilt?"
+        viewModel.sendMessage()
+        try await waitUntil { !viewModel.isStreaming }
+
+        // Second turn goes verbatim — the details are already in the history.
+        let second = try #require(service.lastMessages?.last)
+        #expect(second.content == "And the quilt?")
+    }
+
+    @Test("an unanswered client tool call is answered and the turn resumes")
+    func clientToolCallIsAnswered() async throws {
+        // getPackItemDetails has no server-side execute, so a turn that calls it
+        // ends with no text. The view model must supply the result and re-send.
+        let service = MockChatService(chunks: [
+            #"{"type":"tool-input-start","toolCallId":"call_1","toolName":"getPackItemDetails"}"#,
+            #"{"type":"tool-input-available","toolCallId":"call_1","toolName":"getPackItemDetails","input":{"itemId":"item-42"}}"#,
+        ])
+        let viewModel = ChatViewModel(
+            service: service,
+            context: itemContext(fields: ["id": "item-42", "name": "Down Quilt", "weight": "700 g"])
+        )
+
+        viewModel.inputText = "How can I cut weight?"
+        viewModel.sendMessage()
+        try await waitUntil { !viewModel.isStreaming }
+
+        // The re-sent history must carry the answered call, encoded as a
+        // tool-<name> part with state output-available.
+        let resent = try #require(service.lastMessages)
+        let assistantWithTool = resent.first { !$0.toolInvocations.isEmpty }
+        let invocation = try #require(assistantWithTool?.toolInvocations.first)
+        #expect(invocation.state == .complete)
+        #expect(invocation.toolName == "getPackItemDetails")
+
+        let outputData = try #require(invocation.outputData)
+        let output = try #require(try JSONSerialization.jsonObject(with: outputData) as? [String: Any])
+        #expect(output["success"] as? Bool == true)
+        let data = try #require(output["data"] as? [String: String])
+        #expect(data["weight"] == "700 g")
+    }
+
+    @Test("a URLSession cancellation keeps the user's message and shows no error")
+    func urlCancellationIsNotAFailure() async throws {
+        // URLSession reports cancellation as NSURLErrorCancelled, not
+        // CancellationError. Treating it as a failure used to delete the message
+        // the user had just sent.
+        let service = MockChatService(chunks: [], error: URLError(.cancelled))
+        let viewModel = ChatViewModel(service: service, context: itemContext())
+
+        viewModel.inputText = "How can I cut weight?"
+        viewModel.sendMessage()
+        try await waitUntil { !viewModel.isStreaming }
+
+        #expect(viewModel.error == nil)
+        #expect(viewModel.messages.contains { $0.role == .user && $0.content == "How can I cut weight?" })
+    }
+
+    @Test("clearHistory restores the item greeting rather than a general one")
+    func clearHistoryKeepsItemScope() {
+        let viewModel = ChatViewModel(service: MockChatService(chunks: []), context: itemContext())
+        viewModel.messages.append(ChatMessage(role: .user, content: "Hi"))
+
+        viewModel.clearHistory()
+
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages.first?.content.contains("Down Quilt") == true)
+    }
+
+    @Test("general context keeps the existing generic greeting and prompt")
+    func generalContextUnchanged() async throws {
+        let service = MockChatService(chunks: [#"{"type":"text-delta","id":"m","delta":"ok"}"#])
+        let viewModel = ChatViewModel(service: service)
+
+        #expect(viewModel.messages.first?.content.hasPrefix("Hi! I'm your PackRat AI assistant") == true)
+
+        viewModel.inputText = "Hello there"
+        viewModel.sendMessage()
+        try await waitUntil { !viewModel.isStreaming }
+
+        let sent = try #require(service.lastMessages?.last)
+        #expect(sent.content == "Hello there")
+    }
+}
+
+@Suite("ChatContext wire encoding")
+struct ChatContextEncodingTests {
+    private func encoded(_ context: ChatContext) throws -> [String: Any] {
+        let request = ChatRequest(messages: [ChatMessage(role: .user, content: "Hello")], context: context)
+        let object = try JSONSerialization.jsonObject(with: try JSONEncoder().encode(request))
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("item context encodes contextType and itemId for the API")
+    func itemContextEncodesItemId() throws {
+        let json = try encoded(.item(id: "item-7", name: "Down Quilt"))
+
+        #expect(json["contextType"] as? String == "item")
+        #expect(json["itemId"] as? String == "item-7")
+        #expect(json["packId"] == nil)
+    }
+
+    @Test("pack context still encodes contextType and packId")
+    func packContextEncodesPackId() throws {
+        let json = try encoded(.pack(id: "pack-3", name: "Summer Kit"))
+
+        #expect(json["contextType"] as? String == "pack")
+        #expect(json["packId"] as? String == "pack-3")
+        #expect(json["itemId"] == nil)
+    }
+
+    @Test("general context sends no item or pack id")
+    func generalContextSendsNoIds() throws {
+        let json = try encoded(.general)
+
+        #expect(json["contextType"] as? String == "general")
+        #expect(json["itemId"] == nil)
+        #expect(json["packId"] == nil)
+    }
+
+    @Test("item chips name the item; pack and general scopes have none here")
+    func itemSuggestionsNameTheItem() {
+        let suggestions = ChatContext.item(id: "i", name: "Down Quilt").itemSuggestions
+
+        #expect(!suggestions.isEmpty)
+        #expect(suggestions.allSatisfy { !$0.0.isEmpty })
+        #expect(suggestions.contains { $0.1.contains("Down Quilt") })
+        #expect(ChatContext.pack(id: "p", name: "Kit").itemSuggestions.isEmpty)
+        #expect(ChatContext.general.itemSuggestions.isEmpty)
+    }
+
+    @Test("pack toolPayload carries the pack contents when supplied")
+    func packToolPayloadCarriesContents() {
+        let withDetails = ChatContext.pack(id: "p", name: "Kit", details: "- Items:\n  - Tent, qty 1")
+        #expect(withDetails.toolPayload?["contents"]?.contains("Tent") == true)
+        #expect(withDetails.primingDetails?.contains("Tent") == true)
+
+        // Without contents the payload still identifies the pack, which is what
+        // development shipped — the model then says it can't retrieve it.
+        let withoutDetails = ChatContext.pack(id: "p", name: "Kit")
+        #expect(withoutDetails.toolPayload?["name"] == "Kit")
+        #expect(withoutDetails.toolPayload?["contents"] == nil)
+    }
+
+    @Test("toolPayload supplies item fields, falling back to id and name")
+    func toolPayloadShape() throws {
+        let withFields = ChatContext.item(
+            id: "i", name: "Down Quilt", fields: ["id": "i", "name": "Down Quilt", "weight": "700 g"]
+        )
+        #expect(withFields.toolPayload?["weight"] == "700 g")
+
+        let withoutFields = ChatContext.item(id: "i", name: "Down Quilt")
+        #expect(withoutFields.toolPayload?["name"] == "Down Quilt")
+
+        #expect(ChatContext.general.toolPayload == nil)
+    }
+}
+
 private enum MockChatError: LocalizedError {
     case streamFailed
 
@@ -60,13 +268,18 @@ private final class MockChatService: ChatServicing, @unchecked Sendable {
     /// the view model forwards its pack scoping to the transport.
     private(set) var lastContext: ChatContext?
 
+    /// The history handed to the transport on the most recent call. This is the
+    /// wire copy, which can differ from what the UI displays.
+    private(set) var lastMessages: [ChatMessage]?
+
     init(chunks: [String], error: (any Error)? = nil) {
         self.chunks = chunks
         self.error = error
     }
 
-    func sendMessage(messages _: [ChatMessage], context: ChatContext) async -> AsyncThrowingStream<String, Error> {
+    func sendMessage(messages: [ChatMessage], context: ChatContext) async -> AsyncThrowingStream<String, Error> {
         lastContext = context
+        lastMessages = messages
         return AsyncThrowingStream { continuation in
             for chunk in chunks {
                 continuation.yield(chunk)
@@ -82,7 +295,9 @@ private final class MockChatService: ChatServicing, @unchecked Sendable {
 
 @MainActor
 private func waitUntil(
-    timeout: Duration = .seconds(2),
+    // Generous, because a cold first run of the full suite can take seconds to
+    // schedule these continuations; the loop exits as soon as the condition holds.
+    timeout: Duration = .seconds(10),
     condition: @escaping @MainActor () -> Bool
 ) async throws {
     let start = ContinuousClock.now


### PR DESCRIPTION
## Description

Adds the **item** counterpart to the pack-scoped AI chat from #2686, and fixes the client-executed tool-call gap that stopped both scopes from working end to end.

The Expo app's pack item detail screen has an "Ask AI about this item" action that opens chat scoped to that item (`contextType: 'item'` + `itemId`). The Swift app had no equivalent — `ChatContext.item` was declared after #2686 but nothing ever constructed it, and `PackItemDetailView` had no entry point.

### Item scope

- `ChatContext.item` gains `name`, `details` and `fields`, so it can title the screen, phrase its suggestion chips, and answer a tool call with the item's own data.
- New `PackItemAskAISheet`, mirroring the existing `PackAskAISheet`. The view model is held in `@State` so it is created once per presentation — built inline in the `.sheet` closure, SwiftUI rebuilds it on any re-render (dismissing the keyboard is enough), which cancels the in-flight streaming request and drops the transcript.
- Greeting and chips mirror `getContextualGreeting` / `getContextualSuggestions` in `packages/api/src/utils/chatContextHelpers.ts`, so both clients read alike.
- The button is hidden for guests, since the chat API requires an account and `ChatView` would otherwise render its guest placeholder inside a sheet.

### Client-executed tool calls — also fixes pack chat

`getPackDetails` and `getPackItemDetails` are declared server-side **without an `execute`** (`packages/api/src/utils/ai/tools.ts`). The AI SDK expects the *client* to run them and send the result back, which Expo does via `useChat`'s `onToolCall`. Nothing did that here, so any turn that called either tool hung forever on "Assistant is typing".

**This was already reproducible on `development`:** opening a pack → More → Ask AI → "What's missing?" hangs on `Looked up pack details` with no reply. I verified that against a clean `d84a7a159` build before changing anything.

- `ChatUIMessage.parts` became polymorphic (`ChatUIPart`) so an assistant message can carry a `tool-<name>` part with `state: "output-available"`, its `toolCallId`, `input` and `output` — the shape `convertToModelMessages` reads.
- `ChatViewModel` streams a turn and, if it ended waiting on a client-executed tool, fills the result from local data and re-sends with the answered call in the history. Bounded to 3 round trips so a misbehaving model can't loop.
- `Pack.aiContextSummary`, `PackItem.aiContextSummary` and `PackItem.aiToolFields` supply the data. Both scopes also prime the first user message with it, which usually avoids the round trip entirely. The visible bubble still shows only what the user typed.
- URLSession reports cancellation as `URLError.cancelled`, not `CancellationError`, so it was taking the generic failure path and **deleting the message the user had just sent**. Now handled.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️  Refactor / code improvement
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration change
- [ ] ⬆️  Dependency update
- [ ] 🗄️  Database migration

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [ ] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)
- [x] Native Swift app (`apps/swift`) — iOS

## Testing

Driven on the **iPhone 17 simulator**, signed in as `qa1.admin@packratai.com` against the **deployed dev API** (`PACKRAT_ENV=dev`).

| Check | Result |
|---|---|
| Item chat streams a real reply | ✅ full formatted answer |
| Reply reflects the actual item | ✅ follow-up correctly reported the item as uncategorized with no material details |
| Multi-turn keeps history | ✅ second turn referenced the first |
| **Pack chat (regression check)** | ✅ now answers with the pack's real contents — *"your pack is mostly empty, with only one item listed"*; **hangs on `development`** |
| Pack sheet UI unchanged | ✅ same title, header, subtitle, greeting and all five pack chips |
| Guest mode | ✅ button correctly absent (Guest → Packs → item) |
| Unit tests | ✅ 248 tests; the only failures are 5 pre-existing `KeychainService` cases |

Unit tests added for: item greeting, wire encoding per scope (`contextType`/`itemId`/`packId`), first-message priming (and that later messages aren't re-primed), the tool round trip producing a `state: "output-available"` part, `URLError.cancelled` not destroying the message, and `toolPayload` shape for both scopes.

Also raised `waitUntil`'s timeout from 2s to 10s in `ChatViewModelTests` — a cold first run of the full suite could exceed it, which made the async chat tests flaky. Verified with a wiped `derivedDataPath`.

- [x] Added / updated unit tests
- [x] Manually tested on iOS
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)

## Screenshots / recordings

Captured on the iPhone 17 simulator but not attached here — I can't upload binaries to the PR from this environment. To reproduce in ~30 seconds:

1. Sign in, open any pack, tap an item.
2. Tap **Ask AI about this item** below the notes.
3. The sheet opens titled with the item's name, greeting *"I see you're looking at &lt;item&gt;. What would you like to know about it?"*, with chips **Tell me more / Alternatives / Cut weight / Worth bringing? / How to care**.
4. Tap **Cut weight** — a formatted ultralight-strategies reply streams in, with no "Assistant is typing" stall.

Happy to attach the screenshot if you want it inline.

## Notes for the reviewer

- **No API changes.** The server already accepted `contextType: 'item'` + `itemId`; only the Swift client was missing.
- **`ChatContext` collision.** This branch originally defined its own `ChatContext` before #2686 merged. It has been rebased onto #2686's enum and extended in place — `packName`, the pack sheet, and all pack copy are preserved as-is. Pack chats additionally gained contextual chips, which previously fell back to the generic list.
- I did not add a feature flag: this mirrors an existing shipped Expo surface and sits behind the same auth gate as the rest of chat. Happy to add one if you'd prefer.
- The diff is Swift-only, so `bun check` and `bun check-types` match no changed files. Verification for this change is the Xcode build plus `PackRatTests` above.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors *(Biome matches 0 changed files — Swift-only diff)*
- [x] `bun check-types` passes with no errors *(no TS files changed)*
- [x] No new secrets or credentials are committed
- [ ] Database migration included (if schema changed) — n/a
- [ ] Feature flag added (if this is a new feature) — see note above
- [x] PR title follows conventional commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated “Ask AI about this item” chat from item detail pages.
  * Added item-aware greetings, suggestions, navigation titles, and welcome content.
  * Pack and item chats now provide relevant details to answer questions more accurately.
  * Chat responses can handle supported pack and item detail requests during conversations.

* **Bug Fixes**
  * Preserved partially streamed responses when requests are cancelled.
  * Clearing chat history now restores the appropriate contextual greeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->