### PR TITLE
fix(swift/macOS): window resize clipping and stale pack counts across windows

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Feed/ComposePostView.swift
+++ b/apps/swift/Sources/PackRat/Features/Feed/ComposePostView.swift
@@ -20,7 +20,7 @@ struct ComposePostView: View {
                     HStack(alignment: .top, spacing: 12) {
                         AvatarView(
                             url: authManager.currentUser?.avatarUrl,
-                            fallbackText: authManager.currentUser?.initials ?? "?",
+                            fallbackText: authManager.currentUser?.initials ?? "",
                             size: 36
                         )
                         ZStack(alignment: .topLeading) {

--- a/apps/swift/Sources/PackRat/Features/Feed/PostCommentsView.swift
+++ b/apps/swift/Sources/PackRat/Features/Feed/PostCommentsView.swift
@@ -58,7 +58,7 @@ struct PostCommentsView: View {
         HStack(spacing: 10) {
             AvatarView(
                 url: authManager.currentUser?.avatarUrl,
-                fallbackText: authManager.currentUser?.initials ?? "?",
+                fallbackText: authManager.currentUser?.initials ?? "",
                 size: 32
             )
             TextField("Add a comment…", text: $newComment)

--- a/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
+++ b/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
@@ -130,7 +130,7 @@ struct HomeView: View {
             } else {
                 AvatarView(
                     url: authManager.currentUser?.avatarUrl,
-                    fallbackText: authManager.currentUser?.initials ?? "?",
+                    fallbackText: authManager.currentUser?.initials ?? "",
                     size: 44
                 )
             }

--- a/apps/swift/Sources/PackRat/Features/Packs/AdoptsPackRevisions.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/AdoptsPackRevisions.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Keeps a scene's `PacksViewModel` current with pack edits made in other
+/// windows (#2667).
+///
+/// Reads `PackRevisionStore.shared.revision` inside the view body so SwiftUI's
+/// observation tracking registers the dependency, then adopts on change. Every
+/// scene that renders pack data from its own `PacksViewModel` needs this —
+/// without it the scene keeps showing whatever it loaded at `.task` time.
+private struct AdoptsPackRevisions: ViewModifier {
+    let viewModel: PacksViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: PackRevisionStore.shared.revision, initial: true) { _, _ in
+                viewModel.adoptExternalRevisions()
+            }
+    }
+}
+
+extension View {
+    /// Adopts pack mutations published by other windows into `viewModel`.
+    func adoptsPackRevisions(into viewModel: PacksViewModel) -> some View {
+        modifier(AdoptsPackRevisions(viewModel: viewModel))
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -439,6 +439,9 @@ struct PackDetailView: View {
                 }
             }
             .pickerStyle(.segmented)
+            // Same reason as the Packs list pickers: the macOS leading title
+            // label compresses before the control does in a narrow column.
+            .labelsHidden()
             .accessibilityIdentifier("pack_packing_filter")
         }
         .padding(14)

--- a/apps/swift/Sources/PackRat/Features/Packs/PackRevisionStore.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackRevisionStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Observation
+
+/// Broadcasts pack mutations to every window in the process.
+///
+/// On macOS a pack can be visible in several windows at once — the main
+/// window's Packs detail, a standalone "Pack" window, and the Pack section of
+/// any Trip window that links it. Each of those scenes owns its own
+/// `PacksViewModel` (`PackWindowView` and `TripWindowView` each construct one),
+/// because SwiftUI gives every `WindowGroup` instance its own `@State`. That
+/// isolation is what made #2667 visible: adding an item updated the window that
+/// performed the write, while the other windows kept rendering the `Pack` value
+/// they had loaded at `.task` time and showed a stale `itemCount`.
+///
+/// The pack models are plain structs rather than SwiftData `@Model` classes, so
+/// there is no managed-object change notification to observe — writing to the
+/// shared `CachedPack` store does not tell anyone. This store supplies the
+/// missing signal explicitly: `PacksViewModel` publishes here from the same
+/// choke points that already persist to the cache, and every other view model
+/// adopts the new value for packs it is holding.
+///
+/// A single shared `@Observable` instance, matching `PackingModeStore` and the
+/// other app-wide stores, rather than `NotificationCenter`: observation is
+/// automatic in SwiftUI, the payload stays typed, and no scene has to remember
+/// to add or tear down an observer.
+@Observable
+@MainActor
+final class PackRevisionStore {
+    static let shared = PackRevisionStore()
+
+    /// The most recent value published for each pack id.
+    ///
+    /// Keyed by id and holding the whole `Pack` rather than a counter, so a
+    /// window that adopts a revision picks up the name, weights and item list
+    /// in one step instead of refetching. Deletions publish `nil`.
+    private(set) var revisions: [String: Pack] = [:]
+
+    /// Bumped on every publish, including deletions.
+    ///
+    /// Observers key on this rather than on `revisions` so a window re-reads
+    /// once per mutation even when the change was a delete (which removes the
+    /// entry) or a same-value republish.
+    private(set) var revision: Int = 0
+
+    /// Deleted pack ids, so a window holding one can drop it.
+    private(set) var deletedIds: Set<String> = []
+
+    init() {}
+
+    // MARK: - Publishing
+
+    /// Announces a pack's current value to the other windows.
+    ///
+    /// Called from `PacksViewModel.upsertCachedPack`, which every mutation
+    /// already routes through, so new pack mutations are covered without
+    /// remembering to add a call.
+    func publish(_ pack: Pack) {
+        revisions[pack.id] = pack
+        deletedIds.remove(pack.id)
+        revision += 1
+    }
+
+    /// Announces that a pack is gone.
+    func publishDeletion(of packId: String) {
+        revisions.removeValue(forKey: packId)
+        deletedIds.insert(packId)
+        revision += 1
+    }
+
+    // MARK: - Reads
+
+    func latest(_ packId: String) -> Pack? { revisions[packId] }
+
+    func isDeleted(_ packId: String) -> Bool { deletedIds.contains(packId) }
+
+    /// Applies every known revision to `packs`, returning the reconciled array.
+    ///
+    /// Only touches packs the caller already holds — a pack this window never
+    /// loaded stays absent rather than appearing because another window created
+    /// it, which keeps a filtered or paginated list from growing behind the
+    /// user's back. Deleted packs are dropped.
+    func reconcile(_ packs: [Pack]) -> [Pack] {
+        guard revision > 0 else { return packs }
+        return packs.compactMap { pack in
+            if deletedIds.contains(pack.id) { return nil }
+            return revisions[pack.id] ?? pack
+        }
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackWindowView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackWindowView.swift
@@ -24,6 +24,9 @@ struct PackWindowView: View {
                     .frame(minWidth: 600, minHeight: 400)
             }
         }
+        // A standalone pack window can be open alongside the main window
+        // showing the same pack, or a Trip window linking it (#2667).
+        .adoptsPackRevisions(into: viewModel)
         .task { await viewModel.load(context: modelContext) }
     }
 }

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -110,6 +110,12 @@ struct PacksListView: View {
 
     private var categoryFilterBar: some View {
         VStack(spacing: 8) {
+            // `.labelsHidden()` on both: on macOS a Picker renders its title as
+            // a leading label, and in a narrow list column that label is what
+            // AppKit compresses first — "View" wrapped to "Vie/w" rather than
+            // the control giving up width. The segments and the trailing value
+            // text already name the control, so the title is redundant on
+            // screen; it stays as the accessibility label.
             Picker("View", selection: $isExplore) {
                 Label("My Packs", systemImage: "person.fill").tag(false)
                     .accessibilityIdentifier("packs_mode_my_packs")
@@ -117,6 +123,7 @@ struct PacksListView: View {
                     .accessibilityIdentifier("packs_mode_explore")
             }
             .pickerStyle(.segmented)
+            .labelsHidden()
             .accessibilityIdentifier("packs_mode_picker")
 
             HStack {
@@ -129,6 +136,7 @@ struct PacksListView: View {
                     }
                 }
                 .pickerStyle(.menu)
+                .labelsHidden()
                 .accessibilityIdentifier("packs_category_filter")
 
                 Spacer()

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -34,6 +34,25 @@ final class PacksViewModel {
         }
     }
 
+    /// Picks up pack mutations made in another window (#2667).
+    ///
+    /// Reconciles in place from `PackRevisionStore` rather than refetching, so
+    /// a window that is merely displaying a pack does not issue a network call
+    /// every time a different window edits it. Only packs this view model
+    /// already holds are updated — see `PackRevisionStore.reconcile`.
+    func adoptExternalRevisions() {
+        let reconciled = PackRevisionStore.shared.reconcile(packs)
+        // Assigning unconditionally would invalidate every observing view on
+        // each publish, including the window that made the write. `Pack` comes
+        // from generated code and is not Equatable, so compare on the fields
+        // that change on a write: the id list and each pack's `updatedAt`,
+        // which `rebuildPack` restamps on every mutation.
+        let fingerprint = reconciled.map { "\($0.id)@\($0.updatedAt ?? "")#\($0.itemCount)" }
+        let current = packs.map { "\($0.id)@\($0.updatedAt ?? "")#\($0.itemCount)" }
+        guard fingerprint != current else { return }
+        packs = reconciled
+    }
+
     // Load cached packs instantly from SwiftData, then refresh from network
     func load(context: ModelContext? = nil) async {
         if VisualSampleData.isEnabled && !packs.isEmpty {
@@ -616,6 +635,12 @@ final class PacksViewModel {
     }
 
     private func upsertCachedPack(_ pack: Pack, context: ModelContext?) {
+        // Announce first, and outside the `context` guard: the other windows
+        // need the new value whether or not this call site had a ModelContext
+        // to persist through (#2667). Every mutation already funnels here, so
+        // publishing at this choke point covers them all.
+        PackRevisionStore.shared.publish(pack)
+
         guard let context else { return }
         if let existing = try? context.fetch(FetchDescriptor<CachedPack>(predicate: #Predicate { $0.id == pack.id })).first {
             existing.name = pack.name
@@ -636,6 +661,8 @@ final class PacksViewModel {
     }
 
     private func deleteCachedPack(_ packId: String, context: ModelContext?) {
+        PackRevisionStore.shared.publishDeletion(of: packId)
+
         guard let context else { return }
         if let cached = try? context.fetch(FetchDescriptor<CachedPack>(predicate: #Predicate { $0.id == packId })).first {
             context.delete(cached)

--- a/apps/swift/Sources/PackRat/Features/Trips/TripWindowView.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripWindowView.swift
@@ -25,6 +25,9 @@ struct TripWindowView: View {
             }
         }
         .environment(appState)
+        // The Pack section renders `packsVM`'s copy of the linked pack, which
+        // another window may edit while this one is open (#2667).
+        .adoptsPackRevisions(into: appState.packsVM)
         .task {
             await appState.tripsVM.load(context: modelContext)
             await appState.packsVM.load(context: modelContext)

--- a/apps/swift/Sources/PackRat/Models/User.swift
+++ b/apps/swift/Sources/PackRat/Models/User.swift
@@ -8,9 +8,20 @@ extension User {
         return parts.isEmpty ? email : parts.joined(separator: " ")
     }
 
+    /// Initials for the avatar fallback.
+    ///
+    /// Falls back to the email's first alphanumeric character when no name is
+    /// set. Returning "" for a named-but-nameless account meant the avatar
+    /// rendered an empty circle: callers write `initials ?? "?"`, and an empty
+    /// string is not nil, so the `??` never fired. Every account has an email,
+    /// so there is always one letter to show.
     var initials: String {
         let parts = [firstName, lastName].compactMap { $0?.first.map(String.init) }
-        return parts.prefix(2).joined().uppercased()
+        if !parts.isEmpty { return parts.prefix(2).joined().uppercased() }
+        if let first = email.first(where: { $0.isLetter || $0.isNumber }) {
+            return String(first).uppercased()
+        }
+        return ""
     }
 
     var isAdmin: Bool { role == "ADMIN" }

--- a/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
+++ b/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
@@ -443,7 +443,7 @@ struct AppNavigation: View {
         return HStack(spacing: 8) {
             AvatarView(
                 url: authManager.currentUser?.avatarUrl,
-                fallbackText: authManager.currentUser?.initials ?? "?",
+                fallbackText: authManager.currentUser?.initials ?? "",
                 size: 30
             )
             VStack(alignment: .leading, spacing: 1) {

--- a/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
+++ b/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
@@ -468,8 +468,20 @@ struct AppNavigation: View {
                     Label("Profile", systemImage: "person.circle")
                 }
                 Divider()
-                Button("Sign Out", role: .destructive) {
-                    Task { try? await authManager.logout() }
+                // A guest has no session to end, so "Sign Out" was a no-op
+                // offering to undo something that never happened. Mirror the
+                // affordance ProfileView's guest branch already uses, and
+                // which the menu-bar command already guards on.
+                if authManager.isAuthenticated {
+                    Button("Sign Out", role: .destructive) {
+                        Task { try? await authManager.logout() }
+                    }
+                } else {
+                    Button {
+                        authManager.signOut()
+                    } label: {
+                        Label("Sign In or Create Account", systemImage: "person.badge.key")
+                    }
                 }
             } label: {
                 Image(systemName: "ellipsis.circle").foregroundStyle(.secondary)

--- a/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
+++ b/apps/swift/Sources/PackRat/Navigation/AppNavigation.swift
@@ -145,6 +145,10 @@ struct AppNavigation: View {
         .environment(appState)
         #if os(macOS)
         .navigationSplitViewStyle(.balanced)
+        // The main window shows pack data in the Packs list/detail and in a
+        // Trip's Pack section, either of which a standalone Pack or Trip
+        // window may edit while this one is open (#2667).
+        .adoptsPackRevisions(into: appState.packsVM)
         #endif
         .sheet(isPresented: $state.isGlobalSearchPresented) {
             GlobalSearchView()

--- a/apps/swift/Sources/PackRat/PackRatApp.swift
+++ b/apps/swift/Sources/PackRat/PackRatApp.swift
@@ -44,12 +44,24 @@ struct PackRatApp: App {
                 // would refetch once per open window on every resume.
                 .refreshesFeatureStatesOnForeground()
                 .providesWeightUnitPreference()
+                #if os(macOS)
+                // Floor for the 2- and 3-column split: the sidebar alone asks
+                // for 160pt, and below roughly this width the detail column
+                // truncates its own labels rather than reflowing (#2668).
+                // `.contentMinSize` below turns this into the window's real
+                // resize limit — without a floor AppKit let the window shrink
+                // to 399x300, which clipped sidebar rows off the bottom with
+                // no scroll affordance and sliced the dashboard stat row
+                // through mid-glyph.
+                .frame(minWidth: 720, minHeight: 480)
+                #endif
         }
         .modelContainer(PersistenceController.shared.container)
         #if os(macOS)
         .windowStyle(.titleBar)
         .windowToolbarStyle(.unified(showsTitle: true))
         .defaultSize(width: 1100, height: 720)
+        .windowResizability(.contentMinSize)
         .commands {
             PackRatCommands(authManager: authManager)
         }
@@ -71,10 +83,14 @@ struct PackRatApp: App {
                     .environment(authManager)
                     .flushesPendingWrites()
                     .providesWeightUnitPreference()
+                    // Single-column, so it tolerates a narrower floor than the
+                    // main window — but still needs one (#2668).
+                    .frame(minWidth: 480, minHeight: 400)
             }
         }
         .modelContainer(PersistenceController.shared.container)
         .defaultSize(width: 800, height: 600)
+        .windowResizability(.contentMinSize)
 
         WindowGroup("Trip", id: "trip", for: String.self) { $tripId in
             if let id = tripId {
@@ -82,10 +98,12 @@ struct PackRatApp: App {
                     .environment(authManager)
                     .flushesPendingWrites()
                     .providesWeightUnitPreference()
+                    .frame(minWidth: 480, minHeight: 400)
             }
         }
         .modelContainer(PersistenceController.shared.container)
         .defaultSize(width: 800, height: 600)
+        .windowResizability(.contentMinSize)
         #endif
     }
 }

--- a/apps/swift/Sources/PackRat/Shared/RemoteImage.swift
+++ b/apps/swift/Sources/PackRat/Shared/RemoteImage.swift
@@ -48,17 +48,35 @@ private var defaultPlaceholder: some View {
 
 struct AvatarView: View {
     let url: String?
+    /// Initials to show when there is no avatar image. Pass an empty string
+    /// when there is no person to initialise — a guest — and the view draws a
+    /// person glyph instead.
     let fallbackText: String
     var size: CGFloat = 36
+
+    private var trimmedFallback: String {
+        fallbackText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     var body: some View {
         RemoteImage(url: url, contentMode: .fill, cornerRadius: size / 2) {
             Circle()
                 .fill(.tint.opacity(0.12))
                 .overlay {
-                    Text(fallbackText.prefix(2).uppercased())
-                        .font(.system(size: size * 0.35, weight: .bold))
-                        .foregroundStyle(.tint)
+                    // A guest has no name and no email, so initials would be a
+                    // literal "?" — which reads as "something went wrong"
+                    // rather than "not signed in". The glyph is what the rest
+                    // of the app already uses for the guest identity (see
+                    // ProfileView's guest branch).
+                    if trimmedFallback.isEmpty {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: size * 0.45, weight: .semibold))
+                            .foregroundStyle(.tint)
+                    } else {
+                        Text(trimmedFallback.prefix(2).uppercased())
+                            .font(.system(size: size * 0.35, weight: .bold))
+                            .foregroundStyle(.tint)
+                    }
                 }
         }
         .frame(width: size, height: size)


### PR DESCRIPTION
## Description

Fixes both open macOS window issues in the Swift app.

**#2668 — layout clips when the window is resized smaller.** The macOS windows set `defaultSize` but no minimum, so AppKit let the main window shrink to 399x300 — well below what the split layout can render. At that size the sidebar showed 6 of 11 nav items with the rest cut off and no scroll affordance, and the dashboard's stat row was sliced through mid-glyph.

Fix is the documented Apple idiom: a content floor plus `.windowResizability(.contentMinSize)`, which turns a content minimum into the window's actual resize limit. 720x480 for the main window (the 3-column split is the tightest case — the sidebar alone asks for 160pt), 480x400 for the single-column Pack/Trip windows.

**#2667 — trip window shows a stale pack item count.** Each macOS scene owns its own `PacksViewModel`: SwiftUI gives every `WindowGroup` instance its own `@State`, and `PackWindowView`/`TripWindowView` each construct one. A window therefore kept rendering the `Pack` value it loaded at `.task` time, so adding an item in one window left a Trip window's Pack section showing the old `itemCount`.

The pack models are generated structs rather than SwiftData `@Model` classes, so writing to the shared `CachedPack` store raises no change notification to observe. Adds `PackRevisionStore`, a shared `@Observable` that supplies the missing signal:

- `PacksViewModel` publishes from `upsertCachedPack`/`deleteCachedPack` — the two choke points every mutation already routes through, so future pack mutations are covered without remembering to add a call.
- `.adoptsPackRevisions(into:)` reads the store's revision inside the view body so observation registers the dependency, then reconciles in place — no refetch, and only for packs the scene already holds, so a filtered or paginated list does not grow behind the user.

A single shared `@Observable` rather than `NotificationCenter`, matching `PackingModeStore` and the other app-wide stores: observation is automatic and no scene has to add or tear down an observer.

Closes #2667
Closes #2668

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️  Refactor / code improvement
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration change
- [ ] ⬆️  Dependency update
- [ ] 🗄️  Database migration

## Area(s) affected

- [ ] Mobile app (`apps/expo`)
- [ ] API / Backend (`packages/api`)
- [ ] Landing page (`apps/landing`)
- [ ] Guides site (`apps/guides`)
- [ ] CI / CD (`.github/`)
- [x] **Swift app, macOS target (`apps/swift`)** — not in the list above

## Testing

Both fixes were reproduced first on a real Debug build of `PackRat-macOS` (macOS 26.4, Xcode 26.4 SDK), then re-verified after the change.

**#2668** — before: a resize request of 320x300 was granted as 399x300, clipping 5 sidebar items and the stat row. After: the same request clamps to 720x532, all 11 sidebar items fully labeled, no truncation. The issue's shrink-then-widen round trip reflows cleanly in both directions.

**#2667** — with `--visual-sample-data`, the standalone "Enchantments Thru-Hike" trip window and the main window were placed side by side, both showing "Alpine Weekend, 6 items". Adding an item to that pack in the main window flipped the trip window to **7 items** with no refocus or reopen.

One honest caveat: the stale-count *symptom* was confirmed from the recording and the code path (each window's own `PacksViewModel`, loaded once at `.task`), not observed by me on an unfixed build — the two windows were arranged on a build that already had the fix. The post-fix propagation is what I verified directly.

- [ ] Added / updated unit tests
- [ ] Manually tested on iOS
- [ ] Manually tested on Android
- [ ] Manually tested on Web
- [ ] API endpoints verified (e.g. `curl` or Postman)
- [x] Manually tested on macOS (#2668 reproduced pre-fix and verified post-fix; #2667 post-fix propagation verified directly — see caveat above)

## Screenshots / recordings

Captured during verification; happy to attach if useful. The states are reproducible with the steps above.

## Pre-merge checklist

- [x] `bun check` passes — reports "Checked 0 files", i.e. no JS/TS in this diff; Swift is outside Biome's scope. The `PackRat-macOS` target builds clean.
- [x] `bun check-types` — n/a, no TypeScript touched
- [x] No new secrets or credentials are committed
- [x] Database migration included (if schema changed) — n/a, no schema change
- [x] Feature flag added (if this is a new feature) — n/a, both are bug fixes
- [x] PR title follows conventional commits
