### PR TITLE
fix(swift): guard iOS-only watch tests so the macOS test target compiles

### DIFF
--- a/apps/swift/Tests/PackRatTests/WatchChecklistSyncTests.swift
+++ b/apps/swift/Tests/PackRatTests/WatchChecklistSyncTests.swift
@@ -1,3 +1,8 @@
+// `WatchCompanionService` is `#if os(iOS)` — only the phone talks to the watch.
+// The macOS target compiles this same test directory, so without a matching
+// guard the type is missing there and the whole `PackRatMacOSTests` bundle fails
+// to build, taking every unrelated test with it.
+#if os(iOS)
 import Foundation
 import Testing
 @testable import PackRat
@@ -171,3 +176,5 @@ struct WatchChecklistSyncTests {
         #expect(decoded.name == "Old Pack")
     }
 }
+
+#endif

--- a/apps/swift/Tests/PackRatTests/WatchTrailDraftStoreTests.swift
+++ b/apps/swift/Tests/PackRatTests/WatchTrailDraftStoreTests.swift
@@ -1,3 +1,8 @@
+// `WatchTrailDraftStore` is `#if os(iOS)` — it exists only in the phone half of
+// the companion pairing. The macOS target compiles this same test directory, so
+// without a matching guard the type is missing there and the whole
+// `PackRatMacOSTests` bundle fails to build, taking every unrelated test with it.
+#if os(iOS)
 import Foundation
 import Testing
 @testable import PackRat
@@ -146,3 +151,5 @@ struct WatchTrailDraftStoreTests {
         #expect(store.drafts[0].note == "Dry and clear")
     }
 }
+
+#endif


### PR DESCRIPTION
## Description

`PackRat-macOS (smoke)` has been failing on `development` for several merges:

```
Testing failed:
	Cannot find type 'WatchTrailDraftStore' in scope
	Testing cancelled because the build failed.
** TEST FAILED **
```

`WatchCompanionService` and `WatchTrailDraftStore` are both `#if os(iOS)` — only the phone half of the companion pairing has them. Their test files carried **no matching guard**, and `project.yml` compiles the same `Tests/PackRatTests` directory into both `PackRatTests` (iOS) and `PackRatMacOSTests` (macOS). So on macOS the two suites referenced types that don't exist there.

Swift fails the entire test bundle on that, not just the offending files — so the whole macOS unit target stopped building and took **298 unrelated tests** down with it. `macOS-Smoke` includes that target, which is what turned the smoke job red.

Wrapping the two test files in `#if os(iOS)` matches the platform the code under test actually ships on. This skips no coverage: the tests still run on iOS, where the types exist.

Only these two files needed it — `WatchSnapshotTests` and `WatchTemperatureUnitTests` reference `WatchSnapshot` / `WatchTemperatureUnit`, which are cross-platform, so they keep running on macOS too.

Found while opening #2751 (an unrelated Swift fix) — its macOS smoke job failed, and the cause turned out to be pre-existing on `development` rather than anything in that branch. Kept separate so #2751 stays scoped to its own fix and this unblocks the smoke job for every branch.

## Type of change

- [x] 🐛 Bug fix
- [x] 🔧 CI / configuration change

## Area(s) affected

- [x] Swift app (`apps/swift`) — macOS test target

## Testing

- [x] `xcodebuild build-for-testing -scheme PackRat-macOS` — **BUILD SUCCEEDED** (was failing to compile)
- [x] `xcodebuild test -scheme PackRat-macOS -only-testing:PackRatMacOSTests` — **298 tests in 70 suites passed**
- [x] `xcodebuild test -scheme PackRat-iOS` on both guarded suites — **19 tests in 2 suites passed**, so nothing is hidden from iOS

## Pre-merge checklist

- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits
- [ ] Database migration included (n/a)
- [ ] Feature flag added (n/a — CI/test fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed macOS test builds by limiting iOS-specific watch tests to iOS targets.
  - Preserved existing test behavior while preventing unsupported tests from compiling on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->