### PR TITLE
fix(swift): address Apple review rejections for 2.2.0 macOS submission

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -95,12 +95,20 @@ jobs:
               "PACKRAT_ENV=local"
             )
           else
+            # CODE_SIGN_ENTITLEMENTS is cleared because the macOS target
+            # declares com.apple.developer.applesignin (App Store guideline
+            # 4.8). That entitlement can only be granted by a provisioning
+            # profile, so an ad-hoc signature carrying it produces a binary
+            # launchd refuses to spawn ("Runningboard error 5"). iOS is
+            # unaffected — the Simulator does not enforce entitlements. The
+            # shipping archive signs with the real profile and keeps it.
             CODE_SIGN_ARGS=(
               CODE_SIGN_STYLE=Manual
               DEVELOPMENT_TEAM=
               CODE_SIGN_IDENTITY=-
               CODE_SIGNING_ALLOWED=YES
               CODE_SIGNING_REQUIRED=NO
+              CODE_SIGN_ENTITLEMENTS=
             )
           fi
           DESTINATION="${{ matrix.destination }}"

--- a/apps/swift/Resources/Info-macOS.plist
+++ b/apps/swift/Resources/Info-macOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>PackRat</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/apps/swift/Resources/PackRat-macOS.entitlements
+++ b/apps/swift/Resources/PackRat-macOS.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/apps/swift/Sources/PackRat/Features/Auth/LoginView.swift
+++ b/apps/swift/Sources/PackRat/Features/Auth/LoginView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
-#if os(iOS)
 import AuthenticationServices
-#endif
 
 struct LoginView: View {
     @Environment(AuthManager.self) private var authManager
@@ -100,7 +98,11 @@ struct LoginView: View {
                         .controlSize(.large)
                         .disabled(isLoading)
                         .accessibilityIdentifier("auth_google")
+                        #endif
 
+                        // Guideline 4.8 requires Sign in with Apple to sit alongside
+                        // any third-party login on every platform we ship, macOS
+                        // included — it is not iOS-only.
                         SignInWithAppleButton(.continue) { request in
                             request.requestedScopes = [.fullName, .email]
                         } onCompletion: { result in
@@ -111,17 +113,6 @@ struct LoginView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                         .disabled(isLoading)
                         .accessibilityIdentifier("auth_apple")
-                        #else
-                        Button {
-                            error = "Google sign-in is available in the iOS app. Use email sign-in on macOS for now."
-                        } label: {
-                            Label("Continue with Google", systemImage: "g.circle")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.large)
-                        .accessibilityIdentifier("auth_google")
-                        #endif
                     }
                 }
             }
@@ -156,6 +147,7 @@ struct LoginView: View {
             }
         }
     }
+    #endif
 
     private func signInWithApple(_ result: Result<ASAuthorization, Error>) {
         error = nil
@@ -178,7 +170,6 @@ struct LoginView: View {
             self.error = error.localizedDescription
         }
     }
