### PR TITLE
fix(api): alias `bun` to a stub so the Workers bundle resolves

### DIFF
--- a/packages/api/src/shims/bun-empty.ts
+++ b/packages/api/src/shims/bun-empty.ts
@@ -1,0 +1,8 @@
+// Stub for the `bun` builtin module.
+//
+// `src/db/index.ts` dynamically imports `drizzle-orm/bun-sql` for local Bun
+// runs (migrations, e2e seeding). esbuild still statically resolves that
+// import when bundling for Workers and fails with `Could not resolve "bun"`.
+// The import is guarded by `'Bun' in globalThis`, so on workerd this module is
+// never evaluated — an empty stub keeps the bundle resolvable.
+export const SQL = undefined;

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -17,6 +17,11 @@
   // unminified stack traces. Sentry symbolication uses a separate
   // @sentry/cli sourcemaps upload step in CI (see deploy workflow).
   "upload_source_maps": true,
+  "alias": {
+    // See src/shims/bun-empty.ts — drizzle-orm/bun-sql pulls in the `bun`
+    // builtin, which esbuild cannot resolve for the Workers bundle.
+    "bun": "./src/shims/bun-empty.ts"
+  },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
   },


### PR DESCRIPTION
## Description

The Cloudflare dev deploy was failing at the bundling step:

```
✘ [ERROR] Could not resolve "bun"
    ../../node_modules/drizzle-orm/bun-sql/driver.js:1:20:
      1 │ import { SQL } from "bun";
```

`src/db/index.ts` dynamically imports `drizzle-orm/bun-sql` for local Bun runs (migrations, e2e seeding). The import is guarded by `'Bun' in globalThis`, so it never executes on workerd — but esbuild statically resolves dynamic imports when bundling, hits the `bun` builtin, and fails the deploy.

Adds an empty stub module and a `bun` alias in `wrangler.jsonc`, as suggested by wrangler's own error message.

## Type of change

- [x] 🐛 Bug fix
- [x] 🔧 CI / configuration change

## Area(s) affected

- [x] API / Backend (`packages/api`)

## Testing

- [x] `bunx wrangler deploy --minify -e=dev --dry-run` — bundle builds clean (4770.69 KiB / gzip 1257.31 KiB); the `Could not resolve "bun"` error is gone
- [x] `bun check` — clean
- [x] `bun check-types` — clean
- [x] `bun test:api:unit` — 631 tests passed (45 files)
- [x] Coverage ratchet: `packages/api` improved 98.31% → 99.01%

The top-level `alias` is inherited by `env.dev`, verified by running the dry-run against `-e=dev`.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Workers deployment bundling to resolve Bun-specific database imports correctly.
  * Prevented build-time errors in environments where Bun APIs are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->