### PR TITLE
Retire the side-by-side Swift beta listing

### DIFF
--- a/.github/workflows/swift-e2e.yml
+++ b/.github/workflows/swift-e2e.yml
@@ -130,7 +130,7 @@ jobs:
             echo "::error::Required TestFlight preflight inputs missing: ${missing[*]}"
             exit 1
           fi
-          bun swift:testflight:preflight --replacement --production
+          bun swift:testflight:preflight --production
 
   testflight-replacement-archive:
     name: TestFlight replacement archive verification
@@ -177,7 +177,7 @@ jobs:
             echo "::error::Required TestFlight archive verification inputs missing: ${missing[*]}"
             exit 1
           fi
-          bun apps/swift/scripts/upload-testflight.ts --replacement --production --verify-archive-only
+          bun apps/swift/scripts/upload-testflight.ts --production --verify-archive-only
 
   macos-ui:
     name: macOS Swift UI E2E

--- a/.github/workflows/swift-staging-adhoc.yml
+++ b/.github/workflows/swift-staging-adhoc.yml
@@ -131,7 +131,7 @@ jobs:
             <key>signingStyle</key><string>manual</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>com.andrewbierman.packrat.swift</key>
+              <key>com.andrewbierman.packrat</key>
               <string>$PROVISIONING_PROFILE_UUID</string>
             </dict>
             <key>teamID</key><string>666HGMV2LU</string>

--- a/apps/swift/README.md
+++ b/apps/swift/README.md
@@ -79,34 +79,29 @@ See `docs/ci/swift-e2e-runner.md` for self-hosted Mac runner setup.
 
 ## TestFlight Identity
 
-The Swift iOS app defaults to the replacement identity for the existing Expo/App
-Store listing:
+The Swift iOS app ships to the one public App Store listing:
 
 - iOS: `com.andrewbierman.packrat`, display name `PackRat`
 - watchOS companion: `com.andrewbierman.packrat.watchkitapp`
 
 That is the only identity that validates a seamless update for existing testers.
-The upload tooling still supports an explicit side-by-side lane for unusual
-parallel QA builds, but it must be requested intentionally with `--side-by-side`;
-iOS treats that as a separate app with separate install, keychain, and app
+The separate `PackRat Swift` beta listing that once ran in parallel is retired —
+iOS treated it as a wholly separate app, with its own install, keychain, and app
 container state.
-
-Upload commands require an explicit lane so we do not accidentally target the
-wrong App Store Connect record:
 
 ```sh
 APP_STORE_CURRENT_BUILD_NUMBER=2026071801 BUILD_NUMBER=2026071802 \
-  bun swift:testflight:preflight --replacement --production
-bun apps/swift/scripts/upload-testflight.ts --replacement --dry-run
-bun apps/swift/scripts/upload-testflight.ts --replacement --verify-archive-only
-bun apps/swift/scripts/upload-testflight.ts --replacement
-bun apps/swift/scripts/upload-testflight.ts --side-by-side --staging
+  bun swift:testflight:preflight --production
+bun apps/swift/scripts/upload-testflight.ts --dry-run
+bun apps/swift/scripts/upload-testflight.ts --verify-archive-only
+bun apps/swift/scripts/upload-testflight.ts
+bun apps/swift/scripts/upload-testflight.ts --staging
 ```
 
 `--staging` uses the Staging build config (`PACKRAT_ENV=dev`). Without it, the
 script archives Release (`PACKRAT_ENV=production`).
 
-Use `--dry-run` before a real upload to verify the lane, bundle id, display
+Use `--dry-run` before a real upload to verify the bundle id, display
 name, build configuration, API environment, and Xcode archive overrides without
 requiring Apple credentials or running Xcode.
 
@@ -123,7 +118,7 @@ Use `swift:testflight:preflight` before the replacement upload when validating a
 seamless update. It fails unless the resolved archive is the existing Expo
 listing (`com.andrewbierman.packrat`, `PackRat`), Release/production, and has a
 strictly greater build number than `APP_STORE_CURRENT_BUILD_NUMBER`. Real