-    #endif
 }
 
 private struct LoginInlineErrorView: View {

--- a/apps/swift/Sources/PackRat/Navigation/PackRatCommands.swift
+++ b/apps/swift/Sources/PackRat/Navigation/PackRatCommands.swift
@@ -1,7 +1,13 @@
 import SwiftUI
 
+// Menu-bar commands are a macOS concept; `.windowList` in particular does not
+// exist on iOS. The focused-value keys below are shared by both platforms and
+// stay outside the guard.
+#if os(macOS)
 struct PackRatCommands: Commands {
     let authManager: AuthManager
+
+    @Environment(\.openWindow) private var openWindow
 
     // Bool bindings avoid recreating function closures on every render,
     // which caused "FocusedValue update tried to update multiple times per frame."
@@ -12,7 +18,15 @@ struct PackRatCommands: Commands {
     @FocusedBinding(\.globalSearchAction) private var showingSearch: Bool?
 
     var body: some Commands {
+        // Guideline 4 — replacing `.newItem` wholesale removed AppKit's default
+        // "New Window", leaving no way to reopen the app after closing its last
+        // window. Put an explicit one back at the top of the File menu.
         CommandGroup(replacing: .newItem) {
+            Button("New Window") { openWindow(id: PackRatApp.mainWindowSceneID) }
+                .keyboardShortcut("n", modifiers: [.command, .option])
+
+            Divider()
+
             Button("New Pack") { showingNewPack = true }
                 .keyboardShortcut("n", modifiers: .command)
                 .disabled(showingNewPack == nil)
@@ -37,6 +51,13 @@ struct PackRatCommands: Commands {
                 .disabled(triggerShare == nil)
         }
 
+        // Also surface it under Window, which is where macOS users look for a
+        // closed main window.
+        CommandGroup(after: .windowList) {
+            Divider()
+            Button("PackRat") { openWindow(id: PackRatApp.mainWindowSceneID) }
+        }
+
         CommandGroup(after: .appInfo) {
             Divider()
             Button("Sign Out", role: .destructive) {
@@ -46,6 +67,8 @@ struct PackRatCommands: Commands {
         }
     }
 }
+
+#endif
 
 // MARK: - Focused Value Keys
 // @FocusedBinding requires Value = Binding<T> so SwiftUI compares the wrapped

--- a/apps/swift/Sources/PackRat/Network/AuthManager.swift
+++ b/apps/swift/Sources/PackRat/Network/AuthManager.swift
@@ -1,9 +1,9 @@
+import AuthenticationServices
 import Foundation
 import Observation
 import Sentry
 import SwiftData
 #if os(iOS)
-import AuthenticationServices
 import GoogleSignIn
 import UIKit
 #endif
@@ -145,7 +145,6 @@ final class AuthManager {
         SentryConfig.setUser(id: response.user.id, email: response.user.email)
     }
 
-    #if os(iOS)
     @MainActor
     func loginWithApple(credential: ASAuthorizationAppleIDCredential) async throws {
         guard let data = credential.identityToken,
@@ -164,6 +163,7 @@ final class AuthManager {
         )
     }
 
+    #if os(iOS)
     @MainActor
     func loginWithGoogle() async throws {
         guard let clientID = Bundle.main.object(forInfoDictionaryKey: "GOOGLE_IOS_CLIENT_ID") as? String,

--- a/apps/swift/Sources/PackRat/PackRatApp.swift
+++ b/apps/swift/Sources/PackRat/PackRatApp.swift
@@ -6,6 +6,10 @@ import AppKit
 
 @main
 struct PackRatApp: App {
+    /// Scene id of the primary `WindowGroup`, so the macOS menu commands can
+    /// reopen it via `openWindow(id:)` after the last window is closed.
+    static let mainWindowSceneID = "main"
+
     @State private var authManager = AuthManager()
     #if os(macOS)
     @NSApplicationDelegateAdaptor(PackRatMacAppDelegate.self) private var appDelegate
@@ -25,7 +29,9 @@ struct PackRatApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        // Identified so `openWindow(id:)` from the File/Window menu commands can
+        // reopen it after the user closes the last main window (guideline 4).
+        WindowGroup(id: PackRatApp.mainWindowSceneID) {
             AuthGateView()
                 .environment(authManager)
                 .flushesPendingWrites()
@@ -86,16 +92,26 @@ final class PackRatMacAppDelegate: NSObject, NSApplicationDelegate {
             NSApp.unhide(nil)
             NSApp.activate(ignoringOtherApps: true)
             if NSApp.windows.isEmpty {
-                NSApp.sendAction(Selector(("newWindow:")), to: nil, from: nil)
+                Self.openMainWindow()
             }
         }
     }
 
+    /// Clicking the Dock icon with no windows open has to bring the main window
+    /// back — the other half of guideline 4's "no way to reopen it" finding.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !flag {
-            NSApp.sendAction(Selector(("newWindow:")), to: nil, from: nil)
+            Self.openMainWindow()
         }
         return true
+    }
+
+    /// SwiftUI installs a responder for `newWindow:` for each `WindowGroup`, so
+    /// sending it up the chain reopens the main scene. Falls back to un-minimising
+    /// / re-showing an existing window if one is somehow still around.
+    static func openMainWindow() {
+        if NSApp.sendAction(Selector(("newWindow:")), to: nil, from: nil) { return }
+        NSApp.windows.first?.makeKeyAndOrderFront(nil)
     }
 }
 #endif

--- a/apps/swift/Tests/PackRatUITests/AuthTests.swift
+++ b/apps/swift/Tests/PackRatUITests/AuthTests.swift
@@ -131,9 +131,15 @@ final class AuthTests: AppUITestCase {
         XCTAssertTrue(app.secureTextFields["login_password"].exists)
         XCTAssertTrue(app.buttons["login_submit"].exists)
         XCTAssertTrue(app.buttons["forgot_password_link"].exists)
-        XCTAssertTrue(app.buttons["auth_google"].exists)
-        #if os(iOS)
+        // Sign in with Apple ships on both platforms — App Store guideline 4.8
+        // requires it wherever a third-party login is offered.
         XCTAssertTrue(app.buttons["auth_apple"].exists)
+        // Google is iOS-only: its SDK needs UIKit, so macOS offers email plus
+        // Sign in with Apple instead.
+        #if os(iOS)
+        XCTAssertTrue(app.buttons["auth_google"].exists)
+        #else
+        XCTAssertFalse(app.buttons["auth_google"].exists)
         #endif
     }
 

--- a/apps/swift/docs/macos-testflight.md
+++ b/apps/swift/docs/macos-testflight.md
@@ -50,11 +50,11 @@ xcodebuild -exportArchive -archivePath /tmp/PackRat-mac.xcarchive \
 # 3. Validate, then upload (--type osx; a macOS App Store export is a .pkg)
 set -a && . apps/swift/.env.local && set +a
 xcrun altool --validate-app --type osx \
-  --file /tmp/PackRat-mac-export/PackRat-macOS.pkg \
+  --file /tmp/PackRat-mac-export/PackRat.pkg \
   --username "$APPLE_ID" --password "$APPLE_APP_PASSWORD" \
   --asc-provider "$APPLE_TEAM_ID"
 xcrun altool --upload-app --type osx \
-  --file /tmp/PackRat-mac-export/PackRat-macOS.pkg \
+  --file /tmp/PackRat-mac-export/PackRat.pkg \
   --username "$APPLE_ID" --password "$APPLE_APP_PASSWORD" \
   --asc-provider "$APPLE_TEAM_ID"
 ```
@@ -186,7 +186,7 @@ CI still build unsigned by passing `CODE_SIGNING_REQUIRED=NO` on the
 To check a built app before spending an upload:
 
 ```bash
-APP=/tmp/PackRat-mac.xcarchive/Products/Applications/PackRat-macOS.app
+APP=/tmp/PackRat-mac.xcarchive/Products/Applications/PackRat.app
 ls "$APP/Contents/Resources/" | grep -E 'icns|Assets.car'   # want both
 plutil -p "$APP/Contents/Info.plist" | grep -iE 'icon|Category|Encryption'
 ```

--- a/apps/swift/project.yml
+++ b/apps/swift/project.yml
@@ -210,12 +210,20 @@ targets:
     entitlements:
       path: Resources/PackRat-macOS.entitlements
       properties:
+        # Guideline 4.8 — the Mac build offers a third-party login option, so
+        # Sign in with Apple must be available here too, not just on iOS.
+        com.apple.developer.applesignin:
+          - Default
         com.apple.security.app-sandbox: YES
         com.apple.security.network.client: YES
     info:
       path: Resources/Info-macOS.plist
       properties:
         CFBundleDisplayName: $(PACKRAT_DISPLAY_NAME)
+        # Literal, not $(PRODUCT_NAME): the target is named PackRat-macOS, and
+        # the substituted value put "macOS" into the name Finder and the menu
+        # bar show — rejected under guideline 5.2.5.
+        CFBundleName: PackRat
         CFBundleIconName: AppIcon
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
@@ -266,6 +274,10 @@ targets:
         # TestFlight's macOS tab of the same app as the iPhone one.
         PRODUCT_BUNDLE_IDENTIFIER: com.andrewbierman.packrat
         PACKRAT_DISPLAY_NAME: PackRat
+        # Guideline 5.2.5 — PRODUCT_NAME defaults to the target name, which made
+        # CFBundleName (and the Finder/menu-bar app name) read "PackRat-macOS".
+        # Apple flagged the "macOS" term as confusingly similar to their product.
+        PRODUCT_NAME: PackRat
         # Match iOS target so @testable import PackRat resolves on both platforms.
         PRODUCT_MODULE_NAME: PackRat
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -338,6 +350,10 @@ targets:
       base:
         SWIFT_VERSION: "5.9"
         GENERATE_INFOPLIST_FILE: YES
+        # PRODUCT_NAME on PackRat-macOS is "PackRat" (guideline 5.2.5), but
+        # xcodegen derives TEST_HOST from the *target* name. Point it at the
+        # real product or the test host is not found.
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/PackRat.app/Contents/MacOS/PackRat"
 
   PackRatMacOSUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## Description

Fixes the three issues Apple raised rejecting the 2.2.0 macOS submission (submission ID `c6c39229-b2b0-4880-8d6b-eaaf06e29b83`, reviewed 2026-09-02, build 2026082102). All three are macOS-only — the iOS build was not implicated.

### Guideline 4.8 — Login Services

The Mac build rendered a "Continue with Google" button, but Sign in with Apple was compiled out under `#if os(iOS)`, so the required equivalent login option was genuinely absent on macOS.

`SignInWithAppleButton` and `ASAuthorizationAppleIDCredential` are both available on macOS, so this ungates the button, `AuthManager.loginWithApple`, and the `AuthenticationServices` import. Google stays iOS-only (its SDK needs UIKit), and the macOS placeholder button — which did nothing but set an error string — is removed. `com.apple.developer.applesignin` is added to the macOS entitlements so the capability is actually granted rather than silently failing at runtime.

### Guideline 5.2.5 — Intellectual Property

`CFBundleName` was `$(PRODUCT_NAME)`, which defaults to the target name, so Finder and the menu bar displayed the app as **PackRat-macOS**. That "macOS" term is what Apple flagged.

`PRODUCT_NAME` and `CFBundleName` are now set to `PackRat` explicitly. The Xcode *target* and *scheme* keep their `PackRat-macOS` names (not user-visible, and renaming them would churn CI); only the built product changes.

Two knock-on effects handled:
- The product is now `PackRat.app`, not `PackRat-macOS.app`. xcodegen derives `TEST_HOST` from the target name, so `PackRatMacOSTests` needs an explicit `TEST_HOST` or the host is not found. `PackRatMacOSUITests` uses `TEST_TARGET_NAME` and is unaffected.
- `docs/macos-testflight.md` artifact paths updated (`PackRat.pkg`, `PackRat.app`).

### Guideline 4 — Design

`CommandGroup(replacing: .newItem)` replaced AppKit's default New-item group wholesale, which took "New Window" with it. Once the user closed the last window there was no menu path back — exactly what the reviewer hit.

The main `WindowGroup` now carries a scene id, and there are two ways back: "New Window" (⌥⌘N) at the top of File, and a PackRat entry after the Window menu's window list. Both route through `openWindow(id:)`. The Dock-reopen path (`applicationShouldHandleReopen`) and the launch path now share one `openMainWindow()` helper instead of each calling the private `newWindow:` selector inline.

`PackRatCommands` is guarded to macOS because `.windowList` does not exist on iOS. The focused-value keys in that file are shared with iOS views, so they stay outside the guard.

### Not included

No build-number bump. `CURRENT_PROJECT_VERSION` in `project.yml` is only a default — the submitted `2026082102` came from `BUILD_NUMBER` at upload time, so the resubmission build number is set on the upload, not committed here.

## Type of change

- [x] 🐛 Bug fix
- [x] 🔧 CI / configuration change

## Area(s) affected

- [x] Native Swift app (`apps/swift`) — macOS target

## Testing

- [x] `PackRat-iOS` and `PackRat-macOS` both build clean
- [x] `PackRatMacOSTests` passes
- [x] Full `PackRatTests` (iOS, 276 tests / 67 suites) passes on iPhone 15 Pro

The macOS UI test runner (`PackRatMacOSUITests`) crashes at launch — unsigned bundle, Gatekeeper refuses it. Baselined on clean `development` and it fails identically there, so it is pre-existing and not from this branch.

Sign in with Apple on macOS needs a signed build against the provisioning profile to exercise end-to-end; worth a TestFlight pass before resubmitting.

## Pre-merge checklist

- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Sign in with Apple support on macOS.
  - Added macOS commands for opening a new PackRat window and reopening the main window.

- **Improvements**
  - The macOS app is now consistently named “PackRat” in the system and packaged application.
  - Improved behavior when reopening PackRat after all windows are closed.
  - Google sign-in remains available on iOS, while Apple sign-in is supported across iOS and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->