### PR TITLE
fix(swift): clear the outbox when a signed-in user signs out

### DIFF
--- a/apps/swift/Sources/PackRat/Network/AuthManager.swift
+++ b/apps/swift/Sources/PackRat/Network/AuthManager.swift
@@ -305,10 +305,30 @@ final class AuthManager {
     /// subscribing, for instance — so the welcome screen does not re-ask.
     func signOutForSignIn() {
         wantsSignInDirectly = true
-        signOut()
+        // The point of this flow is to carry a guest's work into a new account,
+        // so anything queued offline has to outlive the transition. Stated
+        // explicitly rather than relying on the guest check inside `signOut`,
+        // since the intent is this flow's, not a side effect of who is calling.
+        signOut(discardsPendingWrites: false)
     }
 
-    func signOut() {
+    /// Clears the local session.
+    ///
+    /// `discardsPendingWrites` decides the fate of the outbox, which has no user
+    /// column and so cannot tell one account's queued writes from another's:
+    ///
+    /// - `true` (the default) for a deliberate sign-out by a signed-in user. Their
+    ///   unsent writes are theirs alone, and leaving them queued would replay them
+    ///   into the *next* account to sign in on this device.
+    /// - `false` when no signed-in user's writes are at stake, or when the person
+    ///   never chose to leave: a guest exiting guest mode still needs the packs
+    ///   they made offline so signing in can upload them, and an expired session
+    ///   is not consent to destroy work that never reached the server.
+    func signOut(discardsPendingWrites: Bool = true) {
+        // Read before the flags are cleared: a guest has no account to own the
+        // queue, so their writes always survive to be claimed on sign-in.
+        let discardsOutbox = discardsPendingWrites && !isGuest
+
         KeychainService.shared.clearTokens()
         UserDefaults.standard.removeObject(forKey: "current_user")
         UserDefaults.standard.removeObject(forKey: skippedLoginKey)
@@ -317,28 +337,54 @@ final class AuthManager {
         SentryConfig.clearUser()
         // `signOut` is reachable from non-main contexts (see `MainActor.run`
         // callers), while the SwiftData container is main-actor isolated.
-        Task { @MainActor in Self.purgeCachedUserContent() }
+        Task { @MainActor in Self.purgeCachedUserContent(discardsPendingWrites: discardsOutbox) }
     }
 
-    /// Drops the SwiftData mirror of the signed-out user's packs and trips.
+    /// Drops the SwiftData mirror of the signed-out user's packs and trips, and —
+    /// when the sign-out was theirs to make — the writes they never got to send.
     ///
     /// `CachedPack`/`CachedTrip` are keyed only by server id with no user column,
     /// and the view models seed themselves from that cache before the network
     /// responds. Left in place, the next user to sign in on this device sees the
     /// previous user's packs and trips flash up first.
+    ///
+    /// `PendingMutation` has the same missing-user-column problem with worse
+    /// consequences: `OutboxService.flush` replays the queue against whatever
+    /// session token is present, so one account's unsent writes would be uploaded
+    /// into the next account to sign in here. Callers that pass
+    /// `discardsPendingWrites: false` keep the queue precisely because the writes
+    /// still belong to someone — see `signOut(discardsPendingWrites:)`.
     @MainActor
-    private static func purgeCachedUserContent() {
+    private static func purgeCachedUserContent(discardsPendingWrites: Bool) {
         let context = PersistenceController.shared.container.mainContext
         do {
-            try context.delete(model: CachedPack.self)
-            try context.delete(model: CachedTrip.self)
-            try context.save()
+            try purgeCachedUserContent(in: context, discardsPendingWrites: discardsPendingWrites)
+            if discardsPendingWrites {
+                OutboxService.shared.refreshCounts(context)
+            }
         } catch {
             SentrySDK.capture(error: error) { scope in
                 scope.setTag(value: "auth", key: "feature")
                 scope.setTag(value: "purgeCachedUserContent", key: "action")
             }
         }
+    }
+
+    /// The deletion itself, against a caller-supplied context.
+    ///
+    /// Split from the singleton lookup above so the rules about what survives a
+    /// sign-out can be tested against an in-memory store.
+    @MainActor
+    static func purgeCachedUserContent(
+        in context: ModelContext,
+        discardsPendingWrites: Bool
+    ) throws {
+        try context.delete(model: CachedPack.self)
+        try context.delete(model: CachedTrip.self)
+        if discardsPendingWrites {
+            try context.delete(model: PendingMutation.self)
+        }
+        try context.save()
     }
 
     /// Android-style "Clear Data": wipes *everything* the app stores locally —
@@ -396,7 +442,10 @@ final class AuthManager {
                 try await refreshProfile()
             } catch PackRatError.unauthorized {
                 await MainActor.run {
-                    signOut()
+                    // The session expired rather than the user choosing to leave.
+                    // Their queued writes are still theirs and still unsent, so
+                    // they survive to replay once the account signs back in.
+                    signOut(discardsPendingWrites: false)
                 }
             } catch {
                 // Preserve the token for transient network failures. The app

--- a/apps/swift/Tests/PackRatTests/OutboxTests.swift
+++ b/apps/swift/Tests/PackRatTests/OutboxTests.swift
@@ -447,3 +447,88 @@ struct LegacyLocalIDMigrationTests {
         #expect(defaults.bool(forKey: "legacyLocalIDMigrationCompleted"))
     }
 }
+
+// MARK: - Sign-out and the outbox
+
+/// The outbox has no user column, so what survives a sign-out is decided entirely
+/// by the caller. Before this, `purgeCachedUserContent` dropped only the cached
+/// packs and trips: a signed-in user's unsent writes stayed queued and
+/// `OutboxService.flush` replayed them against whichever account signed in next.
+/// Guest writes have the opposite requirement — they are queued precisely so
+/// signing in can upload them — so the two cases are pinned separately here.
+/// Shared by the iOS and macOS targets, which compile the same `AuthManager`.
+@Suite("AuthManager.purgeCachedUserContent")
+@MainActor
+struct SignOutOutboxTests {
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: PendingMutation.self, CachedPack.self, CachedTrip.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func queueWrite(_ context: ModelContext, entityId: String = "pack-1") {
+        context.insert(PendingMutation(
+            entityType: .pack,
+            entityId: entityId,
+            operation: .create,
+            payload: OutboxService.encode(PackMutationPayload(
+                name: "Sierra Overnight", description: nil, category: nil, isPublic: false
+            ))
+        ))
+    }
+
+    private func pendingCount(_ context: ModelContext) -> Int {
+        ((try? context.fetch(FetchDescriptor<PendingMutation>())) ?? []).count
+    }
+
+    private func makePack(id: String) -> Pack {
+        Pack(
+            id: id, userId: nil, name: "Pack", description: nil, category: nil,
+            isPublic: false, image: nil, tags: nil, templateId: nil,
+            deleted: false, isAIGenerated: false, items: [],
+            totalWeight: 0, baseWeight: 0, wornWeight: 0, consumableWeight: 0,
+            createdAt: Date.iso8601Now(), updatedAt: Date.iso8601Now()
+        )
+    }
+
+    @Test("a deliberate sign-out discards the account's unsent writes")
+    func deliberateSignOutClearsOutbox() throws {
+        let context = try makeContext()
+        queueWrite(context)
+        try context.save()
+
+        try AuthManager.purgeCachedUserContent(in: context, discardsPendingWrites: true)
+
+        // Otherwise the next account to sign in on this device uploads them.
+        #expect(pendingCount(context) == 0)
+    }
+
+    @Test("keeping pending writes leaves the queue intact")
+    func preservedSignOutKeepsOutbox() throws {
+        let context = try makeContext()
+        queueWrite(context)
+        try context.save()
+
+        try AuthManager.purgeCachedUserContent(in: context, discardsPendingWrites: false)
+
+        // The guest-to-sign-in path and an expired session both land here: the
+        // writes still belong to someone who never chose to discard them.
+        #expect(pendingCount(context) == 1)
+    }
+
+    @Test("cached packs and trips are dropped either way")
+    func cachedContentAlwaysPurged() throws {
+        for discards in [true, false] {
+            let context = try makeContext()
+            context.insert(CachedPack(from: makePack(id: "pack-1")))
+            try context.save()
+
+            try AuthManager.purgeCachedUserContent(in: context, discardsPendingWrites: discards)
+
+            let cached = (try? context.fetch(FetchDescriptor<CachedPack>())) ?? []
+            #expect(cached.isEmpty, "cached packs must not outlive a sign-out (discards: \(discards))")
+        }
+    }
+}


### PR DESCRIPTION
## Description

`PendingMutation` (the offline write outbox) has no user column, and `AuthManager.purgeCachedUserContent` dropped only `CachedPack`/`CachedTrip`. A signed-in user's unsent writes therefore outlived their sign-out, and `OutboxService.flush` replays the queue against whatever session token is present — so **the next account to sign in on the device uploaded the previous user's work as its own**.

Found while dogfooding the Swift app on `development`.

The queue is now cleared on a deliberate sign-out, and deliberately **kept** in the two cases where the writes still belong to someone:

- **Guests keep theirs.** Queueing offline work so signing in can upload it is the entire point of the guest flow (the "Sign In to Sync" button calls `signOut`). Purging there would delete the packs the flow exists to rescue.
- **An expired session keeps them.** Losing a token is not consent to destroy work that never reached the server, so the involuntary `signOut` on a 401 preserves the queue.

Applies to **iOS and macOS alike** — both targets compile the same `AuthManager`, and every sign-out entry point (`ProfileView`, `SyncStatusSection`, `ErrorView`, `PackRatPaywallView`) is a shared view.

Also splits the deletion onto a caller-supplied `ModelContext` so the rules are testable against an in-memory store; the `PersistenceController.shared` lookup stays in the private wrapper.

## Type of change

- [x] 🐛 Bug fix

## Area(s) affected

- [x] Swift app (`apps/swift`) — iOS and macOS

## Testing

- [x] Added / updated unit tests
- [x] Manually tested on iOS

Three new tests in `OutboxTests.swift` pin each rule: a deliberate sign-out empties the queue, a preserved sign-out leaves it intact, and cached packs/trips are dropped either way.

**Verified the tests actually catch the bug** — reverted the fix and confirmed `a deliberate sign-out discards the account's unsent writes` fails (`pendingCount → 1) == 0`), then restored it and confirmed it passes.

Full `PackRatTests` suite: 316 tests, same 10 pre-existing failures as clean `development` (313 tests, identical 10 — a known keychain-suite race). No regression. macOS app target builds clean.

## Notes for the reviewer

Two **pre-existing** problems found but deliberately left out of scope:

1. The `PackRatMacOSTests` target does not compile on `development` — `WatchTrailDraftStoreTests` / `WatchChecklistSyncTests` reference watch-only symbols (`WatchTrailDraftStore`, `WatchCompanionService`) absent from the macOS target. Since `macOS-Smoke` includes that target, Swift CI is already red on `development` (last several merges all failed). Not introduced here.
2. `clearAllData()` ("Clear Data") documents itself as wiping *everything* local, but never touches SwiftData — so cached packs, trips, and the outbox all survive it.

## Pre-merge checklist

- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits
- [ ] Database migration included (n/a — no schema change)
- [ ] Feature flag added (n/a — bug fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-out handling so pending changes are discarded only when appropriate.
  - Preserved pending changes during sign-in transitions and unauthorized-session recovery.
  - Ensured cached content is cleared consistently during sign-out.
  - Updated outbox counts when queued changes are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->