### PR TITLE
fix(watch): surface trail-condition drafts captured on the Apple Watch (#2721)

### DIFF
--- a/apps/swift/Sources/PackRat/Features/TrailConditions/TrailConditionsView.swift
+++ b/apps/swift/Sources/PackRat/Features/TrailConditions/TrailConditionsView.swift
@@ -9,6 +9,11 @@ struct TrailConditionsListView: View {
     @Environment(AuthManager.self) private var authManager
     @State private var showingSubmitSheet = false
     #if os(iOS)
+    /// Drafts captured on the paired watch, waiting for a trail name (#2721).
+    @State private var draftStore = WatchTrailDraftStore.shared
+    @State private var draftBeingCompleted: WatchTrailDraft?
+    #endif
+    #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private var isCompact: Bool {
         horizontalSizeClass == .compact && UIDevice.current.userInterfaceIdiom == .phone
@@ -33,7 +38,7 @@ struct TrailConditionsListView: View {
                 ProgressView("Loading reports…").frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error = viewModel.error, viewModel.reports.isEmpty {
                 ErrorView(error, retry: { await viewModel.load() })
-            } else if viewModel.reports.isEmpty {
+            } else if viewModel.reports.isEmpty && !hasWatchDrafts {
                 EmptyStateView(
                     "No Trail Reports Yet",
                     subtitle: "Be the first to report conditions on a trail",
@@ -60,6 +65,17 @@ struct TrailConditionsListView: View {
         .sheet(isPresented: $showingSubmitSheet) {
             SubmitTrailConditionView(viewModel: viewModel)
         }
+        #if os(iOS)
+        // Opened by tapping a watch draft, never presented on arrival — a draft
+        // syncing in must not hijack whatever the phone is already showing.
+        .sheet(item: $draftBeingCompleted) { draft in
+            SubmitTrailConditionView(
+                viewModel: viewModel,
+                draft: draft,
+                onSubmitted: { draftStore.remove(draft.id) }
+            )
+        }
+        #endif
     }
 
     @ViewBuilder
@@ -85,14 +101,89 @@ struct TrailConditionsListView: View {
         }
     }
 
+    /// Whether the paired watch has captures waiting. Always false off iOS,
+    /// where there is no paired watch.
+    private var hasWatchDrafts: Bool {
+        #if os(iOS)
+        draftStore.hasDrafts
+        #else
+        false
+        #endif
+    }
+
     private var reportList: some View {
         List(selection: $selectedId) {
+            #if os(iOS)
+            watchDraftsSection
+            #endif
             ForEach(viewModel.filteredReports) { report in
                 reportRow(report)
             }
         }
     }
+
+    #if os(iOS)
+    /// Watch captures sit above the reports, and outside the search filter —
+    /// they carry no trail name to match on yet, so filtering them would make
+    /// them vanish the moment someone typed in the search field.
+    @ViewBuilder
+    private var watchDraftsSection: some View {
+        if draftStore.hasDrafts && viewModel.searchText.isEmpty {
+            Section("From Apple Watch") {
+                ForEach(draftStore.drafts) { draft in
+                    Button {
+                        draftBeingCompleted = draft
+                    } label: {
+                        WatchTrailDraftRow(draft: draft)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("watch_trail_draft_row_\(draft.id)")
+                    .accessibilityHint("Add a trail name to finish this report")
+                    .swipeActions(edge: .trailing) {
+                        Button("Discard", systemImage: "trash", role: .destructive) {
+                            draftStore.remove(draft.id)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    #endif
 }
+
+#if os(iOS)
+/// A watch capture awaiting a trail name, shown above the submitted reports.
+private struct WatchTrailDraftRow: View {
+    let draft: WatchTrailDraft
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "applewatch")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(TrailConditionLevel(rawValue: draft.condition)?.label ?? draft.condition.capitalized)
+                    .font(.body.weight(.medium))
+                if !draft.note.isEmpty {
+                    Text(draft.note)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Text("Needs a trail name")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+            Spacer(minLength: 0)
+            Text(draft.createdAt, format: .relative(presentation: .numeric))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .contentShape(Rectangle())
+    }
+}
+#endif
 
 private struct TrailReportRow: View {
     let report: TrailConditionReport
@@ -240,17 +331,49 @@ struct TrailConditionDetailView: View {
 
 struct SubmitTrailConditionView: View {
     let viewModel: TrailConditionsViewModel
+    /// Called after a successful submit. Used to clear the originating watch
+    /// draft only once the report actually exists (#2721).
+    private let onSubmitted: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
 
     @State private var trailName = ""
     @State private var trailRegion = ""
     @State private var surface = TrailSurface.dirt.rawValue
-    @State private var condition = "good"
+    @State private var condition: String
     @State private var selectedHazards: Set<String> = []
-    @State private var notes = ""
+    @State private var notes: String
     @State private var isSubmitting = false
     @State private var error: String?
     @FocusState private var isInputFocused: Bool
+    /// True when the form opened from a watch capture, so the trail field can
+    /// take focus immediately — it is the one thing the draft cannot carry.
+    private let isCompletingWatchDraft: Bool
+
+    init(viewModel: TrailConditionsViewModel) {
+        self.viewModel = viewModel
+        self.onSubmitted = nil
+        self.isCompletingWatchDraft = false
+        _condition = State(initialValue: "good")
+        _notes = State(initialValue: "")
+    }
+
+    #if os(iOS)
+    /// Opens the form pre-filled from a watch capture. The watch supplies the
+    /// condition and the note; the trail name is what the user still has to add.
+    init(
+        viewModel: TrailConditionsViewModel,
+        draft: WatchTrailDraft,
+        onSubmitted: @escaping () -> Void
+    ) {
+        self.viewModel = viewModel
+        self.onSubmitted = onSubmitted
+        self.isCompletingWatchDraft = true
+        _condition = State(
+            initialValue: TrailConditionLevel(rawValue: draft.condition)?.rawValue ?? "good"
+        )
+        _notes = State(initialValue: draft.note)
+    }
+    #endif
 
     private let hazardOptions = ["Downed trees", "Muddy sections", "Ice", "High water", "Rock slides", "Wildlife", "Washed out trail"]
     private var isValid: Bool { !trailName.trimmingCharacters(in: .whitespaces).isEmpty }
@@ -258,7 +381,7 @@ struct SubmitTrailConditionView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Trail") {
+                Section {
                     TextField("Trail", text: $trailName)
                         .focused($isInputFocused)
                         .submitLabel(.done)
@@ -269,6 +392,12 @@ struct SubmitTrailConditionView: View {
                         .submitLabel(.done)
                         .onSubmit { isInputFocused = false }
                         .accessibilityIdentifier("trail_report_region")
+                } header: {
+                    Text("Trail")
+                } footer: {
+                    if isCompletingWatchDraft {
+                        Text("Condition and notes came from your Apple Watch. Add the trail name to submit.")
+                    }
                 }
                 Section("Conditions") {
                     Picker("Overall", selection: $condition) {
@@ -303,10 +432,13 @@ struct SubmitTrailConditionView: View {
             .packRatFormStyle()
             .dismissesKeyboardOnScroll()
             .keyboardDoneButton(isFocused: $isInputFocused)
-            .navigationTitle("Submit Report")
+            .navigationTitle(isCompletingWatchDraft ? "Finish Watch Report" : "Submit Report")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
+            // The trail name is the only field a watch capture cannot fill, so
+            // put the cursor there rather than making the user hunt for it.
+            .task { if isCompletingWatchDraft { isInputFocused = true } }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
@@ -334,6 +466,9 @@ struct SubmitTrailConditionView: View {
                     hazards: Array(selectedHazards),
                     notes: notes.isEmpty ? nil : notes
                 )
+                // Only now — a draft cleared on a failed submit would lose the
+                // capture with nothing to show for it.
+                onSubmitted?()
                 dismiss()
             } catch { self.error = error.localizedDescription }
         }

--- a/apps/swift/Sources/PackRat/Features/TrailConditions/TrailConditionsView.swift
+++ b/apps/swift/Sources/PackRat/Features/TrailConditions/TrailConditionsView.swift
@@ -345,6 +345,10 @@ struct SubmitTrailConditionView: View {
     @State private var isSubmitting = false
     @State private var error: String?
     @FocusState private var isInputFocused: Bool
+    /// Separate from `isInputFocused`, which every field in the form shares —
+    /// setting that one focuses whichever field registered last (the notes box),
+    /// scrolling the trail name off-screen instead of onto it.
+    @FocusState private var isTrailNameFocused: Bool
     /// True when the form opened from a watch capture, so the trail field can
     /// take focus immediately — it is the one thing the draft cannot carry.
     private let isCompletingWatchDraft: Bool
@@ -383,9 +387,9 @@ struct SubmitTrailConditionView: View {
             Form {
                 Section {
                     TextField("Trail", text: $trailName)
-                        .focused($isInputFocused)
+                        .focused($isTrailNameFocused)
                         .submitLabel(.done)
-                        .onSubmit { isInputFocused = false }
+                        .onSubmit { isTrailNameFocused = false }
                         .accessibilityIdentifier("trail_report_name")
                     TextField("Region", text: $trailRegion)
                         .focused($isInputFocused)
@@ -431,14 +435,19 @@ struct SubmitTrailConditionView: View {
             }
             .packRatFormStyle()
             .dismissesKeyboardOnScroll()
-            .keyboardDoneButton(isFocused: $isInputFocused)
+            // One keyboard toolbar only — a second `keyboardDoneButton` renders a
+            // duplicate "Done". Clears whichever of the two focus flags is set.
+            .keyboardDoneButton {
+                isInputFocused = false
+                isTrailNameFocused = false
+            }
             .navigationTitle(isCompletingWatchDraft ? "Finish Watch Report" : "Submit Report")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
             // The trail name is the only field a watch capture cannot fill, so
             // put the cursor there rather than making the user hunt for it.
-            .task { if isCompletingWatchDraft { isInputFocused = true } }
+            .task { if isCompletingWatchDraft { isTrailNameFocused = true } }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {

--- a/apps/swift/Sources/PackRat/Shared/KeyboardDismiss.swift
+++ b/apps/swift/Sources/PackRat/Shared/KeyboardDismiss.swift
@@ -30,6 +30,27 @@ extension View {
         #endif
     }
 
+    /// Adds a keyboard accessory toolbar whose "Done" button runs `onDone`.
+    ///
+    /// For forms with more than one `@FocusState` flag, where a single binding
+    /// cannot clear them all. Attach this once — two keyboard toolbars on the
+    /// same view render two "Done" buttons.
+    @ViewBuilder
+    func keyboardDoneButton(onDone: @escaping () -> Void) -> some View {
+        #if os(macOS)
+        self
+        #else
+        self.toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done", action: onDone)
+                    .fontWeight(.semibold)
+                    .accessibilityIdentifier("keyboard_done")
+            }
+        }
+        #endif
+    }
+
     /// Dismisses the keyboard when a scrollable container is dragged.
     /// No-op on macOS, where there is no software keyboard to dismiss.
     @ViewBuilder

--- a/apps/swift/Sources/PackRat/Watch/WatchCompanionService.swift
+++ b/apps/swift/Sources/PackRat/Watch/WatchCompanionService.swift
@@ -12,6 +12,7 @@ final class WatchCompanionService: NSObject {
     private var lastSnapshot: PackRatWatchSnapshot?
 
     private let packingModeStore: PackingModeStore
+    private let trailDraftStore: WatchTrailDraftStore
     private let defaults: UserDefaults
 
     /// Retained so a toggle arriving from the watch can push a corrected
@@ -25,9 +26,11 @@ final class WatchCompanionService: NSObject {
 
     init(
         packingModeStore: PackingModeStore = .shared,
+        trailDraftStore: WatchTrailDraftStore = .shared,
         defaults: UserDefaults = .standard
     ) {
         self.packingModeStore = packingModeStore
+        self.trailDraftStore = trailDraftStore
         self.defaults = defaults
         super.init()
         encoder.dateEncodingStrategy = .iso8601
@@ -156,10 +159,17 @@ final class WatchCompanionService: NSObject {
         return String(format: "%.1f lb", pounds)
     }
 
-    private func handleTrailDraft(_ draft: WatchTrailReportDraft) {
-        UserDefaults.standard.set(draft.condition, forKey: "watch.latestTrailDraft.condition")
-        UserDefaults.standard.set(draft.note, forKey: "watch.latestTrailDraft.note")
-        UserDefaults.standard.set(draft.createdAt, forKey: "watch.latestTrailDraft.createdAt")
+    /// Files a trail-condition draft captured on the watch.
+    ///
+    /// Returns the draft so callers (and tests) can distinguish a stored draft
+    /// from an undecodable payload. It lands in `WatchTrailDraftStore`, which
+    /// the phone's Trail Conditions list reads — this used to write three
+    /// `watch.latestTrailDraft.*` UserDefaults keys that nothing on the phone
+    /// ever read, so a watch capture silently disappeared (#2721).
+    @discardableResult
+    func handleTrailDraft(_ draft: WatchTrailReportDraft) -> WatchTrailReportDraft {
+        trailDraftStore.add(draft)
+        return draft
     }
 
     /// Applies a packed/unpacked change made on the watch to the phone's store.

--- a/apps/swift/Sources/PackRat/Watch/WatchTrailDraftStore.swift
+++ b/apps/swift/Sources/PackRat/Watch/WatchTrailDraftStore.swift
@@ -33,6 +33,18 @@ final class WatchTrailDraftStore {
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         self.drafts = Self.load(from: defaults)
+        if VisualSampleData.isUITestFixturesEnabled, drafts.isEmpty {
+            // Lets the arrived-from-watch state be exercised without pairing a
+            // watch simulator, which is otherwise the only way to reach it.
+            drafts = [
+                WatchTrailDraft(
+                    id: "watch-fixture-1",
+                    condition: "fair",
+                    note: "Creek crossing above the saddle is knee-deep",
+                    createdAt: Date().addingTimeInterval(-20 * 60)
+                )
+            ]
+        }
     }
 
     var hasDrafts: Bool { !drafts.isEmpty }

--- a/apps/swift/Sources/PackRat/Watch/WatchTrailDraftStore.swift
+++ b/apps/swift/Sources/PackRat/Watch/WatchTrailDraftStore.swift
@@ -1,0 +1,117 @@
+#if os(iOS)
+import Foundation
+import Observation
+
+/// Trail-condition drafts captured on the Apple Watch, waiting to be finished
+/// on the phone.
+///
+/// The watch can only capture a condition and a note (`WatchTrailReportDraft`) —
+/// it has no trail-name field, and `POST /trail-conditions` requires one. So a
+/// watch capture is deliberately *not* submittable on arrival: it parks here
+/// until someone opens it on the phone, adds the trail, and submits.
+///
+/// This is the "capture on the wrist, triage on the phone" pattern watch
+/// companions converge on: the draft syncs silently and waits in a list rather
+/// than interrupting whatever the phone is doing with an unbidden modal
+/// (#2721 — previously the draft was written to three loose UserDefaults keys
+/// that nothing on the phone ever read, so it simply vanished).
+///
+/// Drafts are device-local, like `PackingModeStore`: they belong to the phone
+/// paired with the watch that captured them, not to the account.
+@Observable
+@MainActor
+final class WatchTrailDraftStore {
+    static let shared = WatchTrailDraftStore()
+
+    private static let defaultsKey = "watch.trailDrafts"
+
+    /// Newest first, so the list surfaces the most recent capture at the top.
+    private(set) var drafts: [WatchTrailDraft] = []
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.drafts = Self.load(from: defaults)
+    }
+
+    var hasDrafts: Bool { !drafts.isEmpty }
+
+    // MARK: - Writes
+
+    /// Records a draft that arrived from the watch.
+    ///
+    /// Idempotent by `createdAt`: WatchConnectivity delivers each draft over
+    /// both `sendMessage` and `transferUserInfo` so it survives the phone being
+    /// unreachable, which means the same capture routinely arrives twice.
+    func add(_ draft: WatchTrailReportDraft) {
+        let incoming = WatchTrailDraft(
+            id: Self.identifier(for: draft),
+            condition: draft.condition,
+            note: draft.note,
+            createdAt: draft.createdAt
+        )
+        guard !drafts.contains(where: { $0.id == incoming.id }) else { return }
+        drafts.insert(incoming, at: 0)
+        drafts.sort { $0.createdAt > $1.createdAt }
+        persist()
+    }
+
+    /// Drops a draft once it has been submitted as a real report, or dismissed.
+    func remove(_ id: String) {
+        guard drafts.contains(where: { $0.id == id }) else { return }
+        drafts.removeAll { $0.id == id }
+        persist()
+    }
+
+    func removeAll() {
+        guard !drafts.isEmpty else { return }
+        drafts.removeAll()
+        persist()
+    }
+
+    // MARK: - Persistence
+
+    /// Keyed on the capture instant rather than a fresh UUID so the duplicate
+    /// delivery described in `add` collapses onto one row.
+    private static func identifier(for draft: WatchTrailReportDraft) -> String {
+        "watch-\(Int(draft.createdAt.timeIntervalSince1970.rounded()))"
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder.watchDraft.encode(drafts) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+
+    private static func load(from defaults: UserDefaults) -> [WatchTrailDraft] {
+        guard let data = defaults.data(forKey: Self.defaultsKey),
+              let stored = try? JSONDecoder.watchDraft.decode([WatchTrailDraft].self, from: data)
+        else { return [] }
+        return stored.sorted { $0.createdAt > $1.createdAt }
+    }
+}
+
+/// A watch capture as the phone stores it: the watch's payload plus a stable id.
+struct WatchTrailDraft: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let condition: String
+    let note: String
+    let createdAt: Date
+}
+
+private extension JSONEncoder {
+    static let watchDraft: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+}
+
+private extension JSONDecoder {
+    static let watchDraft: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
+#endif

--- a/apps/swift/Tests/PackRatTests/WatchTrailDraftStoreTests.swift
+++ b/apps/swift/Tests/PackRatTests/WatchTrailDraftStoreTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import PackRat
+
+/// Covers #2721: a trail-conditions draft captured on the watch used to be
+/// written to three `watch.latestTrailDraft.*` UserDefaults keys that no phone
+/// screen read, so it never appeared on the iPhone. Drafts now land in
+/// `WatchTrailDraftStore`, which the Trail Conditions list renders.
+@Suite("Watch trail draft store")
+struct WatchTrailDraftStoreTests {
+    @MainActor
+    private func makeStore() -> WatchTrailDraftStore {
+        let defaults = UserDefaults(suiteName: "watch.trailDraft.tests.\(UUID().uuidString)")!
+        return WatchTrailDraftStore(defaults: defaults)
+    }
+
+    private func draft(
+        condition: String = "fair",
+        note: String = "Creek crossing is high",
+        secondsAgo: TimeInterval = 0
+    ) -> WatchTrailReportDraft {
+        WatchTrailReportDraft(
+            condition: condition,
+            note: note,
+            createdAt: Date(timeIntervalSince1970: 1_756_000_000 - secondsAgo)
+        )
+    }
+
+    // MARK: - Arrival
+
+    @Test("a draft from the watch becomes visible to the phone")
+    @MainActor
+    func draftArrives() {
+        let store = makeStore()
+        #expect(store.hasDrafts == false)
+
+        store.add(draft())
+
+        #expect(store.drafts.count == 1)
+        #expect(store.hasDrafts)
+        #expect(store.drafts[0].condition == "fair")
+        #expect(store.drafts[0].note == "Creek crossing is high")
+    }
+
+    @Test("the same draft delivered twice collapses to one row")
+    @MainActor
+    func duplicateDeliveryIsIdempotent() {
+        let store = makeStore()
+        let captured = draft()
+
+        // WatchConnectivity sends each draft over both sendMessage and
+        // transferUserInfo, so double arrival is the normal case, not an edge.
+        store.add(captured)
+        store.add(captured)
+
+        #expect(store.drafts.count == 1)
+    }
+
+    @Test("distinct captures are kept newest first")
+    @MainActor
+    func draftsAreOrderedNewestFirst() {
+        let store = makeStore()
+
+        store.add(draft(condition: "poor", note: "Older", secondsAgo: 600))
+        store.add(draft(condition: "good", note: "Newer", secondsAgo: 0))
+
+        #expect(store.drafts.map(\.note) == ["Newer", "Older"])
+    }
+
+    // MARK: - Clearing
+
+    @Test("submitting a draft removes it")
+    @MainActor
+    func removeDropsOneDraft() {
+        let store = makeStore()
+        store.add(draft(note: "Keep", secondsAgo: 600))
+        store.add(draft(note: "Drop", secondsAgo: 0))
+        let dropId = store.drafts[0].id
+
+        store.remove(dropId)
+
+        #expect(store.drafts.map(\.note) == ["Keep"])
+    }
+
+    @Test("removing an unknown id leaves the list untouched")
+    @MainActor
+    func removeUnknownIdIsANoop() {
+        let store = makeStore()
+        store.add(draft())
+
+        store.remove("watch-does-not-exist")
+
+        #expect(store.drafts.count == 1)
+    }
+
+    // MARK: - Persistence
+
+    @Test("drafts survive the app being relaunched")
+    @MainActor
+    func draftsPersistAcrossLaunches() {
+        let suite = "watch.trailDraft.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+
+        let first = WatchTrailDraftStore(defaults: defaults)
+        first.add(draft(condition: "poor", note: "Ice above the saddle"))
+
+        // A capture must outlive the launch it arrived in — the phone may not be
+        // opened until well after the watch sent it.
+        let reloaded = WatchTrailDraftStore(defaults: defaults)
+
+        #expect(reloaded.drafts.count == 1)
+        #expect(reloaded.drafts[0].condition == "poor")
+        #expect(reloaded.drafts[0].note == "Ice above the saddle")
+    }
+
+    @Test("clearing removes drafts from storage too")
+    @MainActor
+    func removeAllPersists() {
+        let suite = "watch.trailDraft.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+
+        let first = WatchTrailDraftStore(defaults: defaults)
+        first.add(draft())
+        first.removeAll()
+
+        #expect(WatchTrailDraftStore(defaults: defaults).drafts.isEmpty)
+    }
+
+    // MARK: - Companion service wiring
+
+    @Test("the companion service files an incoming draft into the store")
+    @MainActor
+    func companionServiceStoresIncomingDraft() {
+        let defaults = UserDefaults(suiteName: "watch.trailDraft.tests.\(UUID().uuidString)")!
+        let store = WatchTrailDraftStore(defaults: defaults)
+        let service = WatchCompanionService(
+            packingModeStore: PackingModeStore(defaults: defaults),
+            trailDraftStore: store,
+            defaults: defaults
+        )
+
+        service.handleTrailDraft(draft(condition: "excellent", note: "Dry and clear"))
+
+        #expect(store.drafts.count == 1)
+        #expect(store.drafts[0].condition == "excellent")
+        #expect(store.drafts[0].note == "Dry and clear")
+    }
+}


### PR DESCRIPTION
Closes #2721.

## The bug

A Trail Conditions draft saved on the Apple Watch never appeared on the iPhone. The phone received it, then wrote it to three `watch.latestTrailDraft.*` `UserDefaults` keys that nothing on the phone ever read — `grep` for the key returns only the three writes. The capture was discarded on arrival.

## Why it can't just be submitted

The watch payload carries `condition`, `note`, `createdAt` — there is no trail-name field on the wrist, and `POST /trail-conditions` requires one. So an arriving draft is not a submittable report; it needs the phone to finish it.

## The fix

Drafts land in a new `WatchTrailDraftStore` and appear in a **From Apple Watch** section above the reports in Trail Conditions. Tapping one opens the submit form pre-filled with the condition and note, cursor in the trail name, and the draft clears only once the report actually submits — a failed submit keeps it.

This follows the capture-on-the-wrist, finish-on-the-phone pattern: the draft syncs silently and waits to be triaged rather than auto-presenting a modal over whatever the phone was already showing.

Details worth noting:
- Idempotent on `createdAt` — WatchConnectivity delivers over both `sendMessage` and `transferUserInfo`, so double arrival is the normal case.
- Drafts persist across launches; the phone may not be opened until well after the watch sent one.
- Excluded from the search filter — a draft has no trail name to match, so filtering would make it vanish mid-search.
- Device-local, like `PackingModeStore`.
- The second commit fixes auto-focus landing on the notes box (all fields shared one `@FocusState`) and a duplicate keyboard "Done".

## Verification

Verified end to end on iPhone 15 Pro (own pinned simulator): draft renders under "From Apple Watch" → opens pre-filled with cursor in Trail → typing a name enables Submit → submits as a real report ("Cascade Pass", Fair) → drafts section disappears.

- 8 new tests in `WatchTrailDraftStoreTests` (arrival, duplicate delivery, ordering, removal, persistence, companion-service wiring)
- Full `PackRatTests` suite green: 313 tests / 72 suites
- macOS target compiles clean (`#if os(iOS)` gating holds)

## Note on scope

#2694 and #2718 were already fixed and merged into `development` separately, so this PR covers only #2721.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trail-condition reports captured on Apple Watch now appear in a dedicated section on iPhone.
  * Open a watch capture to review and submit it with details pre-filled.
  * Watch captures are saved for later and displayed with the newest entries first.
  * Duplicate watch deliveries no longer create duplicate entries.
  * Drafts can be removed after submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->