### PR TITLE
fix(mcp): keep ServiceMeta.Version in lockstep with the monorepo bump

### DIFF
--- a/.github/scripts/bump.ts
+++ b/.github/scripts/bump.ts
@@ -91,6 +91,28 @@ try {
   console.error(`❌ Failed to update project.yml:`, error);
 }
 
+// Update the MCP server's advertised version. `ServiceMeta.Version` mirrors
+// packages/mcp/package.json by hand and is asserted to match it in
+// constants.test.ts, so a bump that skipped this file left the repo on a
+// version the test suite rejects — which is exactly how it drifted to 2.2.0
+// while the monorepo moved to 2.2.3.
+const mcpConstantsPath = join(process.cwd(), 'packages/mcp/src/constants.ts');
+const RE_SERVICE_META_VERSION = /(ServiceMeta[\s\S]*?Version:\s*)'[^']*'/;
+try {
+  const content = readFileSync(mcpConstantsPath, 'utf-8');
+  if (!RE_SERVICE_META_VERSION.test(content)) {
+    console.error(
+      `❌ No ServiceMeta.Version found in ${mcpConstantsPath}; MCP version NOT bumped. constants.test.ts will fail until it matches package.json.`,
+    );
+  } else {
+    const updated = content.replace(RE_SERVICE_META_VERSION, `$1'${newVersion}'`);
+    writeFileSync(mcpConstantsPath, updated);
+    console.log(`✅ Updated ${mcpConstantsPath}`);
+  }
+} catch (error) {
+  console.error(`❌ Failed to update constants.ts:`, error);
+}
+
 // Commit and tag as last step
 try {
   await $`git add .`;

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -21,6 +21,6 @@ export const ServiceMeta = {
   Name: 'packrat-mcp',
   /** MCP-server display name surfaced to clients. */
   McpServerName: 'packrat',
-  Version: '2.2.0',
+  Version: '2.2.3',
   Transport: 'streamable-http',
 } as const;


### PR DESCRIPTION
## Description

`Coverage (packages/mcp)` and `Coverage Ratchet` have been failing on `development` for several merges. Cause:

```
AssertionError: expected '2.2.0' to be '2.2.3'
```

`ServiceMeta.Version` in `packages/mcp/src/constants.ts` mirrors `packages/mcp/package.json` **by hand**, and `constants.test.ts` asserts the two stay in lockstep ("single source of truth"). The 2.2.3 bump (`32aa4acf2`) updated every `package.json` but not this constant, so the assertion has failed ever since. `Coverage Ratchet` fails as a knock-on: the aborted run never writes `coverage-summary.json`, so the ratchet errors with `ENOENT`.

Two changes:

1. **Fix the drift** — `ServiceMeta.Version` → `2.2.3`.
2. **Stop it recurring** — teach `bun bump` to rewrite the constant. The script already updates every `package.json`, Expo's `app.config.ts`, and the Swift project's `MARKETING_VERSION`; this file was simply missed. The new block mirrors the `MARKETING_VERSION` one, including the loud error when the pattern stops matching, so a future rename fails visibly instead of silently skipping.

Found while opening #2751 (an unrelated Swift fix) — its CI surfaced these two failures, and they turned out to be pre-existing on `development` rather than caused by that branch. Kept separate so #2751 stays Swift-only and this fix unblocks Coverage for every branch.

## Type of change

- [x] 🐛 Bug fix
- [x] 🔧 CI / configuration change

## Area(s) affected

- [x] CI / CD (`.github/`)
- [x] `packages/mcp`

## Testing

- [x] `bun test:mcp` — 1368 passed, 37 files (was failing on `constants.test.ts` before)
- [x] `bun check-types` — clean
- [x] `bunx biome check` on both changed files — clean
- [x] Verified the new bump regex replaces exactly the `ServiceMeta.Version` line and nothing else

## Pre-merge checklist

- [x] `bun check-types` passes with no errors
- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits
- [ ] Database migration included (n/a)
- [ ] Feature flag added (n/a — bug fix)
