### PR TITLE
fix: filter soft-deleted packs, templates and trips from reads

### DIFF
--- a/apps/swift/Sources/PackRat/Features/PackTemplates/PackTemplatesViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/PackTemplates/PackTemplatesViewModel.swift
@@ -43,7 +43,7 @@ final class PackTemplatesViewModel {
         error = nil
         defer { isLoading = false }
         do {
-            templates = try await service.listTemplates()
+            templates = try await service.listTemplates().activeTemplates
         } catch {
             self.error = error.localizedDescription
         }

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -187,6 +187,7 @@ struct PacksListView: View {
         defer { isLoadingPublic = false }
         do {
             publicPacks = try await viewModel.service.listPacks(page: 1, limit: 30, includePublic: true)
+                .activePacks
         } catch { }
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -51,7 +51,7 @@ final class PacksViewModel {
             let cached = (try? context.fetch(FetchDescriptor<CachedPack>(
                 sortBy: [SortDescriptor(\.cachedAt, order: .reverse)]
             ))) ?? []
-            let cachedPacks = cached.compactMap { $0.toPack() }
+            let cachedPacks = cached.compactMap { $0.toPack() }.activePacks
             if !cachedPacks.isEmpty {
                 packs = cachedPacks
                 isCacheLoaded = true
@@ -69,11 +69,15 @@ final class PacksViewModel {
 
         do {
             let fresh = try await service.listPacks(page: 1, limit: pageSize)
-            packs = fresh
+            let active = fresh.activePacks
+            packs = active
             currentPage = 1
+            // Page-size comparison stays on the raw response: filtering shrinks
+            // the array, and testing the filtered count would end pagination
+            // early on a page that happened to contain tombstones.
             hasMore = fresh.count == pageSize
             if let context {
-                writeCachePacks(fresh, context: context)
+                writeCachePacks(active, context: context)
             }
         } catch {
             if packs.isEmpty {
@@ -94,7 +98,7 @@ final class PacksViewModel {
         defer { isLoading = false }
         do {
             let more = try await service.listPacks(page: nextPage, limit: pageSize)
-            packs.append(contentsOf: more)
+            packs.append(contentsOf: more.activePacks)
             currentPage = nextPage
             hasMore = more.count == pageSize
         } catch { }

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
@@ -63,7 +63,7 @@ final class TripsViewModel {
             let cached = (try? context.fetch(FetchDescriptor<CachedTrip>(
                 sortBy: [SortDescriptor(\.cachedAt, order: .reverse)]
             ))) ?? []
-            let cachedTrips = cached.compactMap { $0.toTrip() }
+            let cachedTrips = cached.compactMap { $0.toTrip() }.activeTrips
             if !cachedTrips.isEmpty {
                 trips = cachedTrips
                 isCacheLoaded = true
@@ -81,11 +81,13 @@ final class TripsViewModel {
 
         do {
             let fresh = try await service.listTrips(page: 1, limit: pageSize)
-            trips = fresh
+            let active = fresh.activeTrips
+            trips = active
             currentPage = 1
+            // Page-size comparison stays on the raw response — see PacksViewModel.
             hasMore = fresh.count == pageSize
             if let context {
-                writeCacheTrips(fresh, context: context)
+                writeCacheTrips(active, context: context)
             }
         } catch {
             if trips.isEmpty {
@@ -106,7 +108,7 @@ final class TripsViewModel {
         defer { isLoading = false }
         do {
             let more = try await service.listTrips(page: nextPage, limit: pageSize)
-            trips.append(contentsOf: more)
+            trips.append(contentsOf: more.activeTrips)
             currentPage = nextPage
             hasMore = more.count == pageSize
         } catch { }

--- a/apps/swift/Sources/PackRat/Models/Pack.swift
+++ b/apps/swift/Sources/PackRat/Models/Pack.swift
@@ -5,6 +5,22 @@ import Foundation
 extension Pack {
     var activeItems: [PackItem] { (items ?? []).filter { !$0.deleted } }
     var itemCount: Int { activeItems.count }
+}
+
+extension Array where Element == Pack {
+    /// Drops soft-deleted packs (tombstones).
+    ///
+    /// Applied at every ingress into a view model's `packs` array — network
+    /// responses, SwiftData cache reads, and pagination — so the app never
+    /// renders a tombstone even if a server or a locally-migrated cache hands
+    /// one over. Expo got this for free from Legend State's `fieldDeleted`
+    /// tombstone handling; the Swift client has no sync layer, so it filters
+    /// explicitly. Migrating users carry Expo-era local data that contains
+    /// tombstones, so client-side filtering is required, not just defensive.
+    var activePacks: [Pack] { filter { !$0.deleted } }
+}
+
+extension Pack {
 
     func formattedWeight(_ grams: Double?) -> String {
         guard let g = grams, g > 0 else { return "0 g" }

--- a/apps/swift/Sources/PackRat/Models/PackTemplate.swift
+++ b/apps/swift/Sources/PackRat/Models/PackTemplate.swift
@@ -13,9 +13,50 @@ struct PackTemplate: Codable, Identifiable, Sendable {
     let items: [PackTemplateItem]?
     let createdAt: String?
     let updatedAt: String?
+    // Optional-with-default: older cached payloads predate this field.
+    let deleted: Bool?
 
-    var itemCount: Int { items?.count ?? 0 }
+    var isDeleted: Bool { deleted ?? false }
+    var activeItems: [PackTemplateItem] { (items ?? []).filter { !$0.isDeleted } }
+    var itemCount: Int { activeItems.count }
     var isOfficial: Bool { isAppTemplate ?? false }
+
+    // Explicit init so `deleted` can default — callers constructing new local
+    // templates never create them pre-deleted.
+    init(
+        id: String,
+        userId: String? = nil,
+        name: String,
+        description: String? = nil,
+        category: String? = nil,
+        image: String? = nil,
+        tags: [String]? = nil,
+        isAppTemplate: Bool? = nil,
+        contentSource: String? = nil,
+        items: [PackTemplateItem]? = nil,
+        createdAt: String? = nil,
+        updatedAt: String? = nil,
+        deleted: Bool? = nil
+    ) {
+        self.id = id
+        self.userId = userId
+        self.name = name
+        self.description = description
+        self.category = category
+        self.image = image
+        self.tags = tags
+        self.isAppTemplate = isAppTemplate
+        self.contentSource = contentSource
+        self.items = items
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deleted = deleted
+    }
+}
+
+extension Array where Element == PackTemplate {
+    /// Drops soft-deleted templates. See `Array<Pack>.activePacks`.
+    var activeTemplates: [PackTemplate] { filter { !$0.isDeleted } }
 }
 
 struct PackTemplateItem: Codable, Identifiable, Sendable {
@@ -29,6 +70,38 @@ struct PackTemplateItem: Codable, Identifiable, Sendable {
     let consumable: Bool?
     let worn: Bool?
     let notes: String?
+    // Optional so older cached payloads (which predate this field) still decode.
+    let deleted: Bool?
+
+    var isDeleted: Bool { deleted ?? false }
+
+    // Explicit init so `deleted` can default — callers constructing new local
+    // items never create them pre-deleted.
+    init(
+        id: String,
+        packTemplateId: String? = nil,
+        name: String,
+        weight: Double? = nil,
+        weightUnit: String? = nil,
+        quantity: Int? = nil,
+        category: String? = nil,
+        consumable: Bool? = nil,
+        worn: Bool? = nil,
+        notes: String? = nil,
+        deleted: Bool? = nil
+    ) {
+        self.id = id
+        self.packTemplateId = packTemplateId
+        self.name = name
+        self.weight = weight
+        self.weightUnit = weightUnit
+        self.quantity = quantity
+        self.category = category
+        self.consumable = consumable
+        self.worn = worn
+        self.notes = notes
+        self.deleted = deleted
+    }
 
     var weightInGrams: Double {
         guard let w = weight, let u = weightUnit else { return 0 }

--- a/apps/swift/Sources/PackRat/Models/Trip.swift
+++ b/apps/swift/Sources/PackRat/Models/Trip.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+extension Array where Element == Trip {
+    /// Drops soft-deleted trips. See `Array<Pack>.activePacks`.
+    var activeTrips: [Trip] { filter { !$0.deleted } }
+}
+
 // MARK: - Trip extensions (structs defined in Generated.swift)
 
 extension Trip {

--- a/apps/swift/Sources/PackRat/Services/PackTemplateService.swift
+++ b/apps/swift/Sources/PackRat/Services/PackTemplateService.swift
@@ -70,7 +70,10 @@ final class PackTemplateService: Sendable {
     /// Applies a template to an existing pack by copying all template items.
     func applyToPack(templateId: String, packId: String) async throws {
         let template = try await getTemplate(templateId)
-        guard let items = template.items else { return }
+        // `activeItems`, not `items`: copying tombstoned template items would
+        // resurrect deleted gear into the target pack.
+        let items = template.activeItems
+        guard !items.isEmpty else { return }
         let packService = PackService.shared
         for item in items {
             _ = try await packService.addItem(

--- a/packages/api/src/routes/packTemplates/index.ts
+++ b/packages/api/src/routes/packTemplates/index.ts
@@ -135,8 +135,11 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
     async ({ user }) => {
       const db = createDb();
       const templates = await db.tag('packTemplates.list').query.packTemplates.findMany({
-        where: or(eq(packTemplates.userId, user.userId), eq(packTemplates.isAppTemplate, true)),
-        with: { items: true },
+        where: and(
+          or(eq(packTemplates.userId, user.userId), eq(packTemplates.isAppTemplate, true)),
+          eq(packTemplates.deleted, false),
+        ),
+        with: { items: { where: eq(packTemplateItems.deleted, false) } },
       });
       return templates;
     },
@@ -537,7 +540,7 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
           or(eq(packTemplates.userId, user.userId), eq(packTemplates.isAppTemplate, true)),
           eq(packTemplates.deleted, false),
         ),
-        with: { items: true },
+        with: { items: { where: eq(packTemplateItems.deleted, false) } },
       });
 
       if (!template) return status(404, { error: 'Template not found' });
@@ -665,7 +668,12 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
         .tag('packTemplates.listItems')
         .select()
         .from(packTemplateItems)
-        .where(eq(packTemplateItems.packTemplateId, templateId));
+        .where(
+          and(
+            eq(packTemplateItems.packTemplateId, templateId),
+            eq(packTemplateItems.deleted, false),
+          ),
+        );
 
       return items;
     },

--- a/packages/api/src/routes/packs/__tests__/createIdempotency.test.ts
+++ b/packages/api/src/routes/packs/__tests__/createIdempotency.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for idempotent pack creation, driven through the real route.
+ *
+ * `POST /packs` takes a client-supplied `id` and inserts it into `packs.id`, a
+ * `text().primaryKey()`. The insert carried no conflict clause, so a create that
+ * arrived twice raised a primary-key violation. The route's catch turned that into a
+ * 500, and `OutboxService.classify` on the client treats 5xx as a retryable transport
+ * failure — so the replay burned all five attempts and then marked the write
+ * permanently failed, surfacing the red "changes couldn't be saved" banner.
+ *
+ * Duplicates are not hypothetical here: the offline outbox replays queued writes, and
+ * the Expo carryover import queued a create for every record it read — which is how a
+ * signed-in user's first launch of the Swift build produced "210 changes waiting to
+ * sync" for packs the server already owned.
+ *
+ * The fix adds `onConflictDoNothing({ target: packs.id })` and, when the insert is a
+ * no-op, re-reads the caller's own pack so the replay is idempotent. The re-read is
+ * scoped by `userId` so a guessed id can neither overwrite nor disclose another user's
+ * pack — that case gets a 409, which the client already treats as success on create.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const EXISTING_ID = 'pack-already-on-server';
+const OWNER_ID = 'user-1';
+
+/** Rows the fake database holds, keyed by `id`. */
+type Row = Record<string, unknown> & { id: string; userId: string };
+const rows = new Map<string, Row>();
+
+/** The columns `PackWithWeightsSchema` requires beyond what the insert supplies. */
+const packColumnDefaults = {
+  description: null,
+  image: null,
+  tags: null,
+  deleted: false,
+  isAIGenerated: false,
+  isPublic: false,
+  category: 'hiking',
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  localCreatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  localUpdatedAt: new Date('2026-08-01T00:00:00.000Z'),
+} as const;
+
+const mocks = vi.hoisted(() => ({
+  onConflictDoNothing: vi.fn(),
+  authenticatedUserId: { current: 'user-1' },
+}));
+
+vi.mock('@packrat/api/db', () => ({
+  createDb: () => {
+    const db = {
+      tag: (_label: string) => db,
+      insert: (_table: unknown) => ({
+        values: (values: Row) => ({
+          // No conflict clause would mean a unique violation here; the route must go
+          // through `onConflictDoNothing` instead, so this path is deliberately absent.
+          onConflictDoNothing: (args: unknown) => {
+            mocks.onConflictDoNothing(args);
+            return {
+              // Postgres returns no row when the conflict target already exists.
+              returning: async () => {
+                if (rows.has(values.id)) return [];
+                const row = { ...packColumnDefaults, ...values };
+                rows.set(values.id, row);
+                return [row];
+              },
+            };
+          },
+        }),
+      }),
+      query: {
+        packs: {
+          findFirst: async (args: { where: Record<string, string | undefined> }) => {
+            // `eq` below keys the clause by the real column name, so `userId` arrives
+            // as its snake_case column, `user_id`.
+            const { id, user_id: userId } = args.where;
+            if (!id || !userId) return undefined;
+            const row = rows.get(id);
+            if (!row || row.userId !== userId) return undefined;
+            return { ...row, items: [] };
+          },
+        },
+      },
+    };
+    return db;
+  },
+}));
+
+// `and`/`eq` are only used to build the where clause the fake `findFirst` reads back.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    and: (...conds: Array<Record<string, unknown>>) => Object.assign({}, ...conds),
+    eq: (col: { name?: string }, val: unknown) => ({ [col?.name ?? 'unknown']: val }),
+  };
+});
+
+// Authenticate every request as `authenticatedUserId` without standing up Better Auth.
+vi.mock('@packrat/api/middleware/auth', async () => {
+  const { Elysia } = await import('elysia');
+  const plugin = new Elysia({ name: 'authPlugin' })
+    .derive(() => ({
+      user: { userId: mocks.authenticatedUserId.current, role: 'USER', email: 't@test.com' },
+    }))
+    .macro({ isAuthenticated: () => ({}), isAdmin: () => ({}) })
+    .as('scoped');
+  return { authPlugin: plugin, adminAuthPlugin: plugin };
+});
+
+// Keep the route's catch silent; these tests assert on status codes, not reports.
+vi.mock('@packrat/api/utils/sentry', () => ({
+  captureApiException: () => {},
+  apiAddBreadcrumb: () => {},
+  record: async (_o: unknown, fn: () => unknown) => fn(),
+}));
+
+const { packsRoutes } = await import('@packrat/api/routes/packs');
+
+function post(body: Record<string, unknown>) {
+  return packsRoutes.handle(
+    new Request('http://localhost/packs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer test' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function newPackBody(overrides: Record<string, unknown> = {}) {
+  const now = new Date().toISOString();
+  return {
+    id: EXISTING_ID,
+    name: 'Server Owned Pack',
+    category: 'hiking',
+    isPublic: false,
+    localCreatedAt: now,
+    localUpdatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('POST /packs idempotency', () => {
+  beforeEach(() => {
+    rows.clear();
+    vi.clearAllMocks();
+    mocks.authenticatedUserId.current = OWNER_ID;
+    rows.set(EXISTING_ID, {
+      ...packColumnDefaults,
+      id: EXISTING_ID,
+      userId: OWNER_ID,
+      name: 'Server Owned Pack',
+    });
+  });
+
+  it('uses a conflict clause so a duplicate id cannot raise a primary-key violation', async () => {
+    await post(newPackBody());
+
+    expect(mocks.onConflictDoNothing).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the existing pack instead of 500 when the owner replays a create', async () => {
+    const res = await post(newPackBody());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: EXISTING_ID, name: 'Server Owned Pack' });
+  });
+
+  it('still creates a pack whose id is genuinely new', async () => {
+    const res = await post(newPackBody({ id: 'brand-new-pack', name: 'Fresh' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: 'brand-new-pack', name: 'Fresh' });
+    expect(rows.has('brand-new-pack')).toBe(true);
+  });
+
+  it('does not disclose or overwrite a pack belonging to another user', async () => {
+    mocks.authenticatedUserId.current = 'user-2';
+
+    const res = await post(newPackBody({ name: 'Hijack' }));
+
+    // 409 rather than the owner's row: the outbox treats 409-on-create as success, so
+    // the write stops replaying without the caller learning anything about the pack.
+    expect(res.status).toBe(409);
+    expect(rows.get(EXISTING_ID)).toMatchObject({ userId: OWNER_ID, name: 'Server Owned Pack' });
+  });
+});

--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -162,6 +162,12 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
 
         // Zod validates all fields at runtime; cast through the Standard Schema
         // inference gap so drizzle's insert accepts the values.
+        //
+        // `id` is client-supplied, so the same create can arrive twice: the offline
+        // outbox replays queued writes, and a retried request is indistinguishable
+        // from a new one. Without a conflict clause the second attempt raised a
+        // primary-key violation, surfaced as a 500, and the client marked the write
+        // permanently failed. Ignoring the conflict makes the replay a no-op instead.
         const [newPack] = await db
           .tag('packs.create')
           .insert(packs)
@@ -177,12 +183,27 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
             localCreatedAt: new Date(data.localCreatedAt as string),
             localUpdatedAt: new Date(data.localUpdatedAt as string),
           } as typeof packs.$inferInsert)
+          .onConflictDoNothing({ target: packs.id })
           .returning();
 
-        if (!newPack) return status(500, { error: 'Failed to create pack' });
+        if (newPack) {
+          const packWithItems: PackWithItems = { ...newPack, items: [] };
+          return PackWithWeightsSchema.parse(computePackWeights({ pack: packWithItems }));
+        }
 
-        const packWithItems: PackWithItems = { ...newPack, items: [] };
-        return PackWithWeightsSchema.parse(computePackWeights({ pack: packWithItems }));
+        // The id already exists. Return the caller's own pack so a replayed create is
+        // idempotent, scoping the read by `userId` so a guessed id can neither
+        // overwrite nor disclose someone else's pack.
+        const existingPack: PackWithItems | undefined = await db
+          .tag('packs.createConflict')
+          .query.packs.findFirst({
+            where: and(eq(packs.id, data.id), eq(packs.userId, user.userId)),
+            with: { items: true },
+          });
+
+        if (!existingPack) return status(409, { error: 'Pack id already exists' });
+
+        return PackWithWeightsSchema.parse(computePackWeights({ pack: existingPack }));
       } catch (error) {
         captureApiException({ error, operation: 'packs.create' });
         return status(500, { error: 'Failed to create pack' });
@@ -193,6 +214,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       response: {
         200: 'packs.PackWithWeights',
         400: 'packs.ErrorResponse',
+        409: 'packs.ErrorResponse',
         500: 'packs.ErrorResponse',
       },
       isAuthenticated: true,

--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -99,9 +99,17 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       const includePublic = Number(query.includePublic ?? 0) === 1;
       const db = createDb();
 
-      const where = includePublic
-        ? and(or(eq(packs.userId, user.userId), eq(packs.isPublic, true)), eq(packs.deleted, false))
-        : eq(packs.userId, user.userId);
+      // `deleted` must be filtered on BOTH branches. It used to hang off the
+      // includePublic branch only, so the default (owned-only) path returned
+      // soft-deleted packs. The Expo client masked it via Legend State's
+      // `fieldDeleted` tombstone handling; the Swift client has no equivalent
+      // and rendered them.
+      const where = and(
+        includePublic
+          ? or(eq(packs.userId, user.userId), eq(packs.isPublic, true))
+          : eq(packs.userId, user.userId),
+        eq(packs.deleted, false),
+      );
 
       // Drop packItems.embedding (1536-dim) from list payload. Mobile hot
       // path — 5 packs × 20 items × ~6KB embedding = 600KB minimum DB→Worker
@@ -133,9 +141,9 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       const result = await db.tag('packs.list').query.packs.findMany({
         where,
         with: {
-          items: includePublic
-            ? { columns: PACK_ITEM_LIST_COLUMNS, where: eq(packItems.deleted, false) }
-            : { columns: PACK_ITEM_LIST_COLUMNS },
+          // Filter deleted items on both branches too — the owned-only path
+          // previously shipped tombstoned items and let clients count them.
+          items: { columns: PACK_ITEM_LIST_COLUMNS, where: eq(packItems.deleted, false) },
         },
       });
 
@@ -336,7 +344,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       // Same pattern as the list endpoint above — the audit missed this
       // callsite; folded in here for parity.
       const pack = await db.tag('packs.getById').query.packs.findFirst({
-        where: eq(packs.id, params.packId),
+        where: and(eq(packs.id, params.packId), eq(packs.deleted, false)),
         with: {
           items: {
             columns: {
@@ -390,7 +398,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
         // `<name> (<weight><unit> × <quantity>)`; without it, every entry
         // renders as `undefined (1200g × 1)`.
         const pack = await db.tag('packs.getById').query.packs.findFirst({
-          where: eq(packs.id, params.packId),
+          where: and(eq(packs.id, params.packId), eq(packs.deleted, false)),
           with: {
             items: {
               columns: {
@@ -784,7 +792,7 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
       const db = createDb();
 
       const pack = await db.tag('packs.getById').query.packs.findFirst({
-        where: eq(packs.id, params.packId),
+        where: and(eq(packs.id, params.packId), eq(packs.deleted, false)),
         columns: { id: true, userId: true, isPublic: true },
       });
 


### PR DESCRIPTION
## Description

The Swift app showed **6 packs** where the Expo app showed **5**. The extra row was `Packour`, a pack soft-deleted back in September 2025.

Root cause was in the API, not the Swift client. In the packs list route the `deleted = false` predicate hung off the `includePublic` branch only:

```ts
const where = includePublic
  ? and(or(eq(packs.userId, user.userId), eq(packs.isPublic, true)), eq(packs.deleted, false))
  : eq(packs.userId, user.userId);   // ← no deleted filter
```

Both clients request `includePublic=0` for "My Packs", so the server had been returning tombstones all along. Expo only looked correct by accident — its Legend State store declares `fieldDeleted: 'deleted'`, which drops tombstoned rows client-side. The Swift client has no sync layer, so the pre-existing server bug became visible.

Fixed on both sides: the server stops serving tombstones, and the Swift client filters them independently. The client-side half is not redundant — **migrating users carry Expo-era local data containing tombstones**, and the SwiftData cache can already hold rows written before this fix, so a server-only fix would leave `Packour` on screen indefinitely.

### API — swept every soft-deletable table

Audited all reads against `packs`, `packItems`, `packTemplates`, `packTemplateItems`, `trailConditionReports`, `trips`. Seven gaps in two files:

| Location | Gap |
|---|---|
| `packs/index.ts:102` | list: no `deleted` filter on pack (the reported bug) |
| `packs/index.ts:104` | list: items unfiltered when `includePublic=0` |
| `packs/index.ts:347, 401, 795` | detail / weight-breakdown / items: deleted pack reachable by direct id |
| `packTemplates/index.ts:138` | list: no filter on template **or** items |
| `packTemplates/index.ts:540` | getById: items unfiltered |
| `packTemplates/index.ts:667` | listItems: no filter |

Templates had live impact too: 4 deleted templates and 1 deleted template item were being served. `trips` and `trailConditionReports` already filtered correctly, so packs and templates were the outliers rather than a house convention.

### Swift — filter at every ingress

Added `activePacks` / `activeTemplates` / `activeTrips` and applied them at each point where rows enter a view model's collection, not just the network response:

- **SwiftData cache reads** — may hold tombstones written before this fix
- **Network refresh** — the filtered array is also what gets cached, so tombstones stop being persisted
- **Pagination appends**
- **Explore tab** public-packs fetch

`hasMore` deliberately still compares the **raw** response length against page size; testing the filtered count would end pagination early on a page containing tombstones.

Two findings beyond missing filters:

- `PackTemplate` / `PackTemplateItem` **did not decode `deleted` at all**, so the flag was invisible to the client and filtering was impossible until the field was added. It is optional so pre-existing cached payloads still decode. `itemCount` now counts active items, matching `Pack`.
- `PackTemplateService.applyToPack` copied **every** template item including tombstoned ones, resurrecting deleted gear into the target pack. That is a data-corruption path, not a display bug.

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [x] API / Backend (`packages/api`)
- [x] Swift app (`apps/swift`)

## Testing

- [x] Verified against production data: the corrected query returns exactly the 5 expected packs, with item counts matching the Expo screenshot — including `Pack` at "1 item", where 2 of its 3 item rows are soft-deleted
- [x] `bun test:api:unit` — 623/623 passing
- [x] Swift iOS smoke test plan — `TEST SUCCEEDED`, 0 failures (pinned iPhone 15 simulator)
- [x] `xcodebuild` PackRat-iOS — build succeeded
- [x] `bun check-types` — clean
- [x] Coverage ratchet — `packages/api` improved

## Notes for reviewer

- This branch also carries `6e57d7e81` (pack-creation idempotency), which predates this work and was already on the branch.
- `bun check` reports one pre-existing Biome error in `apps/expo/expo-env.d.ts`, a generated file ("should not be edited") untouched by this branch and already failing on `development`. All files changed here pass Biome cleanly.
- Not addressed here: the source screenshot showed "34 changes waiting to sync", so the Swift app had unflushed local writes. Worth a re-check once that queue drains.

## Pre-merge checklist

- [x] `bun lint` passes on changed files
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [x] No schema change, so no migration needed
- [x] PR title follows conventional commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely retrying pack creation requests without creating duplicates.
  * Conflicting pack IDs owned by another account now return a clear conflict response.

* **Bug Fixes**
  * Removed deleted packs, trips, templates, and template items from lists, details, caches, and template application workflows.
  * Updated pack and trip pagination to continue correctly when deleted records are present.
  * Pack detail and item endpoints now reject deleted packs.

* **Tests**
  * Added coverage for pack creation retries, conflicts, and ownership validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->