### PR TITLE
fix(swift): clear the low-hanging dogfood findings

### DIFF
--- a/apps/swift/Sources/PackRat/AppState.swift
+++ b/apps/swift/Sources/PackRat/AppState.swift
@@ -26,6 +26,10 @@ final class AppState {
 
     // App-wide presentation
     var isGlobalSearchPresented = false
+    /// Set to route straight into pack creation from outside the Packs screen,
+    /// so a "Start Pack" call to action starts a pack instead of only landing on
+    /// the list. `PacksListView` consumes and clears it.
+    var isPackCreationRequested = false
 
     init() {
         // Back the assistant's pack tools with the local store, so it can find

--- a/apps/swift/Sources/PackRat/Features/Auth/LoginView.swift
+++ b/apps/swift/Sources/PackRat/Features/Auth/LoginView.swift
@@ -229,6 +229,10 @@ struct AuthHeader: View {
                 .font(.system(size: 42, weight: .semibold))
                 .foregroundStyle(.tint)
                 .symbolRenderingMode(.hierarchical)
+                // Decorative: the title below says the same thing, and without
+                // this VoiceOver reads the raw SF Symbol name
+                // ("person.crop.circle.badge.plus" → "Add People/Follow").
+                .accessibilityHidden(true)
 
             VStack(spacing: 5) {
                 Text(title)

--- a/apps/swift/Sources/PackRat/Features/Auth/RegisterView.swift
+++ b/apps/swift/Sources/PackRat/Features/Auth/RegisterView.swift
@@ -33,12 +33,14 @@ struct RegisterView: View {
                             .padding(.horizontal, 14)
                             .padding(.vertical, 12)
                             .accessibilityIdentifier("register_first_name")
+                            .accessibilityLabel("First Name")
                         Divider()
                         TextField("Last Name", text: $lastName)
                             .textContentType(.familyName)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 12)
                             .accessibilityIdentifier("register_last_name")
+                            .accessibilityLabel("Last Name")
                     }
 
                     Divider().padding(.leading, 14)
@@ -53,14 +55,29 @@ struct RegisterView: View {
                         .padding(.horizontal, 14)
                         .padding(.vertical, 12)
                         .accessibilityIdentifier("register_email")
+                        .accessibilityLabel("Email")
 
                     Divider().padding(.leading, 14)
 
-                    SecureField("Password", text: $password)
-                        .textContentType(.newPassword)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 12)
-                        .accessibilityIdentifier("register_password")
+                    // State the rule up front — 8 characters matches both
+                    // `isValid` here and Better Auth's `minPasswordLength`
+                    // server-side, so the user is not left to discover it by
+                    // failing.
+                    VStack(alignment: .leading, spacing: 4) {
+                        SecureField("Password", text: $password)
+                            .textContentType(.newPassword)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 12)
+                            .accessibilityIdentifier("register_password")
+                            .accessibilityLabel("Password")
+                        if password.isEmpty || password.count < 8 {
+                            Text("At least 8 characters")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 14)
+                                .padding(.bottom, 10)
+                        }
+                    }
 
                     Divider().padding(.leading, 14)
 
@@ -71,6 +88,7 @@ struct RegisterView: View {
                             .padding(.horizontal, 14)
                             .padding(.vertical, 12)
                             .accessibilityIdentifier("register_confirm_password")
+                            .accessibilityLabel("Confirm Password")
                         if passwordMismatch {
                             Text("Passwords don't match")
                                 .font(.caption)

--- a/apps/swift/Sources/PackRat/Features/Catalog/CatalogView.swift
+++ b/apps/swift/Sources/PackRat/Features/Catalog/CatalogView.swift
@@ -41,15 +41,10 @@ struct CatalogView: View {
             }
         }
         .navigationTitle("Gear Catalog")
-        #if os(iOS)
-        .searchable(
-            text: $vm.searchText,
-            placement: .navigationBarDrawer(displayMode: .always),
-            prompt: "Search tents, packs, sleeping bags…"
-        )
-        #else
-        .searchable(text: $vm.searchText, prompt: "Search tents, packs, sleeping bags…")
-        #endif
+        // Guests get no search field at all: catalog search is server-backed, so
+        // an editable field above "Catalog Requires an Account" is a dead input
+        // that accepts a query it can never answer.
+        .catalogSearchable(text: $vm.searchText, enabled: authManager.isAuthenticated)
         .onChange(of: vm.searchText) {
             if authManager.isAuthenticated {
                 vm.onSearchTextChanged()
@@ -87,6 +82,29 @@ struct CatalogView: View {
         .accessibilityIdentifier("catalog_results_list")
         .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal)
+    }
+}
+
+private extension View {
+    /// Attaches the catalog search field only when it can actually search.
+    ///
+    /// `.searchable` cannot be applied conditionally inline — the two branches
+    /// are different opaque types — so the choice happens here instead.
+    @ViewBuilder
+    func catalogSearchable(text: Binding<String>, enabled: Bool) -> some View {
+        if enabled {
+            #if os(iOS)
+            searchable(
+                text: text,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search tents, packs, sleeping bags…"
+            )
+            #else
+            searchable(text: text, prompt: "Search tents, packs, sleeping bags…")
+            #endif
+        } else {
+            self
+        }
     }
 }
 

--- a/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
+++ b/apps/swift/Sources/PackRat/Features/Home/HomeView.swift
@@ -188,6 +188,12 @@ struct HomeView: View {
             HStack(spacing: 10) {
                 SummaryActionButton(title: primarySummaryActionTitle, symbol: primarySummaryActionSymbol, isProminent: true) {
                     appState.navItem = primarySummaryDestination
+                    // "Start Pack" promises a new pack, so open the create sheet
+                    // rather than dropping the user on an empty list to find the
+                    // button again.
+                    if appState.packsVM.packs.isEmpty {
+                        appState.isPackCreationRequested = true
+                    }
                 }
 
                 SummaryActionButton(title: "Search", symbol: "magnifyingglass") {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackFormView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackFormView.swift
@@ -33,10 +33,14 @@ struct PackFormView: View {
                         .submitLabel(.done)
                         .onSubmit { isInputFocused = false }
                         .accessibilityIdentifier("pack_name")
+                        // Identifier stays for E2E selectors; the label is what
+                        // VoiceOver reads, which would otherwise be "pack_name".
+                        .accessibilityLabel("Name")
                     TextField("Description", text: $description, axis: .vertical)
                         .lineLimit(3, reservesSpace: true)
                         .focused($isInputFocused)
                         .accessibilityIdentifier("pack_description")
+                        .accessibilityLabel("Description")
                 }
 
                 Section("Category") {

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemFormView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemFormView.swift
@@ -60,6 +60,9 @@ struct PackItemFormView: View {
                     .submitLabel(.done)
                     .onSubmit { isInputFocused = false }
                     .accessibilityIdentifier("pack_item_name")
+                    // Identifier stays for E2E selectors; the label is what
+                    // VoiceOver reads, which would otherwise be the testID.
+                    .accessibilityLabel("Name")
 
                 Picker("Category", selection: $category) {
                     Text("None").tag("")
@@ -80,6 +83,7 @@ struct PackItemFormView: View {
                             #endif
                             .focused($isInputFocused)
                             .accessibilityIdentifier("item_weight")
+                            .accessibilityLabel("Weight")
 
                         Picker("Unit", selection: $weightUnit) {
                             ForEach(AppWeightUnit.allCases, id: \.rawValue) { u in
@@ -108,6 +112,7 @@ struct PackItemFormView: View {
                     .lineLimit(3, reservesSpace: true)
                     .focused($isInputFocused)
                     .accessibilityIdentifier("pack_item_notes")
+                    .accessibilityLabel("Notes")
             }
 
             if let error {

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksListView.swift
@@ -14,6 +14,7 @@ struct PacksListView: View {
     @State private var packPendingDeletion: Pack?
     @State private var showingDeleteConfirmation = false
     @Environment(\.modelContext) private var modelContext
+    @Environment(AppState.self) private var appState
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private var isCompact: Bool { horizontalSizeClass == .compact }
@@ -95,6 +96,13 @@ struct PacksListView: View {
         }
         .sheet(isPresented: $showingCreateSheet) {
             PackFormView(viewModel: viewModel)
+        }
+        // A "Start Pack" tap elsewhere routes here and asks for the create sheet.
+        // Handled on appear *and* on change so it works whether this view is
+        // being built fresh or is already mounted behind another tab.
+        .onAppear { consumePackCreationRequest() }
+        .onChange(of: appState.isPackCreationRequested) { _, requested in
+            if requested { consumePackCreationRequest() }
         }
         .navigationDestination(isPresented: $showingRecentPacks) {
             RecentPacksView(packs: viewModel.packs)
@@ -224,6 +232,17 @@ struct PacksListView: View {
     private func requestDelete(_ pack: Pack) {
         packPendingDeletion = pack
         showingDeleteConfirmation = true
+    }
+
+    /// Opens the create sheet if another screen asked for it, then clears the
+    /// request so returning to this tab later does not reopen the sheet.
+    private func consumePackCreationRequest() {
+        guard appState.isPackCreationRequested else { return }
+        appState.isPackCreationRequested = false
+        // Explore shows other people's packs; creating from there would be
+        // confusing, so land the user on their own list first.
+        isExplore = false
+        showingCreateSheet = true
     }
 
     // MARK: - Delete

--- a/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PacksViewModel.swift
@@ -14,9 +14,14 @@ final class PacksViewModel {
     let service: PackService
     private let outbox: OutboxService
 
-    init(service: PackService = .shared, outbox: OutboxService = .shared) {
+    // `OutboxService.shared` is main-actor isolated, and a default argument is
+    // evaluated in the *caller's* context rather than the callee's — which is a
+    // hard error in the Swift 6 language mode. Taking `nil` and resolving the
+    // singleton in the body keeps the default inside this @MainActor type while
+    // leaving the injection point open for tests.
+    init(service: PackService = .shared, outbox: OutboxService? = nil) {
         self.service = service
-        self.outbox = outbox
+        self.outbox = outbox ?? .shared
     }
 
     var currentPage = 1

--- a/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
+++ b/apps/swift/Sources/PackRat/Features/Trips/TripsViewModel.swift
@@ -14,9 +14,11 @@ final class TripsViewModel {
     private let service: TripService
     private let outbox: OutboxService
 
-    init(service: TripService = .shared, outbox: OutboxService = .shared) {
+    // See `PacksViewModel.init`: an isolated singleton cannot be a default
+    // argument under the Swift 6 language mode, so resolve it in the body.
+    init(service: TripService = .shared, outbox: OutboxService? = nil) {
         self.service = service
-        self.outbox = outbox
+        self.outbox = outbox ?? .shared
     }
 
     var currentPage = 1

--- a/apps/swift/Sources/PackRat/Subscriptions/FeatureAccessStore.swift
+++ b/apps/swift/Sources/PackRat/Subscriptions/FeatureAccessStore.swift
@@ -173,10 +173,14 @@ final class FeatureAccessStore {
     /// without entitlement, say — would let a paying member be treated as
     /// non-Pro against a freshly-fetched gate list, which is worse than staying
     /// on the previous cached answer.
+    // `SubscriptionService.shared` is main-actor isolated and so cannot be a
+    // default argument under the Swift 6 language mode — see
+    // `PacksViewModel.init`. Resolved in the body instead.
     func refresh(
         service: FeatureAccessService = .shared,
-        subscriptions: SubscriptionService = .shared
+        subscriptions: SubscriptionService? = nil
     ) async {
+        let subscriptions = subscriptions ?? .shared
         do {
             let config = try await service.fetchConfig()
 

--- a/apps/swift/Sources/PackRat/Watch/WatchCompanionService.swift
+++ b/apps/swift/Sources/PackRat/Watch/WatchCompanionService.swift
@@ -24,13 +24,16 @@ final class WatchCompanionService: NSObject {
         WatchTemperatureUnit.fromDefaults(defaults)
     }
 
+    // Both store singletons are main-actor isolated, so they cannot be default
+    // arguments under the Swift 6 language mode — see `PacksViewModel.init`.
+    // The labels are unchanged, so existing callers and tests still compile.
     init(
-        packingModeStore: PackingModeStore = .shared,
-        trailDraftStore: WatchTrailDraftStore = .shared,
+        packingModeStore: PackingModeStore? = nil,
+        trailDraftStore: WatchTrailDraftStore? = nil,
         defaults: UserDefaults = .standard
     ) {
-        self.packingModeStore = packingModeStore
-        self.trailDraftStore = trailDraftStore
+        self.packingModeStore = packingModeStore ?? .shared
+        self.trailDraftStore = trailDraftStore ?? .shared
         self.defaults = defaults
         super.init()
         encoder.dateEncodingStrategy = .iso8601


### PR DESCRIPTION
## Description

Clears the five low-hanging findings from a dogfood pass over the Swift apps (iOS, macOS, watchOS) on `development` @ `7c7bddf2f`. Every fix is in shared source under `Sources/PackRat`, so each one lands on iPhone, iPad and Mac from a single change.

**1. Catalog search field was live behind the account wall.** `.searchable` was attached outside the `isAuthenticated` branch, so a guest saw an editable search bar above "Catalog Requires an Account" — a dead input accepting a query it could never answer. Now attached only when authenticated, via a small `@ViewBuilder` helper (`.searchable` can't be applied conditionally inline — the two branches are different opaque types). The platform split and the existing `onChange`/`onSubmit` guards are unchanged.

**2. "Start Pack" did not start a pack.** The primary empty-state CTA on Home only set `navItem = .packs`, dropping the user on an empty list to find "New Pack" themselves. It now also opens the create sheet. The sheet's `showingCreateSheet` is local `@State` in `PacksListView`, so the request routes through a new `AppState.isPackCreationRequested`, consumed and cleared on both `onAppear` and `onChange` — that covers the view being built fresh *and* already mounted behind another tab. Consuming it also drops out of Explore first, since creating from someone else's pack list would be confusing.

**3. Sign-up never stated the password rule.** Added "At least 8 characters" under the Password field. 8 matches both `isValid` locally and Better Auth's `minPasswordLength` server-side (`packages/api/src/auth/auth.config.ts:72`), so the number is not invented — the rule is no longer learned by failing.

**4. VoiceOver announced internal identifiers.** The auth, pack and item form fields carried only an `accessibilityIdentifier`, which VoiceOver falls back to reading: "register_email", "register_password", "pack_name", "pack_item_name". Header icons read as raw SF Symbol names ("backpack.fill", and "person.crop.circle.badge.plus" announces as "Add People/Follow"). Added explicit `accessibilityLabel`s and hid the decorative `AuthHeader` icon, whose meaning the adjacent title already carries.

All identifiers are left exactly as they were — the E2E selector policy in `CLAUDE.md` depends on them, and adding a label does not replace the identifier. Verified after the change that all six `register_*` identifiers still resolve.

**5. Swift 6 concurrency violations, 5 sites.** Each passed a main-actor-isolated singleton as a default argument (`OutboxService.shared`, `SubscriptionService.shared`, `PackingModeStore.shared`, `WatchTrailDraftStore.shared`). A default argument is evaluated in the *caller's* context, not the callee's, so this is `main actor-isolated static property 'shared' can not be referenced from a nonisolated context` — a warning today and a hard error under the Swift 6 language mode. Note this grew from 2 sites to 5 over the last ~115 commits, so it was worth fixing as one batch.

Fixed by taking `nil` and resolving `.shared` in the body, which keeps the injection point open for tests. Marking the `init` `@MainActor` does *not* work — I tried that first and the warnings persisted, because it doesn't change where defaults are evaluated. Parameter labels are unchanged, so existing callers and the `WatchCompanionService` tests still compile untouched.

## Type of change

- [x] 🐛 Bug fix
- [x] ♻️  Refactor / code improvement

## Area(s) affected

- [x] Swift apps (`apps/swift`) — iOS, macOS, watchOS

## Testing

- [x] Manually tested on iOS (iPhone 15 Pro simulator, fresh install)
- [x] Manually tested on macOS
- [x] iOS, macOS and watchOS all build clean; zero `main actor-isolated` warnings remaining on iOS and macOS (5 before)

Verified on device rather than by inspection:

- Catalog as a guest: no search input in the accessibility tree at all (was an editable field)
- "Start Pack" from a zero-pack Home: New Pack sheet opens directly, one tap
- Sign-up: "At least 8 characters" renders; Create Account stays disabled for a malformed email and a missing last name
- Register fields now expose as "First Name" / "Email" / "Password"; the `backpack.fill` and "Add People/Follow" strings are gone from the tree
- All six `register_*` E2E identifiers still resolve after the label change

**Pre-existing failures, not from this PR:** `AuthTests.testGuestSeesNativeSignInStateForAccountBackedFeatures` and `…ForAITools` both fail with `Home action 'Pack Templates'/'Season Suggestions' must exist`. I baselined both on unmodified `development` @ `7c7bddf2f` and they fail there identically, with the same assertions. They look like a Home-row reachability problem in the test helper, unrelated to these changes.

**Not covered:** the sign-out outbox leak from the same dogfood pass (queued `PendingMutation` rows survive sign-out, so the next user inherits the previous user's failed writes) is deliberately excluded — it is a data-correctness decision and is being handled separately. No files in this PR overlap it.

## Pre-merge checklist

- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits
- [ ] `bun format && bun lint` / `bun check-types` — n/a, no TypeScript touched; this PR is Swift only
- [ ] Database migration — n/a
- [ ] Feature flag — n/a, these are fixes to existing surfaces