-`--replacement` uploads enforce the same check before reading Apple credentials
+Uploads enforce the same check before reading Apple credentials
 or archiving.
 
 The same check is available from the manual **Swift E2E Tests** GitHub workflow:

--- a/apps/swift/docs/macos-testflight.md
+++ b/apps/swift/docs/macos-testflight.md
@@ -4,14 +4,12 @@ The native Swift app has a `PackRat-macOS` target that ships to TestFlight
 under the **production** App Store Connect record — `com.andrewbierman.packrat`,
 app id `6499243187`, the same record the Expo iPhone app ships from. One record
 hosts both platforms, so Mac testers find the build under TestFlight's **macOS**
-tab. (iOS builds of the Swift app go to a separate record,
-`com.andrewbierman.packrat.swift`, app id `6791633696`.)
+tab, and iOS builds ship from that same record.
 
 ## Uploading
 
-> **`upload-testflight.ts` has no macOS lane.** The script is built around iOS
-> lanes (`--replacement` / `--side-by-side`) whose config module is iOS-specific
-> throughout — scheme selection, `PACKRAT_IOS_BUNDLE_IDENTIFIER`, IPA
+> **`upload-testflight.ts` has no macOS support.** The script is built around the
+> iOS App Store listing, and its config module is iOS-specific — scheme selection, `PACKRAT_IOS_BUNDLE_IDENTIFIER`, IPA
 > verification. Adding a macOS lane means extending
 > `scripts/lib/testflight-config.ts`; until then, run the three steps below by
 > hand.

--- a/apps/swift/scripts/__tests__/testflight-binary.test.ts
+++ b/apps/swift/scripts/__tests__/testflight-binary.test.ts
@@ -6,7 +6,7 @@ import { verifyTestFlightArchive } from '../lib/testflight-binary';
 import { parseTestFlightUploadConfig } from '../lib/testflight-config';
 
 const replacementConfig = parseTestFlightUploadConfig({
-  argv: ['--replacement', '--production'],
+  argv: ['--production'],
   env: { BUILD_NUMBER: '2026071802' },
 });
 
@@ -86,7 +86,7 @@ describe('TestFlight binary verification', () => {
     }
   });
 
