### PR TITLE
chore: bump version to v2.2.3

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-admin-app",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -145,7 +145,7 @@ export default (): ExpoConfig =>
       {
         name: getAppName(),
         slug: 'packrat',
-        version: '2.2.0',
+        version: '2.2.3',
         scheme: 'packrat',
         web: {
           bundler: 'metro',

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-expo-app",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/guides/package.json
+++ b/apps/guides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-guides-app",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "scripts": {
     "build": "bun run build-content && bun run generate-og-images && next build",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-landing-app",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "scripts": {
     "build": "bun run generate-og-images && next build",

--- a/apps/swift/project.yml
+++ b/apps/swift/project.yml
@@ -158,7 +158,7 @@ targets:
     settings:
       base:
         SWIFT_VERSION: "5.9"
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.2.3"
         CURRENT_PROJECT_VERSION: "2026081101"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 666HGMV2LU
@@ -197,7 +197,7 @@ targets:
     settings:
       base:
         SWIFT_VERSION: "5.9"
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.2.3"
         CURRENT_PROJECT_VERSION: "2026081101"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 666HGMV2LU
@@ -282,7 +282,7 @@ targets:
     settings:
       base:
         SWIFT_VERSION: "5.9"
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.2.3"
         CURRENT_PROJECT_VERSION: "2026081101"
         # Real distribution signing: the target previously used an ad-hoc
         # identity with no team, which cannot produce a TestFlight build. E2E

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-trails-app",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "scripts": {
     "build": "bun run generate-og-images && next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packrat-monorepo",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/analytics",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/api-client",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/api/container_src/package.json
+++ b/packages/api/container_src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "container",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "type": "module",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/api",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/app",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/checks",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/cli",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/config",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/consent-ui/package.json
+++ b/packages/consent-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/consent-ui",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/constants",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/db",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/env",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guards/package.json
+++ b/packages/guards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/guards",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/mcp",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "description": "PackRat MCP Server — outdoor adventure planning via Model Context Protocol",
   "scripts": {

--- a/packages/osm-db/package.json
+++ b/packages/osm-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/osm-db",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/osm-import/package.json
+++ b/packages/osm-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/osm-import",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "description": "osm2pgsql flex config and import tooling for PackRat outdoor routes",
   "type": "module",

--- a/packages/overpass/package.json
+++ b/packages/overpass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/overpass",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/schemas",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/types",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/typescript-config",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "files": [
     "base.json",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/ui",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/units/package.json
+++ b/packages/units/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/units",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/utils",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packrat/web-ui",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump for the 2.2.3 TestFlight build (`2026090601`), which carries the Watch app, item delete, the Settings sync surface, and the Gap Analysis icon fix.

Generated by `bun bump 2.2.3` — 32 files, monorepo version plus the three `MARKETING_VERSION` entries in `apps/swift/project.yml`. Tag `v2.2.3` is already pushed.

Worth noting the repo had drifted behind the store: 2.2.1 shipped publicly without a matching bump, so `development` still read 2.2.0 while the App Store was a version ahead. That drift is what closed the 2.2.0 train and blocked the first upload attempt. This bump lands on 2.2.3 to clear it.