### PR TITLE
Ship the Apple Watch app and add item delete to its detail menu

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemDetailView.swift
@@ -8,7 +8,10 @@ struct PackItemDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AuthManager.self) private var authManager
     @Environment(\.weightUnit) private var weightUnit
+    @Environment(\.modelContext) private var modelContext
     @State private var showingEdit = false
+    @State private var showingDeleteConfirmation = false
+    @State private var deleteError: String?
     @State private var showingAskAI = false
     @State private var similarItems: [CatalogItem] = []
     @State private var isLoadingSimilar = false
@@ -23,6 +26,22 @@ struct PackItemDetailView: View {
     /// reflected here on dismiss. `initialItem` is only a snapshot from when
     /// this view was constructed, so rendering it directly left the detail
     /// screen showing the pre-edit weight after saving.
+    /// Deletes the item and leaves the screen — staying would render an item that
+    /// no longer exists. Mirrors the pack delete in `PackDetailView`: an
+    /// unreachable server queues the delete for replay rather than failing here,
+    /// so only a real error keeps the user on the screen.
+    private func deleteItem() {
+        let itemId = item.id
+        Task {
+            do {
+                try await viewModel.deleteItem(itemId, from: packId, context: modelContext)
+                dismiss()
+            } catch {
+                deleteError = error.localizedDescription
+            }
+        }
+    }
+
     private var item: PackItem {
         viewModel.packs
             .first { $0.id == packId }?
@@ -54,9 +73,40 @@ struct PackItemDetailView: View {
                     Button("Done") { dismiss() }
                 }
                 ToolbarItem(placement: .primaryAction) {
-                    Button("Edit", systemImage: "pencil") { showingEdit = true }
-                        .accessibilityIdentifier("pack_item_detail_edit_button")
+                    // A menu rather than a bare Edit button: deleting an item was
+                    // previously only reachable by swiping or long-pressing its row
+                    // in the pack, which testers could not find (#2720).
+                    Menu {
+                        Button("Edit", systemImage: "pencil") { showingEdit = true }
+                            .accessibilityIdentifier("pack_item_detail_edit_button")
+
+                        Button("Delete Item", systemImage: "trash", role: .destructive) {
+                            showingDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("pack_item_detail_delete_button")
+                    } label: {
+                        Label("More", systemImage: "ellipsis.circle")
+                            .labelStyle(.iconOnly)
+                    }
+                    .accessibilityIdentifier("pack_item_detail_more_menu")
                 }
+            }
+            .alert("Delete \(item.name)?", isPresented: $showingDeleteConfirmation) {
+                Button("Delete", role: .destructive) { deleteItem() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("\"\(item.name)\" will be removed from this pack. This cannot be undone.")
+            }
+            .alert(
+                "Could not delete item",
+                isPresented: Binding(
+                    get: { deleteError != nil },
+                    set: { if !$0 { deleteError = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) { deleteError = nil }
+            } message: {
+                Text(deleteError ?? "")
             }
             .sheet(isPresented: $showingAskAI) {
                 PackItemAskAISheet(item: item)

--- a/apps/swift/Sources/PackRat/Watch/WatchCompanionService.swift
+++ b/apps/swift/Sources/PackRat/Watch/WatchCompanionService.swift
@@ -11,7 +11,24 @@ final class WatchCompanionService: NSObject {
     private var session: WCSession?
     private var lastSnapshot: PackRatWatchSnapshot?
 
-    private override init() {
+    private let packingModeStore: PackingModeStore
+    private let defaults: UserDefaults
+
+    /// Retained so a toggle arriving from the watch can push a corrected
+    /// snapshot straight back without waiting for the phone UI's 15s republish
+    /// loop — the watch needs to see its own change confirmed.
+    private weak var lastPublishedAppState: AppState?
+
+    private var temperatureUnit: WatchTemperatureUnit {
+        WatchTemperatureUnit.fromDefaults(defaults)
+    }
+
+    init(
+        packingModeStore: PackingModeStore = .shared,
+        defaults: UserDefaults = .standard
+    ) {
+        self.packingModeStore = packingModeStore
+        self.defaults = defaults
         super.init()
         encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
@@ -26,6 +43,7 @@ final class WatchCompanionService: NSObject {
     }
 
     func publishSnapshot(from appState: AppState) {
+        lastPublishedAppState = appState
         let snapshot = makeSnapshot(from: appState)
         guard snapshot != lastSnapshot else { return }
         lastSnapshot = snapshot
@@ -52,13 +70,7 @@ final class WatchCompanionService: NSObject {
 
         return PackRatWatchSnapshot(
             updatedAt: Date(),
-            pack: WatchPackSnapshot(
-                name: pack?.name ?? "No Pack Selected",
-                baseWeightText: formatWeight(pack?.baseWeight ?? pack?.totalWeight),
-                packedItemCount: pack?.activeItems.count ?? 0,
-                totalItemCount: pack?.activeItems.count ?? 0,
-                checklist: makeChecklist(from: pack)
-            ),
+            pack: makePackSnapshot(from: pack),
             trip: trip.map {
                 WatchTripSnapshot(
                     name: $0.name,
@@ -70,7 +82,10 @@ final class WatchCompanionService: NSObject {
                 locationName: appState.weatherVM.selectedLocation?.displayName
                     ?? weather?.location?.name
                     ?? "No Location",
-                temperatureText: weather?.current?.tempF.map { "\(Int($0.rounded()))°" } ?? "--",
+                temperatureText: temperatureUnit.format(
+                    celsius: weather?.current?.tempC,
+                    fahrenheit: weather?.current?.tempF
+                ),
                 conditionText: weather?.current?.condition?.text ?? "Open iPhone app to sync weather.",
                 symbolName: weather?.current?.condition?.sfSymbol ?? "cloud"
             ),
@@ -107,31 +122,32 @@ final class WatchCompanionService: NSObject {
         return appState.tripsVM.trips.first
     }
 
-    private func makeChecklist(from pack: Pack?) -> [WatchChecklistItemSnapshot] {
-        (pack?.activeItems ?? [])
-            .prefix(8)
-            .map {
-                WatchChecklistItemSnapshot(
-                    id: $0.id,
-                    title: $0.name,
-                    symbolName: symbol(for: $0.category),
-                    isPacked: true
-                )
-            }
-    }
-
-    private func symbol(for category: String?) -> String {
-        switch category?.lowercased() {
-        case "shelter": return "tent"
-        case "sleep": return "bed.double"
-        case "water": return "drop"
-        case "food": return "fork.knife"
-        case "clothing": return "jacket"
-        case "safety": return "cross.case"
-        case "kitchen": return "flame"
-        case "pack": return "backpack"
-        default: return "checkmark.circle"
+    /// Builds the pack half of the snapshot from real packed state.
+    ///
+    /// Packed state comes from `PackingModeStore`, the phone's source of truth
+    /// (see #2694/#2718 — this used to hardcode `isPacked: true`, so the watch
+    /// showed a fully ticked list and a count that disagreed with the phone).
+    private func makePackSnapshot(from pack: Pack?) -> WatchPackSnapshot {
+        guard let pack else {
+            return WatchSnapshotBuilder.makePackSnapshot(
+                packId: nil,
+                name: "No Pack Selected",
+                baseWeightText: formatWeight(nil),
+                items: [],
+                isPacked: { _ in false }
+            )
         }
+
+        let packingMode = packingModeStore
+        return WatchSnapshotBuilder.makePackSnapshot(
+            packId: pack.id,
+            name: pack.name,
+            baseWeightText: formatWeight(pack.baseWeight ?? pack.totalWeight),
+            items: pack.activeItems.map {
+                WatchSnapshotBuilder.Item(id: $0.id, name: $0.name, category: $0.category)
+            },
+            isPacked: { packingMode.isPacked($0, in: pack.id) }
+        )
     }
 
     private func formatWeight(_ grams: Double?) -> String {
@@ -144,6 +160,38 @@ final class WatchCompanionService: NSObject {
         UserDefaults.standard.set(draft.condition, forKey: "watch.latestTrailDraft.condition")
         UserDefaults.standard.set(draft.note, forKey: "watch.latestTrailDraft.note")
         UserDefaults.standard.set(draft.createdAt, forKey: "watch.latestTrailDraft.createdAt")
+    }
+
+    /// Applies a packed/unpacked change made on the watch to the phone's store.
+    ///
+    /// Returns the applied message so callers (and tests) can tell a real change
+    /// from an ignored payload. Idempotent: WatchConnectivity delivers a toggle
+    /// over both `sendMessage` and `transferUserInfo` so it survives the phone
+    /// being unreachable, which means the same change can arrive twice.
+    @discardableResult
+    func applyChecklistToggle(_ message: WatchChecklistToggleMessage) -> WatchChecklistToggleMessage {
+        packingModeStore.setPacked(
+            message.isPacked,
+            itemId: message.itemId,
+            in: message.packId
+        )
+        return message
+    }
+
+    private func handleChecklistTogglePayload(_ payload: [String: Any]) {
+        guard let data = payload[WatchCompanionMessage.checklistToggle] as? Data,
+              let message = try? decoder.decode(WatchChecklistToggleMessage.self, from: data)
+        else { return }
+
+        applyChecklistToggle(message)
+
+        // Push the corrected state back so the watch's optimistic toggle is
+        // confirmed by the phone rather than left to drift until the next
+        // periodic republish. `lastSnapshot` is cleared because the pack half
+        // changed underneath the equality check that normally suppresses sends.
+        guard let appState = lastPublishedAppState else { return }
+        lastSnapshot = nil
+        publishSnapshot(from: appState)
     }
 
     private func handleTrailDraftPayload(_ payload: [String: Any]) {
@@ -173,12 +221,14 @@ extension WatchCompanionService: WCSessionDelegate {
     nonisolated func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
         Task { @MainActor in
             WatchCompanionService.shared.handleTrailDraftPayload(userInfo)
+            WatchCompanionService.shared.handleChecklistTogglePayload(userInfo)
         }
     }
 
     nonisolated func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
         Task { @MainActor in
             WatchCompanionService.shared.handleTrailDraftPayload(message)
+            WatchCompanionService.shared.handleChecklistTogglePayload(message)
         }
     }
 }

--- a/apps/swift/Sources/PackRatShared/WatchSnapshot.swift
+++ b/apps/swift/Sources/PackRatShared/WatchSnapshot.swift
@@ -57,6 +57,7 @@ struct PackRatWatchSnapshot: Codable, Equatable, Sendable {
     static let fallback = PackRatWatchSnapshot(
         updatedAt: Date(timeIntervalSince1970: 0),
         pack: WatchPackSnapshot(
+            packId: nil,
             name: "No Pack Synced",
             baseWeightText: "--",
             packedItemCount: 0,
@@ -80,6 +81,7 @@ struct PackRatWatchSnapshot: Codable, Equatable, Sendable {
     static let visualSyncedSample = PackRatWatchSnapshot(
         updatedAt: Date(timeIntervalSince1970: 1_779_984_000),
         pack: WatchPackSnapshot(
+            packId: "visual-watch-pack",
             name: "Alpine Weekend",
             baseWeightText: "10.4 lb",
             packedItemCount: 3,
@@ -111,6 +113,12 @@ struct PackRatWatchSnapshot: Codable, Equatable, Sendable {
 }
 
 struct WatchPackSnapshot: Codable, Equatable, Sendable {
+    /// Identifier of the pack this snapshot describes, so a toggle made on the
+    /// watch can name the pack it belongs to when it travels back to the phone.
+    /// Optional for backward compatibility: a snapshot cached by an older build
+    /// decodes with `nil` and simply cannot round-trip toggles until the phone
+    /// publishes again.
+    var packId: String?
     var name: String
     var baseWeightText: String
     var packedItemCount: Int
@@ -150,7 +158,16 @@ struct WatchTrailReportDraft: Codable, Equatable, Sendable {
     var createdAt: Date
 }
 
+/// A single packed/unpacked change made on the watch, travelling back to the
+/// phone so `PackingModeStore` (the phone-side source of truth) can record it.
+struct WatchChecklistToggleMessage: Codable, Equatable, Sendable {
+    var packId: String
+    var itemId: String
+    var isPacked: Bool
+}
+
 enum WatchCompanionMessage {
     static let snapshot = "packrat.watch.snapshot"
     static let trailDraft = "packrat.watch.trailDraft"
+    static let checklistToggle = "packrat.watch.checklistToggle"
 }

--- a/apps/swift/Sources/PackRatShared/WatchSnapshotBuilders.swift
+++ b/apps/swift/Sources/PackRatShared/WatchSnapshotBuilders.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Pure mapping helpers shared by the phone (which builds snapshots) and the
+/// watch (which renders and mutates them).
+///
+/// These deliberately take plain values rather than app models or `WCSession`,
+/// so the two behaviours issues #2694/#2718/#2719 turn on — packed state and
+/// the temperature unit — are testable without a paired device.
+enum WatchSnapshotBuilder {
+    /// How many checklist rows a watch snapshot carries. The watch screen is a
+    /// glanceable summary, not the full pack, so the list is capped.
+    ///
+    /// The cap applies to the *rows sent*, never to the counts: `packedItemCount`
+    /// and `totalItemCount` describe the whole pack. Counting only the first
+    /// `checklistLimit` items is what made the watch disagree with the phone in
+    /// #2718 for any pack larger than the window.
+    static let checklistLimit = 8
+
+    /// One pack item, reduced to what the checklist mapping needs.
+    struct Item: Equatable, Sendable {
+        var id: String
+        var name: String
+        var category: String?
+
+        init(id: String, name: String, category: String?) {
+            self.id = id
+            self.name = name
+            self.category = category
+        }
+    }
+
+    /// Maps pack items to checklist rows, reading real packed state from
+    /// `isPacked` rather than assuming everything is packed (#2694 defect 1).
+    static func makeChecklist(
+        from items: [Item],
+        isPacked: (String) -> Bool
+    ) -> [WatchChecklistItemSnapshot] {
+        items.prefix(checklistLimit).map { item in
+            WatchChecklistItemSnapshot(
+                id: item.id,
+                title: item.name,
+                symbolName: symbol(for: item.category),
+                isPacked: isPacked(item.id)
+            )
+        }
+    }
+
+    /// Packed count across *every* item in the pack, not just the rows that fit
+    /// on the watch — this is the number the phone shows.
+    static func packedCount(in items: [Item], isPacked: (String) -> Bool) -> Int {
+        items.reduce(into: 0) { count, item in
+            if isPacked(item.id) { count += 1 }
+        }
+    }
+
+    /// Builds the pack half of a snapshot with counts and checklist in step.
+    static func makePackSnapshot(
+        packId: String?,
+        name: String,
+        baseWeightText: String,
+        items: [Item],
+        isPacked: (String) -> Bool
+    ) -> WatchPackSnapshot {
+        WatchPackSnapshot(
+            packId: packId,
+            name: name,
+            baseWeightText: baseWeightText,
+            packedItemCount: packedCount(in: items, isPacked: isPacked),
+            totalItemCount: items.count,
+            checklist: makeChecklist(from: items, isPacked: isPacked)
+        )
+    }
+
+    static func symbol(for category: String?) -> String {
+        switch category?.lowercased() {
+        case "shelter": return "tent"
+        case "sleep": return "bed.double"
+        case "water": return "drop"
+        case "food": return "fork.knife"
+        case "clothing": return "jacket"
+        case "safety": return "cross.case"
+        case "kitchen": return "flame"
+        case "pack": return "backpack"
+        default: return "checkmark.circle"
+        }
+    }
+}
+
+/// The temperature unit a snapshot's `temperatureText` was rendered in.
+///
+/// The watch renders whatever string the phone sends, so honouring the phone's
+/// unit preference (#2719) is a phone-side formatting concern. This mirrors
+/// `AppPreferences.TemperatureUnit` in a target both apps can see; the raw
+/// values match so the phone's `@AppStorage("temperatureUnit")` string maps
+/// straight across.
+enum WatchTemperatureUnit: String, CaseIterable, Codable, Sendable {
+    case fahrenheit = "°F"
+    case celsius = "°C"
+
+    /// Reads the phone's stored preference, falling back to the same default
+    /// the phone uses when nothing has been chosen.
+    static func fromDefaults(
+        _ defaults: UserDefaults = .standard,
+        key: String = "temperatureUnit"
+    ) -> WatchTemperatureUnit {
+        guard let raw = defaults.string(forKey: key),
+              let unit = WatchTemperatureUnit(rawValue: raw)
+        else { return .fahrenheit }
+        return unit
+    }
+
+    /// Formats a temperature in the requested unit, converting when the API only
+    /// supplied the other scale. Returns `"--"` when neither is available.
+    ///
+    /// Matches the phone's `formattedTemperature` in ForecastRow.swift, so the
+    /// two surfaces round identically instead of drifting by a degree.
+    func format(celsius: Double?, fahrenheit: Double?) -> String {
+        let value: Double?
+        switch self {
+        case .celsius:
+            value = celsius ?? fahrenheit.map { ($0 - 32) * 5 / 9 }
+        case .fahrenheit:
+            value = fahrenheit ?? celsius.map { ($0 * 9 / 5) + 32 }
+        }
+        guard let value else { return "--" }
+        return "\(Int(value.rounded()))°"
+    }
+}

--- a/apps/swift/Sources/PackRatWatch/PackRatWatchApp.swift
+++ b/apps/swift/Sources/PackRatWatch/PackRatWatchApp.swift
@@ -26,7 +26,7 @@ private struct WatchRootView: View {
         case "dashboard":
             TrailReadyView(snapshot: connectivity.snapshot, isPhoneReachable: connectivity.isPhoneReachable)
         case "checklist":
-            WatchChecklistView(pack: connectivity.snapshot.pack)
+            WatchChecklistView()
         case "weather":
             WatchWeatherView(weather: connectivity.snapshot.weather)
         case "trail-report":
@@ -47,7 +47,7 @@ private struct WatchDashboardView: View {
         TabView(selection: $selectedTab) {
             TrailReadyView(snapshot: connectivity.snapshot, isPhoneReachable: connectivity.isPhoneReachable)
                 .tag(0)
-            WatchChecklistView(pack: connectivity.snapshot.pack)
+            WatchChecklistView()
                 .tag(1)
             WatchWeatherView(weather: connectivity.snapshot.weather)
                 .tag(2)
@@ -124,7 +124,11 @@ private struct TrailReadyView: View {
 }
 
 private struct WatchChecklistView: View {
-    let pack: WatchPackSnapshot
+    @Environment(WatchConnectivityStore.self) private var connectivity
+
+    /// Read from the store on each render, not captured at init, so a toggle
+    /// updates both the row and the "N of M packed" line immediately.
+    private var pack: WatchPackSnapshot { connectivity.snapshot.pack }
 
     var body: some View {
         NavigationStack {
@@ -263,16 +267,22 @@ private struct WatchMetricRow: View {
 }
 
 private struct WatchChecklistToggle: View {
+    @Environment(WatchConnectivityStore.self) private var connectivity
     let item: WatchChecklistItemSnapshot
-    @State private var isOn: Bool
 
-    init(item: WatchChecklistItemSnapshot) {
-        self.item = item
-        _isOn = State(initialValue: item.isPacked)
+    /// Reads through to the store rather than a local `@State` seeded once.
+    /// The old version dropped the toggle when the view went away and never
+    /// told the phone (#2694 defect 2); binding to the store persists it and
+    /// sends it on.
+    private var isOn: Binding<Bool> {
+        Binding(
+            get: { item.isPacked },
+            set: { connectivity.setChecklistItemPacked($0, itemId: item.id) }
+        )
     }
 
     var body: some View {
-        Toggle(isOn: $isOn) {
+        Toggle(isOn: isOn) {
             Label(item.title, systemImage: item.symbolName)
         }
     }

--- a/apps/swift/Sources/PackRatWatch/WatchConnectivityStore.swift
+++ b/apps/swift/Sources/PackRatWatch/WatchConnectivityStore.swift
@@ -62,6 +62,47 @@ final class WatchConnectivityStore: NSObject {
         session.transferUserInfo(payload)
     }
 
+    /// Records a packed/unpacked change made on the watch.
+    ///
+    /// Applied optimistically to the in-memory snapshot and written to the same
+    /// cached-snapshot key the phone's payloads land in, so the toggle survives
+    /// leaving and returning to the screen even before the phone answers
+    /// (#2694 defect 2). The change is then sent to the phone, which owns the
+    /// durable state in `PackingModeStore` and republishes a corrected snapshot.
+    func setChecklistItemPacked(_ isPacked: Bool, itemId: String) {
+        applyLocally(isPacked: isPacked, itemId: itemId)
+
+        guard let packId = snapshot.pack.packId else { return }
+        let message = WatchChecklistToggleMessage(packId: packId, itemId: itemId, isPacked: isPacked)
+        guard let session, let data = try? encoder.encode(message) else { return }
+
+        let payload = [WatchCompanionMessage.checklistToggle: data]
+        if session.isReachable {
+            session.sendMessage(payload, replyHandler: nil)
+        }
+        // Queued regardless of reachability so a toggle made out of range still
+        // reaches the phone, mirroring how trail drafts are delivered.
+        session.transferUserInfo(payload)
+    }
+
+    private func applyLocally(isPacked: Bool, itemId: String) {
+        guard let index = snapshot.pack.checklist.firstIndex(where: { $0.id == itemId }),
+              snapshot.pack.checklist[index].isPacked != isPacked
+        else { return }
+
+        var next = snapshot
+        next.pack.checklist[index].isPacked = isPacked
+        // Keep the "N of M packed" line in step with the toggles on screen.
+        next.pack.packedItemCount = max(0, next.pack.packedItemCount + (isPacked ? 1 : -1))
+        snapshot = next
+        persistSnapshot()
+    }
+
+    private func persistSnapshot() {
+        guard let data = try? encoder.encode(snapshot) else { return }
+        UserDefaults.standard.set(data, forKey: snapshotKey)
+    }
+
     private func handle(_ payload: [String: Any]) {
         guard let data = payload[WatchCompanionMessage.snapshot] as? Data,
               let next = try? decoder.decode(PackRatWatchSnapshot.self, from: data)

--- a/apps/swift/Tests/PackRatTests/WatchChecklistSyncTests.swift
+++ b/apps/swift/Tests/PackRatTests/WatchChecklistSyncTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import PackRat
+
+/// Covers the two defects in #2694 (and the #2718 duplicate of defect 1): the
+/// checklist mapping must reflect real packed state, and a watch toggle must
+/// land in the phone's `PackingModeStore`.
+@Suite("Watch checklist sync")
+struct WatchChecklistSyncTests {
+    private func items(_ count: Int) -> [WatchSnapshotBuilder.Item] {
+        (1...count).map {
+            WatchSnapshotBuilder.Item(id: "item-\($0)", name: "Item \($0)", category: nil)
+        }
+    }
+
+    @MainActor
+    private func makeStore() -> PackingModeStore {
+        let defaults = UserDefaults(suiteName: "watch.checklist.tests.\(UUID().uuidString)")!
+        return PackingModeStore(defaults: defaults)
+    }
+
+    // MARK: - Defect 1: packed state and counts
+
+    @Test("checklist reflects real packed state instead of hardcoding packed")
+    func checklistReflectsRealPackedState() {
+        let packed: Set<String> = ["item-2", "item-4"]
+
+        let checklist = WatchSnapshotBuilder.makeChecklist(from: items(4)) { packed.contains($0) }
+
+        #expect(checklist.map(\.isPacked) == [false, true, false, true])
+    }
+
+    @Test("nothing packed yields an all-unpacked checklist")
+    func nothingPackedYieldsAllUnpackedChecklist() {
+        let checklist = WatchSnapshotBuilder.makeChecklist(from: items(3)) { _ in false }
+
+        #expect(checklist.allSatisfy { !$0.isPacked })
+        #expect(checklist.count == 3)
+    }
+
+    // MARK: - Defect 1 / #2718: the count line must agree with the phone
+
+    @Test("packed count matches the phone for a partially packed pack")
+    func packedCountMatchesPhoneForPartiallyPackedPack() {
+        // The exact numbers reported in #2718: iPhone said 5 of 7.
+        let packed: Set<String> = ["item-1", "item-2", "item-3", "item-4", "item-5"]
+
+        let snapshot = WatchSnapshotBuilder.makePackSnapshot(
+            packId: "pack-1",
+            name: "Weekend",
+            baseWeightText: "10.0 lb",
+            items: items(7),
+            isPacked: { packed.contains($0) }
+        )
+
+        #expect(snapshot.packedItemCount == 5)
+        #expect(snapshot.totalItemCount == 7)
+    }
+
+    @Test("counts describe the whole pack even when the checklist is capped")
+    func countsDescribeWholePackEvenWhenChecklistIsCapped() {
+        let snapshot = WatchSnapshotBuilder.makePackSnapshot(
+            packId: "pack-1",
+            name: "Big",
+            baseWeightText: "20.0 lb",
+            items: items(12),
+            isPacked: { _ in true }
+        )
+
+        // Only 8 rows travel to the wrist, but 12 of 12 are packed — counting
+        // the window instead of the pack is what made the two disagree.
+        #expect(snapshot.checklist.count == WatchSnapshotBuilder.checklistLimit)
+        #expect(snapshot.packedItemCount == 12)
+        #expect(snapshot.totalItemCount == 12)
+    }
+
+    @Test("an empty pack reports no packed items rather than a full checklist")
+    func emptyPackReportsNoPackedItems() {
+        let snapshot = WatchSnapshotBuilder.makePackSnapshot(
+            packId: nil,
+            name: "No Pack Selected",
+            baseWeightText: "--",
+            items: [],
+            isPacked: { _ in true }
+        )
+
+        #expect(snapshot.packedItemCount == 0)
+        #expect(snapshot.totalItemCount == 0)
+        #expect(snapshot.checklist.isEmpty)
+    }
+
+    // MARK: - Defect 2: a watch toggle reaches phone-side state
+
+    @MainActor
+    @Test("a toggle from the watch persists to the phone's packing store")
+    func toggleFromWatchPersistsToPhoneStore() {
+        let store = makeStore()
+        let service = WatchCompanionService(packingModeStore: store)
+
+        service.applyChecklistToggle(
+            WatchChecklistToggleMessage(packId: "pack-1", itemId: "item-1", isPacked: true)
+        )
+
+        #expect(store.isPacked("item-1", in: "pack-1"))
+    }
+
+    @MainActor
+    @Test("unpacking from the watch clears the phone's packed state")
+    func unpackingFromWatchClearsPhoneState() {
+        let store = makeStore()
+        store.setPacked(true, itemId: "item-1", in: "pack-1")
+        let service = WatchCompanionService(packingModeStore: store)
+
+        service.applyChecklistToggle(
+            WatchChecklistToggleMessage(packId: "pack-1", itemId: "item-1", isPacked: false)
+        )
+
+        #expect(!store.isPacked("item-1", in: "pack-1"))
+    }
+
+    @MainActor
+    @Test("the same toggle delivered twice is idempotent")
+    func sameToggleDeliveredTwiceIsIdempotent() {
+        // WatchConnectivity sends each toggle over both sendMessage and
+        // transferUserInfo, so duplicate delivery is expected, not exceptional.
+        let store = makeStore()
+        let service = WatchCompanionService(packingModeStore: store)
+        let message = WatchChecklistToggleMessage(packId: "pack-1", itemId: "item-1", isPacked: true)
+
+        service.applyChecklistToggle(message)
+        service.applyChecklistToggle(message)
+
+        #expect(store.packedCount(in: "pack-1", among: ["item-1"]) == 1)
+    }
+
+    @MainActor
+    @Test("a toggle only affects the pack it names")
+    func toggleOnlyAffectsNamedPack() {
+        let store = makeStore()
+        let service = WatchCompanionService(packingModeStore: store)
+
+        service.applyChecklistToggle(
+            WatchChecklistToggleMessage(packId: "pack-1", itemId: "item-1", isPacked: true)
+        )
+
+        #expect(store.isPacked("item-1", in: "pack-1"))
+        #expect(!store.isPacked("item-1", in: "pack-2"))
+    }
+
+    // MARK: - Transport shape
+
+    @Test("toggle message round-trips through JSON")
+    func toggleMessageRoundTripsThroughJSON() throws {
+        let message = WatchChecklistToggleMessage(packId: "pack-1", itemId: "item-1", isPacked: true)
+
+        let data = try JSONEncoder().encode(message)
+        let decoded = try JSONDecoder().decode(WatchChecklistToggleMessage.self, from: data)
+
+        #expect(decoded == message)
+    }
+
+    @Test("a snapshot cached by a build without packId still decodes")
+    func snapshotWithoutPackIdStillDecodes() throws {
+        let legacy = """
+        {"name":"Old Pack","baseWeightText":"5.0 lb","packedItemCount":1,
+         "totalItemCount":2,"checklist":[]}
+        """
+        let decoded = try JSONDecoder().decode(WatchPackSnapshot.self, from: Data(legacy.utf8))
+
+        #expect(decoded.packId == nil)
+        #expect(decoded.name == "Old Pack")
+    }
+}

--- a/apps/swift/Tests/PackRatTests/WatchTemperatureUnitTests.swift
+++ b/apps/swift/Tests/PackRatTests/WatchTemperatureUnitTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import PackRat
+
+/// Covers #2719: the watch showed Fahrenheit for a location the phone showed in
+/// Celsius, because the snapshot always formatted `tempF`. The watch renders the
+/// string the phone sends, so the unit must be resolved from the phone's
+/// preference at snapshot time.
+@Suite("Watch temperature unit")
+struct WatchTemperatureUnitTests {
+    private func defaults() -> UserDefaults {
+        UserDefaults(suiteName: "watch.temperature.tests.\(UUID().uuidString)")!
+    }
+
+    @Test("celsius preference formats the celsius reading")
+    func celsiusPreferenceFormatsCelsiusReading() {
+        // Taipei from the issue: 28°C / 82°F.
+        let text = WatchTemperatureUnit.celsius.format(celsius: 28, fahrenheit: 82.4)
+
+        #expect(text == "28°")
+    }
+
+    @Test("fahrenheit preference formats the fahrenheit reading")
+    func fahrenheitPreferenceFormatsFahrenheitReading() {
+        let text = WatchTemperatureUnit.fahrenheit.format(celsius: 28, fahrenheit: 82.4)
+
+        #expect(text == "82°")
+    }
+
+    @Test("celsius is converted when the API only supplied fahrenheit")
+    func celsiusIsConvertedWhenOnlyFahrenheitSupplied() {
+        let text = WatchTemperatureUnit.celsius.format(celsius: nil, fahrenheit: 82.4)
+
+        #expect(text == "28°")
+    }
+
+    @Test("fahrenheit is converted when the API only supplied celsius")
+    func fahrenheitIsConvertedWhenOnlyCelsiusSupplied() {
+        let text = WatchTemperatureUnit.fahrenheit.format(celsius: 28, fahrenheit: nil)
+
+        #expect(text == "82°")
+    }
+
+    @Test("a missing reading renders the placeholder, not a bogus zero")
+    func missingReadingRendersPlaceholder() {
+        #expect(WatchTemperatureUnit.celsius.format(celsius: nil, fahrenheit: nil) == "--")
+        #expect(WatchTemperatureUnit.fahrenheit.format(celsius: nil, fahrenheit: nil) == "--")
+    }
+
+    @Test("the stored phone preference is what resolves the unit")
+    func storedPhonePreferenceResolvesUnit() {
+        let store = defaults()
+
+        store.set(AppPreferences.TemperatureUnit.celsius.rawValue, forKey: "temperatureUnit")
+        #expect(WatchTemperatureUnit.fromDefaults(store) == .celsius)
+
+        store.set(AppPreferences.TemperatureUnit.fahrenheit.rawValue, forKey: "temperatureUnit")
+        #expect(WatchTemperatureUnit.fromDefaults(store) == .fahrenheit)
+    }
+
+    @Test("an unset preference falls back to the phone's own default")
+    func unsetPreferenceFallsBackToPhoneDefault() {
+        #expect(WatchTemperatureUnit.fromDefaults(defaults()) == .fahrenheit)
+    }
+
+    @Test("a corrupt stored preference degrades to the default rather than crashing")
+    func corruptStoredPreferenceDegradesToDefault() {
+        let store = defaults()
+        store.set("kelvin", forKey: "temperatureUnit")
+
+        #expect(WatchTemperatureUnit.fromDefaults(store) == .fahrenheit)
+    }
+
+    @Test("watch raw values match the phone preference so the setting maps across")
+    func watchRawValuesMatchPhonePreference() {
+        // The watch mirror is only correct while the two enums agree on the raw
+        // strings @AppStorage persists — this pins that.
+        #expect(
+            WatchTemperatureUnit.celsius.rawValue
+                == AppPreferences.TemperatureUnit.celsius.rawValue
+        )
+        #expect(
+            WatchTemperatureUnit.fahrenheit.rawValue
+                == AppPreferences.TemperatureUnit.fahrenheit.rawValue
+        )
+    }
+
+    @Test("the watch agrees with the phone's weather formatter on the same reading")
+    func watchAgreesWithPhoneFormatterOnSameReading() {
+        // Same number, same rounding — only the unit suffix differs, since the
+        // watch's large readout uses a bare degree sign.
+        let phone = WeatherTemperatureDisplay.format(celsius: 28, fahrenheit: 82.4, unit: .celsius)
+        let watch = WatchTemperatureUnit.celsius.format(celsius: 28, fahrenheit: 82.4)
+
+        #expect(phone == "28°C")
+        #expect(watch == "28°")
+    }
+}

--- a/apps/swift/project.yml
+++ b/apps/swift/project.yml
@@ -150,9 +150,11 @@ targets:
         product: RevenueCat
       - package: RevenueCat
         product: RevenueCatUI
-      # PackRat-Watch is intentionally NOT embedded: the watch app is not part of
-      # the first Swift release. The target still builds via its own scheme, so
-      # re-embed this dependency when the watch app ships.
+      # The watch app ships from 2.2.1 on, so it is embedded in the iOS app.
+      # WKCompanionAppBundleIdentifier must resolve to the iOS bundle id or
+      # installs fail with "Unable to Install PackRat".
+      - target: PackRat-Watch
+        embed: true
     settings:
       base:
         SWIFT_VERSION: "5.9"

--- a/apps/swift/scripts/upload-testflight.ts
+++ b/apps/swift/scripts/upload-testflight.ts
@@ -37,6 +37,14 @@
  *   APP_STORE_CURRENT_BUILD_NUMBER
  *                            Required for --replacement uploads; latest existing
  *                            PackRat App Store/TestFlight build number.
+ *   EXPORT_PROVISIONING_PROFILE
+ *                            Profile *name* for the iOS app. Set it to sign the
+ *                            export manually — automatic signing fails with
+ *                            `No Accounts` when Xcode has no Apple ID.
+ *   EXPORT_WATCH_PROVISIONING_PROFILE
+ *                            Profile *name* for the embedded watch app. Required
+ *                            alongside the above once the watch app ships, or the
+ *                            manual export fails on the watchkitapp bundle id.
  *
  * Flags:
  *   --replacement            Archive for the existing Expo/App Store iOS listing.
@@ -249,6 +257,9 @@ verifyBinary({
 // EXPORT_PROVISIONING_PROFILE to the profile's *name* to sign manually instead.
 // See docs/macos-testflight.md, which hits the same wall on the macOS lane.
 const exportProfileName = process.env.EXPORT_PROVISIONING_PROFILE?.trim();
+// The embedded watch app needs its own profile mapping; without it a manual
+// export fails on the watchkitapp bundle id even though the iOS one resolves.
+const exportWatchProfileName = process.env.EXPORT_WATCH_PROVISIONING_PROFILE?.trim();
 const exportOptions = join(work, 'ExportOptions.plist');
 writeFileSync(
   exportOptions,
@@ -265,7 +276,12 @@ ${
   <key>signingCertificate</key><string>Apple Distribution</string>
   <key>provisioningProfiles</key>
   <dict>
-    <key>${uploadConfig.bundleId}</key><string>${exportProfileName}</string>
+    <key>${uploadConfig.bundleId}</key><string>${exportProfileName}</string>${
+      exportWatchProfileName
+        ? `
+    <key>${uploadConfig.watchBundleId}</key><string>${exportWatchProfileName}</string>`
+        : ''
+    }
   </dict>`
     : '  <key>signingStyle</key><string>automatic</string>'
 }


### PR DESCRIPTION
Two things for 2.2.3: the Watch app finally ships, and item deletion becomes discoverable.

## The Watch app was stranded

The work to embed it was done back in August but never reached `development`. Its commits sat on `fix/soft-delete-tombstone-filtering` alongside unrelated soft-delete fixes — PR #2731 merged **only the two soft-delete commits**, so the watch embed and its export-profile mapping were left behind and `project.yml` still read "intentionally NOT embedded". A second branch, `fix/triage-watch-sync`, held four more watch fixes and was never PR'd at all.

Both are recovered here by cherry-pick rather than by merging those branches: `fix/triage-watch-sync` had drifted far enough behind that merging it would have reverted ~8,900 lines, including the feature-gating work. The six watch commits themselves touch only watch files and `project.yml`.

Recovered:

- embed `PackRat-Watch` in the iOS target, with `WKCompanionAppBundleIdentifier` resolving to the iOS bundle id (installs fail with "Unable to Install PackRat" otherwise)
- `EXPORT_WATCH_PROVISIONING_PROFILE` so manual exports can sign the embedded watch app
- shared checklist + temperature snapshot builders
- send real packed state and the phone's temperature unit to the watch
- persist checklist toggles and send them back to the phone

The `project.yml` conflict on cherry-pick was the RevenueCat dependencies that landed after the branch was cut; both they and the watch embed are kept.

## Item delete (#2720)

Deleting an item was reachable only by swiping or long-pressing its row in the pack — the same discoverability gap the pack itself had. The item detail screen's bare Edit button becomes a `⋯` menu with **Edit** and **Delete Item**, matching what Pack Detail does now. Confirms first, dismisses on success.

Placed in the detail menu rather than the Edit form the issue suggested: a destructive action inside a form that also has Cancel and Save reads as part of editing and is easy to hit mid-edit. The overflow menu is where iOS convention puts it, and where the rest of this app already had it.

## Testing

305 tests, 71 suites, green across 2 consecutive runs — up from 284, the difference being the recovered watch tests. Verified the built `.app` contains `Watch/PackRat-Watch.app` with `WKCompanionAppBundleIdentifier = com.andrewbierman.packrat`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to delete items from the item details screen, with confirmation and error handling.
  * Watch checklist changes now sync with the iPhone and remain saved across view refreshes.
  * Watch checklist status and packed-item counts now reflect the actual pack state.
  * Weather temperatures on Apple Watch now follow the selected Celsius or Fahrenheit preference.
  * The Apple Watch companion app is now included with the iOS app.

* **Bug Fixes**
  * Corrected checklist synchronization and temperature display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->