-  it('rejects an archive that still has side-by-side or non-production metadata', () => {
+  it('rejects an archive with the retired beta listing or non-production metadata', () => {
     const archivePath = writeArchive({
       iosBundleId: 'com.andrewbierman.packrat.swift',
       packratEnv: 'dev',

--- a/apps/swift/scripts/__tests__/testflight-config.test.ts
+++ b/apps/swift/scripts/__tests__/testflight-config.test.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   parseTestFlightUploadConfig,
-  TestFlightConfigError,
   verifyTestFlightReplacementReadiness,
   xcodeArchiveOverrides,
 } from '../lib/testflight-config';
@@ -18,51 +17,13 @@ const monorepoVersion = (
 ).version;
 
 describe('parseTestFlightUploadConfig', () => {
-  it('requires an explicit TestFlight lane', () => {
-    expect(() => parseTestFlightUploadConfig({ argv: [], env: { BUILD_NUMBER: '123' } })).toThrow(
-      TestFlightConfigError,
-    );
-  });
-
-  it('rejects conflicting lanes', () => {
-    expect(() =>
-      parseTestFlightUploadConfig({
-        argv: ['--side-by-side', '--replacement'],
-        env: { BUILD_NUMBER: '123' },
-      }),
-    ).toThrow('Choose exactly one TestFlight lane');
-  });
-
-  it('builds the side-by-side Swift beta identity', () => {
-    expect(
-      parseTestFlightUploadConfig({
-        argv: ['--side-by-side'],
-        env: { BUILD_NUMBER: '123' },
-      }),
-    ).toMatchObject({
-      lane: 'side-by-side',
-      staging: false,
-      dryRun: false,
-      scheme: 'PackRat-iOS',
-      configuration: 'Release',
-      bundleId: 'com.andrewbierman.packrat.swift',
-      watchBundleId: 'com.andrewbierman.packrat.swift.watchkitapp',
-      companionBundleId: 'com.andrewbierman.packrat.swift',
-      displayName: 'PackRat Swift',
-      marketingVersion: monorepoVersion,
-      buildNumber: '123',
-      apiEnvironment: 'production',
-    });
-  });
-
-  it('builds the replacement identity for the existing Expo listing', () => {
+  it('builds the App Store listing identity', () => {
     const config = parseTestFlightUploadConfig({
-      argv: ['--replacement'],
+      argv: [],
       env: { BUILD_NUMBER: '456' },
     });
 
     expect(config).toMatchObject({
-      lane: 'replacement',
       staging: false,
       dryRun: false,
       scheme: 'PackRat-iOS',
@@ -86,14 +47,13 @@ describe('parseTestFlightUploadConfig', () => {
     ]);
   });
 
-  it('uses the staging scheme without changing the selected lane identity', () => {
+  it('uses the staging scheme without changing the app identity', () => {
     expect(
       parseTestFlightUploadConfig({
-        argv: ['--replacement', '--staging'],
+        argv: ['--staging'],
         env: { BUILD_NUMBER: '789' },
       }),
     ).toMatchObject({
-      lane: 'replacement',
       staging: true,
       dryRun: false,
       scheme: 'PackRat-iOS-Staging',
@@ -109,11 +69,10 @@ describe('parseTestFlightUploadConfig', () => {
   it('supports dry-run preflight without changing identity', () => {
     expect(
       parseTestFlightUploadConfig({
-        argv: ['--replacement', '--dry-run'],
+        argv: ['--dry-run'],
         env: { BUILD_NUMBER: '101' },
       }),
     ).toMatchObject({
-      lane: 'replacement',
       dryRun: true,
       bundleId: 'com.andrewbierman.packrat',
       displayName: 'PackRat',
@@ -125,7 +84,7 @@ describe('parseTestFlightUploadConfig', () => {
 
   it('allows an explicit marketing version override for controlled release testing', () => {
     const config = parseTestFlightUploadConfig({
-      argv: ['--replacement', '--production'],
+      argv: ['--production'],
       env: { BUILD_NUMBER: '2026072101', MARKETING_VERSION: '2.1.1' },
     });
 
@@ -136,14 +95,14 @@ describe('parseTestFlightUploadConfig', () => {
   });
 
   it('rejects conflicting API profile flags', () => {
-    expect(() =>
-      parseTestFlightUploadConfig({ argv: ['--replacement', '--staging', '--production'] }),
-    ).toThrow('Use either --staging or --production, not both.');
+    expect(() => parseTestFlightUploadConfig({ argv: ['--staging', '--production'] })).toThrow(
+      'Use either --staging or --production, not both.',
+    );
   });
 
   it('verifies replacement settings for seamless TestFlight update', () => {
     const config = parseTestFlightUploadConfig({
-      argv: ['--replacement', '--production'],
+      argv: ['--production'],
       env: { BUILD_NUMBER: '2026071802' },
     });
 
@@ -155,11 +114,19 @@ describe('parseTestFlightUploadConfig', () => {
     ).toEqual({ ok: true, errors: [], warnings: [] });
   });
 
-  it('rejects side-by-side settings for replacement readiness', () => {
-    const config = parseTestFlightUploadConfig({
-      argv: ['--side-by-side', '--production'],
-      env: { BUILD_NUMBER: '2026071802' },
-    });
+  // The parser can no longer emit a non-App-Store identity, but the readiness
+  // guard is the last line of defence before an upload, so it still has to
+  // reject a hand-built config carrying the retired beta listing's bundle ids.
+  it('rejects a config carrying the retired Swift beta bundle ids', () => {
+    const config = {
+      ...parseTestFlightUploadConfig({
+        argv: ['--production'],
+        env: { BUILD_NUMBER: '2026071802' },
+      }),
+      bundleId: 'com.andrewbierman.packrat.swift',
+      companionBundleId: 'com.andrewbierman.packrat.swift',
+      watchBundleId: 'com.andrewbierman.packrat.swift.watchkitapp',
+    };
 
     const readiness = verifyTestFlightReplacementReadiness({
       config,
@@ -168,13 +135,13 @@ describe('parseTestFlightUploadConfig', () => {
 
     expect(readiness.ok).toBe(false);
     expect(readiness.errors).toContain(
-      'Use --replacement. Side-by-side Swift beta builds cannot update the Expo app.',
+      'Expected iOS bundle id com.andrewbierman.packrat, got com.andrewbierman.packrat.swift.',
     );
   });
 
   it('rejects stale replacement build numbers', () => {
     const config = parseTestFlightUploadConfig({
-      argv: ['--replacement', '--production'],
+      argv: ['--production'],
       env: { BUILD_NUMBER: '2026071801' },
     });
 
@@ -191,7 +158,7 @@ describe('parseTestFlightUploadConfig', () => {
 
   it('warns when current App Store build is not supplied', () => {
     const config = parseTestFlightUploadConfig({
-      argv: ['--replacement', '--production'],
+      argv: ['--production'],
       env: { BUILD_NUMBER: '2026071802' },
     });
 
@@ -205,7 +172,7 @@ describe('parseTestFlightUploadConfig', () => {
 
   it('rejects missing current App Store build when strict replacement readiness is required', () => {
     const config = parseTestFlightUploadConfig({
-      argv: ['--replacement', '--production'],
+      argv: ['--production'],
       env: { BUILD_NUMBER: '2026071802' },
     });
 

--- a/apps/swift/scripts/__tests__/testflight-export.test.ts
+++ b/apps/swift/scripts/__tests__/testflight-export.test.ts
@@ -38,7 +38,7 @@ describe('findExportedIPA', () => {
   it('fails when export produced multiple ipa files', () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, 'PackRat.ipa'), '');
-    writeFileSync(join(dir, 'PackRat Swift.ipa'), '');
+    writeFileSync(join(dir, 'PackRat-2.ipa'), '');
 
     expect(() => findExportedIPA(dir)).toThrow('Expected one .ipa file');
   });

--- a/apps/swift/scripts/__tests__/testflight-upload-cli.test.ts
+++ b/apps/swift/scripts/__tests__/testflight-upload-cli.test.ts
@@ -14,7 +14,7 @@ const verifyScript = resolve(repoRoot, 'apps/swift/scripts/verify-testflight-rep
 
 describe('upload-testflight CLI', () => {
   it('uses BUILD_NUMBER in dry-run preflight output', () => {
-    const output = execFileSync('bun', [script, '--replacement', '--production', '--dry-run'], {
+    const output = execFileSync('bun', [script, '--production', '--dry-run'], {
       cwd: repoRoot,
       encoding: 'utf8',
       env: { ...currentEnv, APPLE_ASC_PROVIDER: 'PackRatProvider', BUILD_NUMBER: '2026071801' },
@@ -22,7 +22,6 @@ describe('upload-testflight CLI', () => {
 
     const preflight = JSON.parse(output);
     expect(preflight).toMatchObject({
-      lane: 'replacement',
       bundleId: 'com.andrewbierman.packrat',
       displayName: 'PackRat',
       marketingVersion: monorepoVersion,
@@ -35,7 +34,7 @@ describe('upload-testflight CLI', () => {
   });
 
   it('verifies replacement TestFlight readiness from the CLI', () => {
-    const output = execFileSync('bun', [verifyScript, '--replacement', '--production'], {
+    const output = execFileSync('bun', [verifyScript, '--production'], {
       cwd: repoRoot,
       encoding: 'utf8',
       env: {
@@ -47,7 +46,6 @@ describe('upload-testflight CLI', () => {
 
     const report = JSON.parse(output);
     expect(report).toMatchObject({
-      lane: 'replacement',
       bundleId: 'com.andrewbierman.packrat',
       displayName: 'PackRat',
       apiEnvironment: 'production',
@@ -63,7 +61,7 @@ describe('upload-testflight CLI', () => {
     const env = { ...currentEnv, BUILD_NUMBER: '2026071802' };
     delete env.APP_STORE_CURRENT_BUILD_NUMBER;
 
-    const result = spawnSync('bun', [verifyScript, '--replacement', '--production'], {
+    const result = spawnSync('bun', [verifyScript, '--production'], {
       cwd: repoRoot,
       encoding: 'utf8',
       env,
@@ -87,7 +85,7 @@ describe('upload-testflight CLI', () => {
     };
     delete env.APP_STORE_CURRENT_BUILD_NUMBER;
 
-    const result = spawnSync('bun', [script, '--replacement', '--production'], {
+    const result = spawnSync('bun', [script, '--production'], {
       cwd: repoRoot,
       encoding: 'utf8',
       env,

--- a/apps/swift/scripts/lib/testflight-config.ts
+++ b/apps/swift/scripts/lib/testflight-config.ts
@@ -3,10 +3,7 @@ import { join } from 'node:path';
 import { isString, toRecord } from '@packrat/guards';
 import { safeJsonParse, safeJsonStringify } from '@packrat/utils';
 
-export type TestFlightLane = 'side-by-side' | 'replacement';
-
 export type TestFlightUploadConfig = {
-  lane: TestFlightLane;
   staging: boolean;
   dryRun: boolean;
   scheme: string;
@@ -39,10 +36,12 @@ export class TestFlightConfigError extends Error {
   }
 }
 
-const SIDE_BY_SIDE_BUNDLE_ID = 'com.andrewbierman.packrat.swift';
-const REPLACEMENT_BUNDLE_ID = 'com.andrewbierman.packrat';
-const SIDE_BY_SIDE_WATCH_BUNDLE_ID = 'com.andrewbierman.packrat.swift.watchkitapp';
-const REPLACEMENT_WATCH_BUNDLE_ID = 'com.andrewbierman.packrat.watchkitapp';
+// The Swift app ships to the one public App Store listing. The separate
+// `com.andrewbierman.packrat.swift` beta listing that once ran in parallel is
+// retired — every upload now targets the real app.
+const BUNDLE_ID = 'com.andrewbierman.packrat';
+const WATCH_BUNDLE_ID = 'com.andrewbierman.packrat.watchkitapp';
+const DISPLAY_NAME = 'PackRat';
 /**
  * The Swift marketing version tracks the monorepo version in the root
  * `package.json`, which `bun bump` owns. Reading it here instead of hardcoding a
@@ -75,35 +74,26 @@ export function parseTestFlightUploadConfig(input: {
   env?: { BUILD_NUMBER?: string | undefined; MARKETING_VERSION?: string | undefined };
 }): TestFlightUploadConfig {
   const { argv, env = {} } = input;
-  const sideBySide = argv.includes('--side-by-side');
-  const replacement = argv.includes('--replacement');
   const staging = argv.includes('--staging');
   const production = argv.includes('--production');
   const dryRun = argv.includes('--dry-run');
 
-  if (sideBySide === replacement) {
-    throw new TestFlightConfigError(
-      'Choose exactly one TestFlight lane: --replacement for the existing Expo/App Store listing, or --side-by-side for the separate Swift beta app.',
-    );
-  }
   if (staging && production) {
     throw new TestFlightConfigError('Use either --staging or --production, not both.');
   }
 
-  const lane: TestFlightLane = replacement ? 'replacement' : 'side-by-side';
   const marketingVersion = env.MARKETING_VERSION ?? readMonorepoVersion();
   const buildNumber = env.BUILD_NUMBER ?? String(Math.floor(Date.now() / 1000));
 
   return {
-    lane,
     staging,
     dryRun,
     scheme: staging ? 'PackRat-iOS-Staging' : 'PackRat-iOS',
     configuration: staging ? 'Staging' : 'Release',
-    bundleId: replacement ? REPLACEMENT_BUNDLE_ID : SIDE_BY_SIDE_BUNDLE_ID,
-    watchBundleId: replacement ? REPLACEMENT_WATCH_BUNDLE_ID : SIDE_BY_SIDE_WATCH_BUNDLE_ID,
-    companionBundleId: replacement ? REPLACEMENT_BUNDLE_ID : SIDE_BY_SIDE_BUNDLE_ID,
-    displayName: replacement ? 'PackRat' : 'PackRat Swift',
+    bundleId: BUNDLE_ID,
+    watchBundleId: WATCH_BUNDLE_ID,
+    companionBundleId: BUNDLE_ID,
+    displayName: DISPLAY_NAME,
     marketingVersion,
     buildNumber,
     apiEnvironment: staging ? 'dev' : 'production',
@@ -138,9 +128,6 @@ export function verifyTestFlightReplacementReadiness(
   const errors: string[] = [];
   const warnings: string[] = [];
 
-  if (config.lane !== 'replacement') {
-    errors.push('Use --replacement. Side-by-side Swift beta builds cannot update the Expo app.');
-  }
   if (
     config.staging ||
     config.configuration !== 'Release' ||
@@ -148,17 +135,15 @@ export function verifyTestFlightReplacementReadiness(
   ) {
     errors.push('Use the production Release archive for a seamless TestFlight update.');
   }
-  if (config.bundleId !== REPLACEMENT_BUNDLE_ID) {
-    errors.push(`Expected iOS bundle id ${REPLACEMENT_BUNDLE_ID}, got ${config.bundleId}.`);
+  if (config.bundleId !== BUNDLE_ID) {
+    errors.push(`Expected iOS bundle id ${BUNDLE_ID}, got ${config.bundleId}.`);
   }
-  if (config.watchBundleId !== REPLACEMENT_WATCH_BUNDLE_ID) {
-    errors.push(
-      `Expected watch bundle id ${REPLACEMENT_WATCH_BUNDLE_ID}, got ${config.watchBundleId}.`,
-    );
+  if (config.watchBundleId !== WATCH_BUNDLE_ID) {
+    errors.push(`Expected watch bundle id ${WATCH_BUNDLE_ID}, got ${config.watchBundleId}.`);
   }
-  if (config.companionBundleId !== REPLACEMENT_BUNDLE_ID) {
+  if (config.companionBundleId !== BUNDLE_ID) {
     errors.push(
-      `Expected watch companion bundle id ${REPLACEMENT_BUNDLE_ID}, got ${config.companionBundleId}.`,
+      `Expected watch companion bundle id ${BUNDLE_ID}, got ${config.companionBundleId}.`,
     );
   }
   if (config.displayName !== 'PackRat') {

--- a/apps/swift/scripts/upload-testflight.ts
+++ b/apps/swift/scripts/upload-testflight.ts
@@ -2,11 +2,9 @@
 /**
  * Archive the native Swift PackRat iOS app and upload it to TestFlight.
  *
- * Choose the App Store Connect lane explicitly:
- *   --replacement   existing Expo/App Store listing (`com.andrewbierman.packrat`,
- *                   display name `PackRat`) for true TestFlight update testing.
- *   --side-by-side  separate Swift beta listing (`com.andrewbierman.packrat.swift`,
- *                   display name `PackRat Swift`) for parallel beta installs.
+ * Uploads go to the one public App Store listing (`com.andrewbierman.packrat`,
+ * display name `PackRat`). The separate `PackRat Swift` beta listing that once
+ * ran in parallel is retired.
  *
  * Auth accepts either an App Store Connect API key or an Apple ID +
  * app-specific password (appleid.apple.com -> Sign-In & Security ->
@@ -35,8 +33,8 @@
  *                            (default: the monorepo version from the root
  *                            package.json, which `bun bump` owns)
  *   APP_STORE_CURRENT_BUILD_NUMBER
- *                            Required for --replacement uploads; latest existing
- *                            PackRat App Store/TestFlight build number.
+ *                            Required; latest existing PackRat App Store /
+ *                            TestFlight build number.
  *   EXPORT_PROVISIONING_PROFILE
  *                            Profile *name* for the iOS app. Set it to sign the
  *                            export manually — automatic signing fails with
@@ -47,8 +45,6 @@
  *                            manual export fails on the watchkitapp bundle id.
  *
  * Flags:
- *   --replacement            Archive for the existing Expo/App Store iOS listing.
- *   --side-by-side           Archive for the separate Swift beta listing.
  *   --staging                Archive the Staging config (PACKRAT_ENV=dev) so the
  *                            build targets the deployed DEV API instead of production.
  *   --production             Optional clarity flag; Release/production is the default
@@ -59,10 +55,10 @@
  *                            before reading Apple ID upload credentials.
  *
  * Usage:
- *   bun apps/swift/scripts/upload-testflight.ts --replacement
- *   bun apps/swift/scripts/upload-testflight.ts --replacement --dry-run
- *   bun apps/swift/scripts/upload-testflight.ts --replacement --verify-archive-only
- *   bun apps/swift/scripts/upload-testflight.ts --side-by-side --staging
+ *   bun apps/swift/scripts/upload-testflight.ts
+ *   bun apps/swift/scripts/upload-testflight.ts --dry-run
+ *   bun apps/swift/scripts/upload-testflight.ts --verify-archive-only
+ *   bun apps/swift/scripts/upload-testflight.ts --staging
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -88,13 +84,10 @@ const VERIFY_ARCHIVE_ONLY = process.argv.includes('--verify-archive-only');
 function usage(): string {
   return [
     'Usage:',
-    '  bun apps/swift/scripts/upload-testflight.ts --replacement [--production|--staging] [--dry-run]',
-    '  bun apps/swift/scripts/upload-testflight.ts --replacement [--production|--staging] --verify-archive-only',
-    '  bun apps/swift/scripts/upload-testflight.ts --side-by-side [--production|--staging] [--dry-run]',
+    '  bun apps/swift/scripts/upload-testflight.ts [--production|--staging] [--dry-run]',
+    '  bun apps/swift/scripts/upload-testflight.ts [--production|--staging] --verify-archive-only',
     '',
-    'Lanes:',
-    '  --replacement   Existing Expo/App Store listing: com.andrewbierman.packrat, PackRat.',
-    '  --side-by-side  Separate Swift beta listing: com.andrewbierman.packrat.swift, PackRat Swift.',
+    'Uploads target the App Store listing: com.andrewbierman.packrat, PackRat.',
   ].join('\n');
 }
 
@@ -130,7 +123,6 @@ function printPreflight(input: {
   const archiveOverrides = xcodeArchiveOverrides({ config, teamId });
   console.log(
     safeJsonStringify({
-      lane: config.lane,
       bundleId: config.bundleId,
       watchBundleId: config.watchBundleId,
       companionBundleId: config.companionBundleId,
@@ -171,7 +163,7 @@ if (nodeEnv.BUILD_NUMBER) {
   uploadConfig = { ...uploadConfig, buildNumber: nodeEnv.BUILD_NUMBER };
 }
 
-if (uploadConfig.lane === 'replacement') {
+{
   const readiness = verifyTestFlightReplacementReadiness({
     config: uploadConfig,
     currentAppStoreBuildNumber: nodeEnv.APP_STORE_CURRENT_BUILD_NUMBER,
@@ -347,6 +339,6 @@ run({
 
 console.log(
   `\n✓ Uploaded build ${uploadConfig.buildNumber} to TestFlight (${uploadConfig.bundleId}, ${uploadConfig.displayName}, ${uploadConfig.configuration}` +
-    `${uploadConfig.staging ? ' -> dev API' : ' -> production'}, ${uploadConfig.lane}).`,
+    `${uploadConfig.staging ? ' -> dev API' : ' -> production'}).`,
 );
 console.log('It will appear in App Store Connect after processing (usually 5-15 min).');

--- a/apps/swift/scripts/verify-testflight-replacement.ts
+++ b/apps/swift/scripts/verify-testflight-replacement.ts
@@ -7,7 +7,7 @@
  *
  * Usage:
  *   APP_STORE_CURRENT_BUILD_NUMBER=123 BUILD_NUMBER=456 \
- *     bun apps/swift/scripts/verify-testflight-replacement.ts --replacement --production
+ *     bun apps/swift/scripts/verify-testflight-replacement.ts --production
  */
 import { nodeEnv } from '@packrat/env/node';
 import { safeJsonStringify } from '@packrat/utils';
@@ -22,7 +22,7 @@ const HELP = process.argv.includes('--help') || process.argv.includes('-h');
 function usage(): string {
   return [
     'Usage:',
-    '  bun apps/swift/scripts/verify-testflight-replacement.ts --replacement --production',
+    '  bun apps/swift/scripts/verify-testflight-replacement.ts --production',
     '',
     'Recommended env:',
     '  BUILD_NUMBER                    build number intended for upload',

--- a/apps/swift/scripts/watch-sync-smoke.ts
+++ b/apps/swift/scripts/watch-sync-smoke.ts
@@ -22,11 +22,8 @@ const SWIFT_DIR = resolve(REPO_ROOT, 'apps/swift');
 const ARTIFACT_DIR = resolve(REPO_ROOT, 'artifacts/screenshots-latest');
 const IOS_BUNDLE_ID = nodeEnv.PACKRAT_IOS_BUNDLE_ID ?? 'com.andrewbierman.packrat';
 const WATCH_BUNDLE_ID = nodeEnv.PACKRAT_WATCH_BUNDLE_ID ?? 'com.andrewbierman.packrat.watchkitapp';
-const KNOWN_IOS_BUNDLE_IDS = ['com.andrewbierman.packrat', 'com.andrewbierman.packrat.swift'];
-const KNOWN_WATCH_BUNDLE_IDS = [
-  'com.andrewbierman.packrat.watchkitapp',
-  'com.andrewbierman.packrat.swift.watchkitapp',
-];
+const KNOWN_IOS_BUNDLE_IDS = ['com.andrewbierman.packrat'];
+const KNOWN_WATCH_BUNDLE_IDS = ['com.andrewbierman.packrat.watchkitapp'];
 const WAIT_MS = Number(nodeEnv.PACKRAT_WATCH_SYNC_WAIT_MS ?? 45_000);
 
 // biome-ignore lint/complexity/useMaxParams: command wrappers read like shell invocations.


### PR DESCRIPTION
Every TestFlight upload now targets the one public App Store listing.

The parallel `com.andrewbierman.packrat.swift` / `PackRat Swift` record existed so the Swift rewrite could be beta-tested alongside the shipping Expo app. The Swift app is on the main listing now, so the second record is dead weight — and a standing risk of shipping to the wrong place.

## What went

- `--replacement` and `--side-by-side` flags
- `TestFlightLane` type and the `lane` config field
- Per-lane bundle-id / display-name branching — these are constants now

`verifyTestFlightReplacementReadiness` keeps its bundle-id guards. The parser can no longer produce a wrong identity, but that guard is the last check before an upload, so it still earns its place. The test covering it now builds a bad config by hand rather than via a retired flag.

## Fixes a live bug

`swift-staging-adhoc.yml` signed its export with `com.andrewbierman.packrat.swift`. That workflow would have failed against a provisioning profile for the real app — it was only working because nothing had exercised it since the move to the main listing.

## Testing

74/74 Swift script tests green. Verified against a real archive: `--dry-run` resolves to `com.andrewbierman.packrat` / `PackRat` / production Release with no flag passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Swift TestFlight uploads now target the single public PackRat App Store listing.
  * The separate PackRat Swift beta listing and side-by-side/replacement upload options have been retired.
  * macOS TestFlight builds now appear under the same App Store Connect record as the Expo iPhone app.
  * Updated verification and staging workflows to use the current production bundle and provisioning configuration.

* **Documentation**
  * Updated Swift TestFlight and macOS distribution guidance to reflect the consolidated release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->