### PR TITLE
Fix Gap Analysis icon and add Delete Pack to pack detail

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -232,7 +232,7 @@ struct PackDetailView: View {
                         }
                         .disabled(items.isEmpty)
 
-                        Button("Gap Analysis", systemImage: "sparkles.magnifyingglass") {
+                        Button("Gap Analysis", systemImage: "sparkle.magnifyingglass") {
                             showingGapAnalysis = true
                         }
                         .disabled(items.isEmpty)

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -26,6 +26,11 @@ struct PackDetailView: View {
     @State private var triggerShare = false
     @State private var itemPendingDeletion: PackItem?
     @State private var showingDeleteConfirmation = false
+    /// Separate from `showingDeleteConfirmation`, which is the *item* alert — the two
+    /// can never be presented together, but sharing one flag would make the alert
+    /// builder ambiguous about what is being deleted.
+    @State private var showingDeletePackConfirmation = false
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(\.weightUnit) private var weightUnit
     @State private var statusMessage: String?
@@ -251,6 +256,11 @@ struct PackDetailView: View {
                         }
                         .accessibilityIdentifier("pack_detail_edit_pack")
                         .keyboardShortcut("e", modifiers: .command)
+
+                        Button("Delete Pack", systemImage: "trash", role: .destructive) {
+                            showingDeletePackConfirmation = true
+                        }
+                        .accessibilityIdentifier("pack_detail_delete_pack")
                     } label: {
                         Label("More", systemImage: "ellipsis.circle")
                             .labelStyle(.iconOnly)
@@ -278,6 +288,12 @@ struct PackDetailView: View {
         // See PacksListView: alert actions must be bare `Button`s — a modifier
         // on one wraps it in `ModifiedContent` and the alert degrades into a
         // clipped popover with buttons dropped.
+        .alert(deletePackAlertTitle, isPresented: $showingDeletePackConfirmation) {
+            Button("Delete", role: .destructive) { deletePack() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(deletePackAlertMessage)
+        }
         .alert(deleteItemAlertTitle, isPresented: $showingDeleteConfirmation) {
             Button("Delete", role: .destructive) {
                 if let item = itemPendingDeletion { deleteItem(item) }
@@ -481,6 +497,27 @@ struct PackDetailView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .background(.bar)
+    }
+
+    private var deletePackAlertTitle: String {
+        "Delete \(currentPack.name)?"
+    }
+
+    /// Same wording as the Packs list, so deleting from either place reads the same.
+    private var deletePackAlertMessage: String {
+        let count = items.count
+        return "\"\(currentPack.name)\" and its \(count) item\(count == 1 ? "" : "s") will be deleted. This cannot be undone."
+    }
+
+    /// Deletes the pack and leaves the screen — staying would render a pack that no
+    /// longer exists. Like the list's delete, an unreachable server queues the delete
+    /// for replay rather than failing at the call site.
+    private func deletePack() {
+        let packId = currentPack.id
+        Task {
+            await viewModel.deletePack(packId, context: modelContext)
+            dismiss()
+        }
     }
 
     private var deleteItemAlertTitle: String {


### PR DESCRIPTION
Two small pack-detail fixes.

## Gap Analysis icon

The menu item used `sparkles.magnifyingglass`, which is not a valid SF Symbol, so it rendered blank. The correct name is `sparkle.magnifyingglass` (singular).

This was fixed once before in 6d1fb7cd, but that commit only ever existed on `feat/swift-catalog-add-bar-dark-mode-gap-icon`, which has no PR and was never merged — so the invalid name is still what ships. Cherry-picked here rather than rebasing that branch, which carries 82 unrelated files (catalog add-bar gating, appearance toggle) that need their own review.

## Delete Pack

The pack detail More menu offered Ask AI, Start Packing, Weight/Gap Analysis, Share and Edit Pack, but no way to delete the pack you were looking at — deleting meant backing out to the Packs list and swiping the row.

Wording and behaviour mirror the list's delete so the two read identically: the same "and its N items … cannot be undone" message, and the same optimistic path where an unreachable server queues the delete for replay. Dismisses on success, since staying would render a pack that no longer exists. The item-delete alert keeps its own flag; sharing one would leave the alert builder ambiguous about which entity is being deleted.

## Testing

284 tests green post-rebase. Verified on iPhone 17 Pro: icon renders, and deleting from detail confirms then returns to the list.