### PR TITLE
fix(api): make pack creation idempotent for replayed writes

### DIFF
--- a/packages/api/src/routes/packs/__tests__/createIdempotency.test.ts
+++ b/packages/api/src/routes/packs/__tests__/createIdempotency.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for idempotent pack creation, driven through the real route.
+ *
+ * `POST /packs` takes a client-supplied `id` and inserts it into `packs.id`, a
+ * `text().primaryKey()`. The insert carried no conflict clause, so a create that
+ * arrived twice raised a primary-key violation. The route's catch turned that into a
+ * 500, and `OutboxService.classify` on the client treats 5xx as a retryable transport
+ * failure — so the replay burned all five attempts and then marked the write
+ * permanently failed, surfacing the red "changes couldn't be saved" banner.
+ *
+ * Duplicates are not hypothetical here: the offline outbox replays queued writes, and
+ * the Expo carryover import queued a create for every record it read — which is how a
+ * signed-in user's first launch of the Swift build produced "210 changes waiting to
+ * sync" for packs the server already owned.
+ *
+ * The fix adds `onConflictDoNothing({ target: packs.id })` and, when the insert is a
+ * no-op, re-reads the caller's own pack so the replay is idempotent. The re-read is
+ * scoped by `userId` so a guessed id can neither overwrite nor disclose another user's
+ * pack — that case gets a 409, which the client already treats as success on create.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const EXISTING_ID = 'pack-already-on-server';
+const OWNER_ID = 'user-1';
+
+/** Rows the fake database holds, keyed by `id`. */
+type Row = Record<string, unknown> & { id: string; userId: string };
+const rows = new Map<string, Row>();
+
+/** The columns `PackWithWeightsSchema` requires beyond what the insert supplies. */
+const packColumnDefaults = {
+  description: null,
+  image: null,
+  tags: null,
+  deleted: false,
+  isAIGenerated: false,
+  isPublic: false,
+  category: 'hiking',
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  localCreatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  localUpdatedAt: new Date('2026-08-01T00:00:00.000Z'),
+} as const;
+
+const mocks = vi.hoisted(() => ({
+  onConflictDoNothing: vi.fn(),
+  authenticatedUserId: { current: 'user-1' },
+}));
+
+vi.mock('@packrat/api/db', () => ({
+  createDb: () => {
+    const db = {
+      tag: (_label: string) => db,
+      insert: (_table: unknown) => ({
+        values: (values: Row) => ({
+          // No conflict clause would mean a unique violation here; the route must go
+          // through `onConflictDoNothing` instead, so this path is deliberately absent.
+          onConflictDoNothing: (args: unknown) => {
+            mocks.onConflictDoNothing(args);
+            return {
+              // Postgres returns no row when the conflict target already exists.
+              returning: async () => {
+                if (rows.has(values.id)) return [];
+                const row = { ...packColumnDefaults, ...values };
+                rows.set(values.id, row);
+                return [row];
+              },
+            };
+          },
+        }),
+      }),
+      query: {
+        packs: {
+          findFirst: async (args: { where: Record<string, string | undefined> }) => {
+            // `eq` below keys the clause by the real column name, so `userId` arrives
+            // as its snake_case column, `user_id`.
+            const { id, user_id: userId } = args.where;
+            if (!id || !userId) return undefined;
+            const row = rows.get(id);
+            if (!row || row.userId !== userId) return undefined;
+            return { ...row, items: [] };
+          },
+        },
+      },
+    };
+    return db;
+  },
+}));
+
+// `and`/`eq` are only used to build the where clause the fake `findFirst` reads back.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    and: (...conds: Array<Record<string, unknown>>) => Object.assign({}, ...conds),
+    eq: (col: { name?: string }, val: unknown) => ({ [col?.name ?? 'unknown']: val }),
+  };
+});
+
+// Authenticate every request as `authenticatedUserId` without standing up Better Auth.
+vi.mock('@packrat/api/middleware/auth', async () => {
+  const { Elysia } = await import('elysia');
+  const plugin = new Elysia({ name: 'authPlugin' })
+    .derive(() => ({
+      user: { userId: mocks.authenticatedUserId.current, role: 'USER', email: 't@test.com' },
+    }))
+    .macro({ isAuthenticated: () => ({}), isAdmin: () => ({}) })
+    .as('scoped');
+  return { authPlugin: plugin, adminAuthPlugin: plugin };
+});
+
+// Keep the route's catch silent; these tests assert on status codes, not reports.
+vi.mock('@packrat/api/utils/sentry', () => ({
+  captureApiException: () => {},
+  apiAddBreadcrumb: () => {},
+  record: async (_o: unknown, fn: () => unknown) => fn(),
+}));
+
+const { packsRoutes } = await import('@packrat/api/routes/packs');
+
+function post(body: Record<string, unknown>) {
+  return packsRoutes.handle(
+    new Request('http://localhost/packs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function newPackBody(overrides: Record<string, unknown> = {}) {
+  const now = new Date().toISOString();
+  return {
+    id: EXISTING_ID,
+    name: 'Server Owned Pack',
+    category: 'hiking',
+    isPublic: false,
+    localCreatedAt: now,
+    localUpdatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('POST /packs idempotency', () => {
+  beforeEach(() => {
+    rows.clear();
+    vi.clearAllMocks();
+    mocks.authenticatedUserId.current = OWNER_ID;
+    rows.set(EXISTING_ID, {
+      ...packColumnDefaults,
+      id: EXISTING_ID,
+      userId: OWNER_ID,
+      name: 'Server Owned Pack',
+    });
+  });
+
+  it('uses a conflict clause so a duplicate id cannot raise a primary-key violation', async () => {
+    await post(newPackBody());
+
+    expect(mocks.onConflictDoNothing).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the existing pack instead of 500 when the owner replays a create', async () => {
+    const res = await post(newPackBody());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: EXISTING_ID, name: 'Server Owned Pack' });
+  });
+
+  it('still creates a pack whose id is genuinely new', async () => {
+    const res = await post(newPackBody({ id: 'brand-new-pack', name: 'Fresh' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: 'brand-new-pack', name: 'Fresh' });
+    expect(rows.has('brand-new-pack')).toBe(true);
+  });
+
+  it('does not disclose or overwrite a pack belonging to another user', async () => {
+    mocks.authenticatedUserId.current = 'user-2';
+
+    const res = await post(newPackBody({ name: 'Hijack' }));
+
+    // 409 rather than the owner's row: the outbox treats 409-on-create as success, so
+    // the write stops replaying without the caller learning anything about the pack.
+    expect(res.status).toBe(409);
+    expect(rows.get(EXISTING_ID)).toMatchObject({ userId: OWNER_ID, name: 'Server Owned Pack' });
+  });
+});

--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -161,6 +161,12 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
 
         // Zod validates all fields at runtime; cast through the Standard Schema
         // inference gap so drizzle's insert accepts the values.
+        //
+        // `id` is client-supplied, so the same create can arrive twice: the offline
+        // outbox replays queued writes, and a retried request is indistinguishable
+        // from a new one. Without a conflict clause the second attempt raised a
+        // primary-key violation, surfaced as a 500, and the client marked the write
+        // permanently failed. Ignoring the conflict makes the replay a no-op instead.
         const [newPack] = await db
           .tag('packs.create')
           .insert(packs)
@@ -176,12 +182,27 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
             localCreatedAt: new Date(data.localCreatedAt as string),
             localUpdatedAt: new Date(data.localUpdatedAt as string),
           } as typeof packs.$inferInsert)
+          .onConflictDoNothing({ target: packs.id })
           .returning();
 
-        if (!newPack) return status(500, { error: 'Failed to create pack' });
+        if (newPack) {
+          const packWithItems: PackWithItems = { ...newPack, items: [] };
+          return PackWithWeightsSchema.parse(computePackWeights({ pack: packWithItems }));
+        }
 
-        const packWithItems: PackWithItems = { ...newPack, items: [] };
-        return PackWithWeightsSchema.parse(computePackWeights({ pack: packWithItems }));
+        // The id already exists. Return the caller's own pack so a replayed create is
+        // idempotent, scoping the read by `userId` so a guessed id can neither
+        // overwrite nor disclose someone else's pack.
+        const existingPack: PackWithItems | undefined = await db
+          .tag('packs.createConflict')
+          .query.packs.findFirst({
+            where: and(eq(packs.id, data.id), eq(packs.userId, user.userId)),
+            with: { items: true },
+          });
+
+        if (!existingPack) return status(409, { error: 'Pack id already exists' });
+
+        return PackWithWeightsSchema.parse(computePackWeights({ pack: existingPack }));
       } catch (error) {
         captureApiException({ error, operation: 'packs.create' });
         return status(500, { error: 'Failed to create pack' });
@@ -192,6 +213,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       response: {
         200: 'packs.PackWithWeights',
         400: 'packs.ErrorResponse',
+        409: 'packs.ErrorResponse',
         500: 'packs.ErrorResponse',
       },
       isAuthenticated: true,


### PR DESCRIPTION
## Description

`POST /packs` takes a client-supplied `id` and inserts it into `packs.id`, a `text().primaryKey()`, with no conflict clause. A create that arrived twice raised a unique violation, the route's catch turned it into a **500**, and `OutboxService.classify` on the client treats 5xx as a retryable transport failure — so the mobile app burned all five attempts and then marked the write permanently failed, surfacing the red "changes couldn't be saved to the server" banner.

Duplicate creates are routine rather than hypothetical: the offline outbox replays queued writes, and a retried request is indistinguishable from a new one to the server.

This adds `onConflictDoNothing({ target: packs.id })`, and when the insert is a no-op re-reads the caller's own pack so the replay returns 200 with the existing row. The re-read is scoped by `userId`, so a guessed id can neither overwrite nor disclose another user's pack — that case returns **409**, which the client already treats as success on create (`classify`: `if operation == .create, statusCode == 409 { return .success }`).

### Where this came from

Found while chasing a "210 changes waiting to sync" banner after an Expo → Swift in-place update. The client-side half of that bug — the Expo import re-queueing records the server already owned — is in #2724, which is where the migration itself lives. This half stands on its own: any offline write replayed after a connectivity blip hit the same 500.

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [x] API / Backend (`packages/api`)

## Testing

- [x] Added / updated unit tests

Four tests drive the real `packsRoutes` handler with a faked DB and auth: the conflict clause is used, an owner's replay returns 200 with the existing pack, a genuinely new id still creates, and another user's id returns 409 without overwriting or disclosing the row.

They fail against the pre-fix route with exactly the reported symptom:

```
× returns the existing pack instead of 500 when the owner replays a create
  → expected 500 to be 200
× does not disclose or overwrite a pack belonging to another user
  → expected 500 to be 409
```

Full API unit suite: **623 passed / 42 files**.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [ ] Database migration included (n/a — no schema change; `packs.id` was already the primary key)
- [ ] Feature flag added (n/a — bug fix)
- [x] PR title follows conventional commits

### Note on `bun lint:weak-assertions`

It fails on this branch, but on `entitlementsService.test.ts`, `passwordResetService.test.ts` and `packages/analytics` — all pre-existing on `development`, none touched here. The fat-table projection lint passes; the `with: { items: true }` added here matches the existing allow-listed `packs.getById` shape.
