### PR TITLE
fix(swift): trip detail meta card spacing (#2712)

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Trips/TripDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripDetailView.swift
@@ -29,6 +29,7 @@ struct TripDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 metaCards
+                    .padding(.top, 8)
 
                 // Map — shown when the trip has coordinates
                 if let coord = coordinate {


### PR DESCRIPTION
## Summary

Adds 8pt top padding above the Dates/Location meta cards on the Swift iPhone trip detail screen. They were the first element in the `ScrollView` with only horizontal padding, so under a `.large` navigation title they butted against the title with no breathing room.

Closes #2712

## Triage of the rest of the low-effort iPhone batch

Verified on the iPhone 15 Pro simulator against this branch. Three issues need no code — they were fixed on 2026-07-23 in `6b167e190` and never closed:

| Issue | Finding |
|---|---|
| #2640 — no back nav in AI Assistant | Fixed. `HomeView { phoneHomePath.append(.chat) }` pushes onto the home stack; a native "‹ Home" back button is present and returns to the dashboard. |
| #2641 — misaligned "Name" filter button | Fixed. Now a native toolbar `Menu` with `.fixedSize()`; renders flush top-right with balanced padding. |
| #2642 — weather not switching to Celsius | Fixed. Set °C in Settings → Denver shows 23°C current, 22°C feels-like, and all forecast highs/lows in °C. |
| #2657 — debug/performance overlay | Not our bug. That is Apple's Metal Performance HUD, enabled per-device via iOS Settings → Developer → Show Graphics HUD. Nothing in the project sets `MTL_HUD_ENABLED` or equivalent. |

## Test plan

- [x] `xcodebuild -scheme PackRat-iOS` builds clean
- [x] Trip detail: meta cards clear the nav title
- [x] Gear Inventory sort button alignment
- [x] Weather renders °C after changing the unit
- [x] AI Assistant back navigation returns to Home

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing in trip details by adding padding between the metadata cards and the content below.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->