### PR TITLE
fix: filter soft-deleted packs, templates and trips from reads

### DIFF
--- a/apps/swift/Sources/PackRat/Features/PackTemplates/PackTemplatesViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/PackTemplates/PackTemplatesViewModel.swift
@@ -43,7 +43,7 @@ final class PackTemplatesViewModel {
         error = nil
         defer { isLoading = false }
         do {
-            templates = try await service.listTemplates()
+            templates = try await service.listTemplates().activeTemplates
         } catch {
             self.error = error.localizedDescription
         }

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -245,6 +245,7 @@ struct PacksListView: View {
         defer { isLoadingPublic = false }
         do {
             publicPacks = try await viewModel.service.listPacks(page: 1, limit: 30, includePublic: true)
+                .activePacks
         } catch { }
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -60,7 +60,7 @@ final class PacksViewModel {
             let cached = (try? context.fetch(FetchDescriptor<CachedPack>(
                 sortBy: [SortDescriptor(\.cachedAt, order: .reverse)]
             ))) ?? []
-            let cachedPacks = cached.compactMap { $0.toPack() }
+            let cachedPacks = cached.compactMap { $0.toPack() }.activePacks
             if !cachedPacks.isEmpty {
                 packs = cachedPacks
             }
@@ -78,11 +78,15 @@ final class PacksViewModel {
 
         do {
             let fresh = try await service.listPacks(page: 1, limit: pageSize)
-            packs = fresh
+            let active = fresh.activePacks
+            packs = active
             currentPage = 1
+            // Page-size comparison stays on the raw response: filtering shrinks
+            // the array, and testing the filtered count would end pagination
+            // early on a page that happened to contain tombstones.
             hasMore = fresh.count == pageSize
             if let context {
-                writeCachePacks(fresh, context: context)
+                writeCachePacks(active, context: context)
             }
         } catch {
             if packs.isEmpty {
@@ -108,7 +112,7 @@ final class PacksViewModel {
             // duplicate ids also collide in `ForEach` identity, so the duplicates
             // were visible rather than harmless.
             let known = Set(packs.map(\.id))
-            packs.append(contentsOf: more.filter { !known.contains($0.id) })
+            packs.append(contentsOf: more.activePacks.filter { !known.contains($0.id) })
             currentPage = nextPage
             hasMore = more.count == pageSize
         } catch { }

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
@@ -68,7 +68,7 @@ final class TripsViewModel {
             let cached = (try? context.fetch(FetchDescriptor<CachedTrip>(
                 sortBy: [SortDescriptor(\.cachedAt, order: .reverse)]
             ))) ?? []
-            let cachedTrips = cached.compactMap { $0.toTrip() }
+            let cachedTrips = cached.compactMap { $0.toTrip() }.activeTrips
             if !cachedTrips.isEmpty {
                 trips = cachedTrips
             }
@@ -86,11 +86,13 @@ final class TripsViewModel {
 
         do {
             let fresh = try await service.listTrips(page: 1, limit: pageSize)
-            trips = fresh
+            let active = fresh.activeTrips
+            trips = active
             currentPage = 1
+            // Page-size comparison stays on the raw response — see PacksViewModel.
             hasMore = fresh.count == pageSize
             if let context {
-                writeCacheTrips(fresh, context: context)
+                writeCacheTrips(active, context: context)
             }
         } catch {
             if trips.isEmpty {
@@ -116,7 +118,7 @@ final class TripsViewModel {
             // duplicate ids also collide in `ForEach` identity, so the duplicates
             // were visible rather than harmless.
             let known = Set(trips.map(\.id))
-            trips.append(contentsOf: more.filter { !known.contains($0.id) })
+            trips.append(contentsOf: more.activeTrips.filter { !known.contains($0.id) })
             currentPage = nextPage
             hasMore = more.count == pageSize
         } catch { }

--- a/apps/swift/Sources/PackRat/Models/Pack.swift
+++ b/apps/swift/Sources/PackRat/Models/Pack.swift
@@ -5,6 +5,22 @@ import Foundation
 extension Pack {
     var activeItems: [PackItem] { (items ?? []).filter { !$0.deleted } }
     var itemCount: Int { activeItems.count }
+}
+
+extension Array where Element == Pack {
+    /// Drops soft-deleted packs (tombstones).
+    ///
+    /// Applied at every ingress into a view model's `packs` array — network
+    /// responses, SwiftData cache reads, and pagination — so the app never
+    /// renders a tombstone even if a server or a locally-migrated cache hands
+    /// one over. Expo got this for free from Legend State's `fieldDeleted`
+    /// tombstone handling; the Swift client has no sync layer, so it filters
+    /// explicitly. Migrating users carry Expo-era local data that contains
+    /// tombstones, so client-side filtering is required, not just defensive.
+    var activePacks: [Pack] { filter { !$0.deleted } }
+}
+
+extension Pack {
 
     /// Formats a gram value for display.
     ///

--- a/apps/swift/Sources/PackRat/Models/PackTemplate.swift
+++ b/apps/swift/Sources/PackRat/Models/PackTemplate.swift
@@ -13,9 +13,50 @@ struct PackTemplate: Codable, Identifiable, Sendable {
     let items: [PackTemplateItem]?
     let createdAt: String?
     let updatedAt: String?
+    // Optional-with-default: older cached payloads predate this field.
+    let deleted: Bool?
 
-    var itemCount: Int { items?.count ?? 0 }
+    var isDeleted: Bool { deleted ?? false }
+    var activeItems: [PackTemplateItem] { (items ?? []).filter { !$0.isDeleted } }
+    var itemCount: Int { activeItems.count }
     var isOfficial: Bool { isAppTemplate ?? false }
+
+    // Explicit init so `deleted` can default — callers constructing new local
+    // templates never create them pre-deleted.
+    init(
+        id: String,
+        userId: String? = nil,
+        name: String,
+        description: String? = nil,
+        category: String? = nil,
+        image: String? = nil,
+        tags: [String]? = nil,
+        isAppTemplate: Bool? = nil,
+        contentSource: String? = nil,
+        items: [PackTemplateItem]? = nil,
+        createdAt: String? = nil,
+        updatedAt: String? = nil,
+        deleted: Bool? = nil
+    ) {
+        self.id = id
+        self.userId = userId
+        self.name = name
+        self.description = description
+        self.category = category
+        self.image = image
+        self.tags = tags
+        self.isAppTemplate = isAppTemplate
+        self.contentSource = contentSource
+        self.items = items
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deleted = deleted
+    }
+}
+
+extension Array where Element == PackTemplate {
+    /// Drops soft-deleted templates. See `Array<Pack>.activePacks`.
+    var activeTemplates: [PackTemplate] { filter { !$0.isDeleted } }
 }
 
 struct PackTemplateItem: Codable, Identifiable, Sendable {
@@ -29,6 +70,38 @@ struct PackTemplateItem: Codable, Identifiable, Sendable {
     let consumable: Bool?
     let worn: Bool?
     let notes: String?
+    // Optional so older cached payloads (which predate this field) still decode.
+    let deleted: Bool?
+
+    var isDeleted: Bool { deleted ?? false }
+
+    // Explicit init so `deleted` can default — callers constructing new local
+    // items never create them pre-deleted.
+    init(
+        id: String,
+        packTemplateId: String? = nil,
+        name: String,
+        weight: Double? = nil,
+        weightUnit: String? = nil,
+        quantity: Int? = nil,
+        category: String? = nil,
+        consumable: Bool? = nil,
+        worn: Bool? = nil,
+        notes: String? = nil,
+        deleted: Bool? = nil
+    ) {
+        self.id = id
+        self.packTemplateId = packTemplateId
+        self.name = name
+        self.weight = weight
+        self.weightUnit = weightUnit
+        self.quantity = quantity
+        self.category = category
+        self.consumable = consumable
+        self.worn = worn
+        self.notes = notes
+        self.deleted = deleted
+    }
 
     var weightInGrams: Double {
         guard let w = weight, let u = weightUnit else { return 0 }

--- a/apps/swift/Sources/PackRat/Models/Trip.swift
+++ b/apps/swift/Sources/PackRat/Models/Trip.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+extension Array where Element == Trip {
+    /// Drops soft-deleted trips. See `Array<Pack>.activePacks`.
+    var activeTrips: [Trip] { filter { !$0.deleted } }
+}
+
 // MARK: - Trip extensions (structs defined in Generated.swift)
 
 extension Trip {

--- a/apps/swift/Sources/PackRat/Services/PackTemplateService.swift
+++ b/apps/swift/Sources/PackRat/Services/PackTemplateService.swift
@@ -99,7 +99,10 @@ final class PackTemplateService: Sendable {
     /// Applies a template to an existing pack by copying all template items.
     func applyToPack(templateId: String, packId: String) async throws {
         let template = try await getTemplate(templateId)
-        guard let items = template.items else { return }
+        // `activeItems`, not `items`: copying tombstoned template items would
+        // resurrect deleted gear into the target pack.
+        let items = template.activeItems
+        guard !items.isEmpty else { return }
         let packService = PackService.shared
         for item in items {
             _ = try await packService.addItem(

--- a/packages/api/src/routes/packTemplates/index.ts
+++ b/packages/api/src/routes/packTemplates/index.ts
@@ -134,8 +134,11 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
     async ({ user }) => {
       const db = createDb();
       const templates = await db.tag('packTemplates.list').query.packTemplates.findMany({
-        where: or(eq(packTemplates.userId, user.userId), eq(packTemplates.isAppTemplate, true)),
-        with: { items: true },
+        where: and(
+          or(eq(packTemplates.userId, user.userId), eq(packTemplates.isAppTemplate, true)),
+          eq(packTemplates.deleted, false),
+        ),
+        with: { items: { where: eq(packTemplateItems.deleted, false) } },
       });
       return templates;
     },
@@ -537,7 +540,7 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
           or(eq(packTemplates.userId, user.userId), eq(packTemplates.isAppTemplate, true)),
           eq(packTemplates.deleted, false),
         ),
-        with: { items: true },
+        with: { items: { where: eq(packTemplateItems.deleted, false) } },
       });
 
       if (!template) return status(404, { error: 'Template not found' });
@@ -665,7 +668,12 @@ export const packTemplatesRoutes = new Elysia({ prefix: '/pack-templates' })
         .tag('packTemplates.listItems')
         .select()
         .from(packTemplateItems)
-        .where(eq(packTemplateItems.packTemplateId, templateId));
+        .where(
+          and(
+            eq(packTemplateItems.packTemplateId, templateId),
+            eq(packTemplateItems.deleted, false),
+          ),
+        );
 
       return items;
     },

--- a/packages/api/src/routes/packs/index.ts
+++ b/packages/api/src/routes/packs/index.ts
@@ -98,9 +98,17 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       const includePublic = Number(query.includePublic ?? 0) === 1;
       const db = createDb();
 
-      const where = includePublic
-        ? and(or(eq(packs.userId, user.userId), eq(packs.isPublic, true)), eq(packs.deleted, false))
-        : eq(packs.userId, user.userId);
+      // `deleted` must be filtered on BOTH branches. It used to hang off the
+      // includePublic branch only, so the default (owned-only) path returned
+      // soft-deleted packs. The Expo client masked it via Legend State's
+      // `fieldDeleted` tombstone handling; the Swift client has no equivalent
+      // and rendered them.
+      const where = and(
+        includePublic
+          ? or(eq(packs.userId, user.userId), eq(packs.isPublic, true))
+          : eq(packs.userId, user.userId),
+        eq(packs.deleted, false),
+      );
 
       // Drop packItems.embedding (1536-dim) from list payload. Mobile hot
       // path — 5 packs × 20 items × ~6KB embedding = 600KB minimum DB→Worker
@@ -132,9 +140,9 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       const result = await db.tag('packs.list').query.packs.findMany({
         where,
         with: {
-          items: includePublic
-            ? { columns: PACK_ITEM_LIST_COLUMNS, where: eq(packItems.deleted, false) }
-            : { columns: PACK_ITEM_LIST_COLUMNS },
+          // Filter deleted items on both branches too — the owned-only path
+          // previously shipped tombstoned items and let clients count them.
+          items: { columns: PACK_ITEM_LIST_COLUMNS, where: eq(packItems.deleted, false) },
         },
       });
 
@@ -314,7 +322,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
       // Same pattern as the list endpoint above — the audit missed this
       // callsite; folded in here for parity.
       const pack = await db.tag('packs.getById').query.packs.findFirst({
-        where: eq(packs.id, params.packId),
+        where: and(eq(packs.id, params.packId), eq(packs.deleted, false)),
         with: {
           items: {
             columns: {
@@ -368,7 +376,7 @@ export const packsRoutes = new Elysia({ prefix: '/packs' })
         // `<name> (<weight><unit> × <quantity>)`; without it, every entry
         // renders as `undefined (1200g × 1)`.
         const pack = await db.tag('packs.getById').query.packs.findFirst({
-          where: eq(packs.id, params.packId),
+          where: and(eq(packs.id, params.packId), eq(packs.deleted, false)),
           with: {
             items: {
               columns: {
@@ -762,7 +770,7 @@ Limit to maximum 6 recommendations, prioritizing the most important gaps. Only s
       const db = createDb();
 
       const pack = await db.tag('packs.getById').query.packs.findFirst({
-        where: eq(packs.id, params.packId),
+        where: and(eq(packs.id, params.packId), eq(packs.deleted, false)),
         columns: { id: true, userId: true, isPublic: true },
       });
 


### PR DESCRIPTION
## Description

The Swift app showed **6 packs** where the Expo app showed **5**. The extra row was `Packour`, a pack soft-deleted back in September 2025.

Root cause was in the API, not the Swift client. In the packs list route the `deleted = false` predicate hung off the `includePublic` branch only:

```ts
const where = includePublic
  ? and(or(eq(packs.userId, user.userId), eq(packs.isPublic, true)), eq(packs.deleted, false))
  : eq(packs.userId, user.userId);   // ← no deleted filter
```

Both clients request `includePublic=0` for "My Packs", so the server had been returning tombstones all along. Expo only looked correct by accident — its Legend State store declares `fieldDeleted: 'deleted'`, which drops tombstoned rows client-side. The Swift client has no sync layer, so the pre-existing server bug became visible.

Fixed on both sides: the server stops serving tombstones, and the Swift client filters them independently. The client-side half is not redundant — **migrating users carry Expo-era local data containing tombstones**, and the SwiftData cache can already hold rows written before this fix, so a server-only fix would leave `Packour` on screen indefinitely.

### API — swept every soft-deletable table

Audited all reads against `packs`, `packItems`, `packTemplates`, `packTemplateItems`, `trailConditionReports`, `trips`. Seven gaps in two files:

| Location | Gap |
|---|---|
| packs list | no `deleted` filter on pack (the reported bug) |
| packs list | items unfiltered when `includePublic=0` |
| packs detail / weight-breakdown / items | deleted pack reachable by direct id |
| packTemplates list | no filter on template **or** items |
| packTemplates getById | items unfiltered |
| packTemplates listItems | no filter |

Templates had live impact too: 4 deleted templates and 1 deleted template item were being served. `trips` and `trailConditionReports` already filtered correctly, so packs and templates were the outliers rather than a house convention.

### Swift — filter at every ingress

Added `activePacks` / `activeTemplates` / `activeTrips` and applied them at each point where rows enter a view model's collection, not just the network response:

- **SwiftData cache reads** — may hold tombstones written before this fix
- **Network refresh** — the filtered array is also what gets cached, so tombstones stop being persisted
- **Pagination appends** — composed with the existing dedupe-by-id logic
- **Explore tab** public-packs fetch

`hasMore` deliberately still compares the **raw** response length against page size; testing the filtered count would end pagination early on a page containing tombstones.

Two findings beyond missing filters:

- `PackTemplate` / `PackTemplateItem` **did not decode `deleted` at all**, so the flag was invisible to the client and filtering was impossible until the field was added. It is optional so pre-existing cached payloads still decode. `itemCount` now counts active items, matching `Pack`.
- `PackTemplateService.applyToPack` copied **every** template item including tombstoned ones, resurrecting deleted gear into the target pack. That is a data-corruption path, not a display bug.

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [x] API / Backend (`packages/api`)
- [x] Swift app (`apps/swift`)

## Testing

- [x] Verified against production data: the corrected query returns exactly the 5 expected packs, with item counts matching the Expo screenshot — including `Pack` at "1 item", where 2 of its 3 item rows are soft-deleted
- [x] `bun test:api:unit` — 627/627 passing
- [x] `xcodebuild` PackRat-iOS — build succeeded
- [x] Swift iOS smoke test plan — passing
- [x] `bun check-types` — clean
- [x] Biome clean on all changed files

## Notes for reviewer

- Supersedes #2730, which was opened from `feat/expo-ui-migration-sdk57` — that branch was 193 commits behind `development` and GitHub reported it CONFLICTING, which also prevented the path-filtered `api-tests` / `coverage` workflows from firing. This branch is cut fresh from `development` and carries only the two relevant commits.
- Resolving the cherry-pick required composing with dedupe-by-id logic that landed upstream in `loadMore` for both packs and trips. Both behaviours are preserved: `more.activePacks.filter { !known.contains($0.id) }`.
- Not addressed here: the source screenshot showed "34 changes waiting to sync", so the Swift app had unflushed local writes. Worth a re-check once that queue drains.

## Pre-merge checklist

- [x] `bun lint` passes on changed files
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [x] No schema change, so no migration needed
- [x] PR title follows conventional commits