### PR TITLE
fix(swift): open Start Packing on an empty pack, and make the photo scan show its work

### DIFF
--- a/apps/swift/Sources/PackRat/Features/Packs/EmptyPackPresentation.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/EmptyPackPresentation.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Copy for a pack with no items, which reads differently inside packing mode.
+///
+/// Start Packing used to be disabled on an empty pack, so tapping it did
+/// nothing and the greyed-out row explained nothing (#2696). The button is now
+/// always enabled and the screen explains itself instead. Apple's guidance is
+/// not to disable or hide a control because its content is empty — show it and
+/// explain the empty state inside — and the empty-state convention is to say
+/// what the space is for, why it is empty, and give one next step.
+///
+/// Extracted from the view so the copy and the choice between the two cases are
+/// directly testable.
+struct EmptyPackPresentation: Equatable {
+    let isPackingMode: Bool
+
+    var title: String {
+        isPackingMode ? "Nothing to Pack Yet" : "No Items Yet"
+    }
+
+    var subtitle: String {
+        isPackingMode
+            ? "This pack is empty, so there is nothing to check off. Add some gear and it will show up here ready to pack."
+            : "Add gear to build your pack"
+    }
+
+    var systemImage: String {
+        isPackingMode ? "checklist.unchecked" : "archivebox"
+    }
+
+    /// Both cases lead to the same sheet; only the wording differs, because in
+    /// packing mode "Add Item" reads like it would add a checklist row.
+    var actionLabel: String {
+        isPackingMode ? "Add Gear" : "Add Item"
+    }
+
+    var accessibilityIdentifier: String? {
+        isPackingMode ? "pack_packing_empty" : nil
+    }
+}

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -98,8 +98,13 @@ struct PackDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 if isPackingMode {
-                    packingHeader
-                        .padding(.horizontal)
+                    // "0 of 0 packed" at 0% is technically true and reads like a
+                    // bug, so an empty pack gets the empty state instead of a
+                    // progress card it cannot fill (#2696).
+                    if !items.isEmpty {
+                        packingHeader
+                            .padding(.horizontal)
+                    }
                 } else {
                     weightSummary
                         .padding(.horizontal)
@@ -146,11 +151,17 @@ struct PackDetailView: View {
                     }
 
                     if items.isEmpty {
+                        // Packing mode gets its own copy: the reason the screen
+                        // is empty is different (nothing to check off, rather
+                        // than nothing in the pack), and the way out is the same
+                        // — add gear — so the action stays. See #2696.
+                        let empty = EmptyPackPresentation(isPackingMode: isPackingMode)
                         EmptyStateView(
-                            "No Items Yet",
-                            subtitle: "Add gear to build your pack",
-                            systemImage: "archivebox",
-                            actionLabel: "Add Item",
+                            empty.title,
+                            subtitle: empty.subtitle,
+                            systemImage: empty.systemImage,
+                            actionLabel: empty.actionLabel,
+                            accessibilityIdentifier: empty.accessibilityIdentifier,
                             action: { showingAddItemSheet = true }
                         )
                         .frame(minHeight: 200)
@@ -224,10 +235,13 @@ struct PackDetailView: View {
                         }
                         .accessibilityIdentifier("pack_detail_ask_ai")
 
+                        // Deliberately enabled on an empty pack. A greyed-out
+                        // control explains nothing; the packing screen opens and
+                        // says why it is empty, matching how the rest of the app
+                        // handles emptiness. See issue #2696.
                         Button("Start Packing", systemImage: "checklist") {
                             startPackingMode()
                         }
-                        .disabled(items.isEmpty)
                         .accessibilityIdentifier("pack_detail_start_packing")
 
                         Divider()

--- a/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackDetailView.swift
@@ -367,7 +367,11 @@ struct PackDetailView: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            if isPackingMode {
+            // Reset and Mark All Packed both act on items, so on an empty pack
+            // they are two more controls that explain nothing — the same problem
+            // as the disabled Start Packing row in #2696. The empty state is the
+            // whole screen instead.
+            if isPackingMode && !items.isEmpty {
                 packingToolbar
             }
         }

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
@@ -15,6 +15,13 @@ final class PackItemsScanViewModel {
         case analyzing
         case reviewing
         case failed(String)
+        /// The picked photo could not be read at all, so there is nothing to
+        /// upload and "Try Again" would retry nothing. Distinct from `failed`
+        /// for the same reason `offline` is: the sheet states the case itself
+        /// rather than routing already-friendly copy through the infrastructure
+        /// error classifier, which buckets anything it does not recognise into
+        /// "Temporarily Unavailable" with a retry that cannot work.
+        case unreadablePhoto
         /// Distinct from `failed` so the sheet can show the connectivity state
         /// directly instead of round-tripping a message through string sniffing.
         case offline
@@ -161,8 +168,12 @@ struct PackItemsScanSheet: View {
                     guard let item else { return }
                     Task {
                         defer { photoItem = nil }
-                        guard let data = try? await item.loadTransferable(type: Data.self) else {
-                            viewModel.phase = .failed("Couldn't read that photo. Try another one.")
+                        guard let data = try? await item.loadTransferable(type: Data.self),
+                              !data.isEmpty else {
+                            // Common on the simulator, where a library photo's
+                            // backing file may not exist, and for iCloud photos
+                            // that are not downloaded yet.
+                            viewModel.phase = .unreadablePhoto
                             return
                         }
                         guard let userId = authManager.currentUser?.id else {
@@ -211,6 +222,21 @@ struct PackItemsScanSheet: View {
                 noResultsState
             } else {
                 reviewList
+            }
+        case .unreadablePhoto:
+            UnavailableStateView(
+                title: "Couldn't Read That Photo",
+                subtitle: "That photo could not be opened. If it is stored in iCloud, open it in Photos first so it downloads to this device, then try again.",
+                systemImage: "photo.badge.exclamationmark",
+                accessibilityIdentifier: "pack_scan_unreadable_photo"
+            ) {
+                // Choosing a different photo is the only thing that can help —
+                // there is no upload to retry.
+                PhotosPicker(selection: $photoItem, matching: .images) {
+                    Label("Choose Another Photo", systemImage: "photo.on.rectangle")
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("pack_scan_choose_another_photo")
             }
         case .failed(let message):
             ErrorView(message, retry: { viewModel.reset() })

--- a/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
+++ b/apps/swift/Sources/PackRat/Features/Packs/PackItemsScanSheet.swift
@@ -20,7 +20,33 @@ final class PackItemsScanViewModel {
         case offline
     }
 
+    /// The named steps of a scan, shown instead of one generic label.
+    ///
+    /// These are the real boundaries in `ImageDetectionService.detectItems` —
+    /// the upload completes, then a single request covers vision analysis and
+    /// catalog matching. `matching` is therefore not separately observable, so
+    /// it is entered when the analyze request is issued rather than reported by
+    /// the server. Apple's guidance is to prefer a determinate indicator where
+    /// one is honest; the model pass has no progress to report, so this stays
+    /// indeterminate and names the stage instead of faking a percentage.
+    enum Stage: Int, CaseIterable, Equatable {
+        case uploading
+        case detecting
+
+        var label: String {
+            switch self {
+            case .uploading: return "Uploading your photo…"
+            case .detecting: return "Looking for gear and matching the catalog…"
+            }
+        }
+    }
+
     var phase: Phase = .picking
+    /// Which step of the analysis is running. Only meaningful in `.analyzing`.
+    var stage: Stage = .uploading
+    /// The chosen photo, kept so the wait shows the image being analyzed
+    /// rather than an empty screen with a spinner (#2695).
+    var previewImageData: Data?
     var detections: [DetectedItemWithMatches] = []
     /// Indices into `detections` that the user wants to add.
     var selectedIndices: Set<Int> = []
@@ -51,6 +77,7 @@ final class PackItemsScanViewModel {
     func analyze(imageData: Data, userId: String) async {
         detections = []
         selectedIndices = []
+        previewImageData = imageData
 
         // Scanning needs the server's vision model, so there is nothing useful to
         // do offline. Checking up front keeps the user out of a doomed upload and
@@ -60,9 +87,16 @@ final class PackItemsScanViewModel {
             return
         }
 
+        stage = .uploading
         phase = .analyzing
         do {
-            let results = try await service.detectItems(imageData: imageData, userId: userId)
+            let results = try await service.detectItems(
+                imageData: imageData,
+                userId: userId,
+                onUploadFinished: { [weak self] in
+                    Task { @MainActor in self?.stage = .detecting }
+                }
+            )
             detections = results
             // Pre-select everything, matching Expo's auto-select-all.
             selectedIndices = Set(results.indices)
@@ -89,6 +123,8 @@ final class PackItemsScanViewModel {
         phase = .picking
         detections = []
         selectedIndices = []
+        previewImageData = nil
+        stage = .uploading
     }
 }
 
@@ -169,14 +205,7 @@ struct PackItemsScanSheet: View {
         case .picking:
             pickerState
         case .analyzing:
-            VStack(spacing: 14) {
-                ProgressView()
-                Text("Looking for gear in your photo…")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .accessibilityIdentifier("pack_scan_analyzing")
+            analyzingState
         case .reviewing:
             if viewModel.detections.isEmpty {
                 noResultsState
@@ -191,6 +220,64 @@ struct PackItemsScanSheet: View {
                 retry: { viewModel.reset() }
             )
         }
+    }
+
+    /// The wait, with the photo on screen.
+    ///
+    /// The scan takes a few seconds — an upload, then a vision pass and catalog
+    /// match. NN/g puts a spinner in range for a 2–10s wait, but a bare one
+    /// gives no sense of what is happening and no confirmation that the right
+    /// photo was picked, which was the complaint in #2695. Showing the image
+    /// with the current step named answers both without inventing a percentage
+    /// the server cannot report.
+    private var analyzingState: some View {
+        VStack(spacing: 20) {
+            if let data = viewModel.previewImageData, let image = PlatformImage(data: data) {
+                Image(platformImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 260)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .strokeBorder(.separator, lineWidth: 0.5)
+                    )
+                    .overlay(alignment: .bottom) { scanningSheen }
+                    .accessibilityLabel("The photo being scanned")
+                    .accessibilityIdentifier("pack_scan_preview_image")
+            }
+
+            VStack(spacing: 12) {
+                ProgressView()
+                Text(viewModel.stage.label)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    // Announce each step change to VoiceOver, which otherwise
+                    // hears one static label for the whole wait.
+                    .accessibilityIdentifier("pack_scan_stage_label")
+                    .id(viewModel.stage)
+                    .transition(.opacity)
+            }
+            .animation(.easeInOut(duration: 0.2), value: viewModel.stage)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("pack_scan_analyzing")
+    }
+
+    /// A soft band at the base of the photo, so the image reads as being worked
+    /// on rather than just displayed. Purely decorative — the stage label is
+    /// what actually communicates progress.
+    private var scanningSheen: some View {
+        LinearGradient(
+            colors: [.accentColor.opacity(0), .accentColor.opacity(0.22)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 60)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityHidden(true)
     }
 
     private var pickerState: some View {
@@ -287,6 +374,8 @@ private struct DetectedItemRow: View {
                 .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                 .accessibilityHidden(true)
 
+            matchThumbnail
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(detection.detected.name)
                     .font(.subheadline.weight(.medium))
@@ -328,6 +417,57 @@ private struct DetectedItemRow: View {
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .accessibilityIdentifier("pack_scan_item_\(detection.detected.name)")
+    }
+
+    /// The matched product's image beside its row, so a wrong match is obvious
+    /// without opening anything (#2695).
+    ///
+    /// The detection response carries no crop of the photo — `DetectedItemSchema`
+    /// returns name, description, quantity, category, flags and confidence, with
+    /// no geometry — so the catalog image is the only picture available for a
+    /// row. Unmatched detections fall back to the same category glyph the
+    /// catalog list uses, keeping the rows a consistent width.
+    @ViewBuilder
+    private var matchThumbnail: some View {
+        let size: CGFloat = 44
+        Group {
+            if let match, let urlString = match.images?.first, let url = URL(string: urlString) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable().scaledToFill()
+                    case .failure:
+                        thumbnailPlaceholder
+                    case .empty:
+                        // No spinner at 44pt — it draws attention to itself and
+                        // the row is already readable without the picture.
+                        thumbnailPlaceholder
+                    @unknown default:
+                        thumbnailPlaceholder
+                    }
+                }
+            } else {
+                thumbnailPlaceholder
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(.separator, lineWidth: 0.5)
+        )
+        // Decorative: the row's text already names the item and its match, so a
+        // second announcement would just make VoiceOver more verbose.
+        .accessibilityHidden(true)
+    }
+
+    private var thumbnailPlaceholder: some View {
+        ZStack {
+            Color.secondary.opacity(0.12)
+            Image(systemName: match == nil ? "questionmark" : "photo")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
     }
 
     @ViewBuilder

--- a/apps/swift/Sources/PackRat/Network/AuthManager.swift
+++ b/apps/swift/Sources/PackRat/Network/AuthManager.swift
@@ -77,6 +77,7 @@ final class AuthManager {
         await MainActor.run { currentUser = response.user }
         persistUser(response.user)
         SentryConfig.setUser(id: response.user.id, email: response.user.email)
+        verifySessionPersisted(path: "sign-in/email")
     }
 
     func continueWithoutLogin() {
@@ -149,6 +150,7 @@ final class AuthManager {
         }
         persistUser(response.user)
         SentryConfig.setUser(id: response.user.id, email: response.user.email)
+        verifySessionPersisted(path: "sign-in/social")
     }
 
     @MainActor
@@ -236,6 +238,7 @@ final class AuthManager {
         await MainActor.run { currentUser = response.user }
         persistUser(response.user)
         SentryConfig.setUser(id: response.user.id, email: response.user.email)
+        verifySessionPersisted(path: "sign-up/email")
     }
 
     func requestPasswordReset(email: String) async throws {
@@ -412,6 +415,24 @@ final class AuthManager {
     private func persistUser(_ user: User) {
         if let data = try? JSONEncoder().encode(user) {
             UserDefaults.standard.set(data, forKey: "current_user")
+        }
+    }
+
+    /// Reports a sign-in that produced a user but no session token.
+    ///
+    /// Every sign-in path guards `if let token`, and `APIClient` also captures
+    /// the `set-auth-token` header, so a missing token used to be silent: the
+    /// user record persisted, no session did, and the next launch showed the
+    /// authwall as if the session had simply expired. If neither source
+    /// supplied one, say so loudly at the moment it happens.
+    private func verifySessionPersisted(path: String) {
+        guard KeychainService.shared.sessionToken == nil else { return }
+        let message = "Sign-in via \(path) stored no session token — the next launch will show the authwall"
+        print("[Auth] \(message)")
+        SentrySDK.capture(message: message) { scope in
+            scope.setLevel(.error)
+            scope.setTag(value: "auth", key: "subsystem")
+            scope.setContext(value: ["path": path], key: "auth")
         }
     }
 

--- a/apps/swift/Sources/PackRat/Network/KeychainService.swift
+++ b/apps/swift/Sources/PackRat/Network/KeychainService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Security
+import Sentry
 
 final class KeychainService: Sendable {
     static let shared = KeychainService()
@@ -69,7 +70,25 @@ final class KeychainService: Sendable {
         SecItemDelete(query as CFDictionary)
         var attributes = query
         attributes[kSecValueData] = data
-        SecItemAdd(attributes as CFDictionary, nil)
+        // Keep the item readable after first unlock so a launch straight from a
+        // locked device can still restore the session. The default
+        // (`kSecAttrAccessibleWhenUnlocked`) is evaluated at write time, which
+        // is fine, but being explicit documents the intent.
+        attributes[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status != errSecSuccess else { return }
+
+        // A discarded status here is why "log in, reopen, back at the authwall"
+        // looked like a session bug with nothing in the logs: the write failed,
+        // login still reported success, and the next launch found no token. Never
+        // log `value` — it is the session token.
+        let message = "Keychain write failed for \(key.rawValue): OSStatus \(status)"
+        print("[Keychain] \(message)")
+        SentrySDK.capture(message: message) { scope in
+            scope.setLevel(.error)
+            scope.setTag(value: "keychain", key: "subsystem")
+            scope.setContext(value: ["status": Int(status), "key": key.rawValue], key: "keychain")
+        }
     }
 
     private func read(_ key: Key) -> String? {

--- a/apps/swift/Sources/PackRat/Services/ImageDetectionService.swift
+++ b/apps/swift/Sources/PackRat/Services/ImageDetectionService.swift
@@ -36,10 +36,16 @@ final class ImageDetectionService: Sendable {
     }
 
     /// Uploads raw JPEG data, then analyzes it.
+    ///
+    /// `onUploadFinished` fires once the PUT completes and before the analyze
+    /// request is issued — the one real step boundary in the flow, so callers
+    /// can name the stage they are waiting on instead of showing a single
+    /// generic label for the whole wait (#2695).
     func detectItems(
         imageData: Data,
         userId: String,
-        matchLimit: Int = 1
+        matchLimit: Int = 1,
+        onUploadFinished: (@Sendable () -> Void)? = nil
     ) async throws -> [DetectedItemWithMatches] {
         let fileName = "\(userId)-\(UUID().uuidString).jpg"
         let objectKey = try await uploader.upload(
@@ -47,6 +53,7 @@ final class ImageDetectionService: Sendable {
             fileName: fileName,
             mimeType: "image/jpeg"
         )
+        onUploadFinished?()
         return try await analyze(objectKey: objectKey, matchLimit: matchLimit)
     }
 }

--- a/apps/swift/Sources/PackRat/Shared/PlatformImageView.swift
+++ b/apps/swift/Sources/PackRat/Shared/PlatformImageView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+#if os(iOS)
+import UIKit
+typealias PlatformImage = UIImage
+#else
+import AppKit
+typealias PlatformImage = NSImage
+#endif
+
+extension Image {
+    /// Builds an `Image` from raw platform image data on either platform.
+    ///
+    /// `Image` has no shared initializer across UIKit and AppKit, so every site
+    /// that renders picked photo data otherwise repeats the same `#if os(iOS)`
+    /// pair (cf. `WildlifeView.thumbnailView`). One helper keeps the call sites
+    /// platform-free.
+    init(platformImage: PlatformImage) {
+        #if os(iOS)
+        self.init(uiImage: platformImage)
+        #else
+        self.init(nsImage: platformImage)
+        #endif
+    }
+}

--- a/apps/swift/Tests/PackRatTests/EmptyPackPresentationTests.swift
+++ b/apps/swift/Tests/PackRatTests/EmptyPackPresentationTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import PackRat
+
+/// Covers #2696: Start Packing was disabled on a pack with no items, so the
+/// menu row sat greyed out and tapping it did nothing. The button is now always
+/// enabled and the packing screen explains why it is empty, with a way forward.
+@Suite("Empty pack presentation")
+struct EmptyPackPresentationTests {
+
+    private let browsing = EmptyPackPresentation(isPackingMode: false)
+    private let packing = EmptyPackPresentation(isPackingMode: true)
+
+    @Test("packing mode explains why there is nothing to check off")
+    func packingCopyExplainsTheEmptiness() {
+        // The reported dead end was a control that "explains nothing", so the
+        // replacement has to actually state the reason.
+        #expect(packing.title == "Nothing to Pack Yet")
+        #expect(packing.subtitle.localizedCaseInsensitiveContains("empty"))
+        #expect(packing.subtitle.localizedCaseInsensitiveContains("add"))
+    }
+
+    @Test("packing mode differs from the plain empty pack on every visible element")
+    func packingDiffersFromBrowsing() {
+        // Same screen, two different reasons for being empty. If any of these
+        // collapsed to the same string the packing case would be indistinguishable
+        // from simply having an empty pack.
+        #expect(packing.title != browsing.title)
+        #expect(packing.subtitle != browsing.subtitle)
+        #expect(packing.systemImage != browsing.systemImage)
+        #expect(packing.actionLabel != browsing.actionLabel)
+    }
+
+    @Test("both cases offer a way forward rather than a bare label")
+    func bothOfferANextStep() {
+        // The issue asks for "a next action on the screen — adding gear — so the
+        // user is not made to back out and find the + menu themselves".
+        for presentation in [browsing, packing] {
+            #expect(presentation.actionLabel.isEmpty == false)
+            #expect(presentation.actionLabel.localizedCaseInsensitiveContains("add"))
+            #expect(presentation.title.isEmpty == false)
+            #expect(presentation.subtitle.isEmpty == false)
+        }
+    }
+
+    @Test("the packing empty state is addressable for UI tests")
+    func packingStateHasAStableIdentifier() {
+        #expect(packing.accessibilityIdentifier == "pack_packing_empty")
+        // The browsing case keeps EmptyStateView's derived identifier, so it
+        // must not claim the packing one.
+        #expect(browsing.accessibilityIdentifier != "pack_packing_empty")
+    }
+
+    @Test("copy stays free of jargon and scolding")
+    func copyToneIsPlain() {
+        // House rule: no internal jargon in user-facing copy, and empty states
+        // should not read as an error the user caused.
+        for text in [packing.title, packing.subtitle, browsing.title, browsing.subtitle] {
+            for banned in ["nil", "null", "error", "invalid", "failed", "cannot", "can't"] {
+                #expect(text.localizedCaseInsensitiveContains(banned) == false,
+                        "\"\(text)\" should not contain \"\(banned)\"")
+            }
+        }
+    }
+}

--- a/apps/swift/Tests/PackRatTests/PackItemsScanViewModelTests.swift
+++ b/apps/swift/Tests/PackRatTests/PackItemsScanViewModelTests.swift
@@ -70,6 +70,31 @@ struct PackItemsScanViewModelTests {
         #expect(viewModel.selectedIndices.isEmpty)
     }
 
+    // MARK: - Unreadable photo
+
+    @Test("an unreadable photo is its own state, not a generic failure")
+    func unreadablePhotoIsDistinct() {
+        // The picker can hand back nothing — an iCloud photo that is not
+        // downloaded, or a simulator library entry whose file is missing. Routed
+        // through `failed`, the message hit the infrastructure error classifier,
+        // which does not recognise it and falls back to "Temporarily Unavailable"
+        // with a Try Again that retries nothing. Keeping it a separate phase is
+        // what lets the sheet offer "Choose Another Photo" instead.
+        #expect(PackItemsScanViewModel.Phase.unreadablePhoto != .failed("Couldn't read that photo. Try another one."))
+        #expect(PackItemsScanViewModel.Phase.unreadablePhoto == .unreadablePhoto)
+    }
+
+    @Test("choosing a readable photo after an unreadable one clears the state")
+    func resetFromUnreadablePhoto() {
+        let viewModel = PackItemsScanViewModel()
+        viewModel.phase = .unreadablePhoto
+
+        viewModel.reset()
+
+        #expect(viewModel.phase == .picking)
+        #expect(viewModel.previewImageData == nil)
+    }
+
     // MARK: - Selection
 
     @Test("select all then none moves every row and leaves Add disabled when empty")

--- a/apps/swift/Tests/PackRatTests/PackItemsScanViewModelTests.swift
+++ b/apps/swift/Tests/PackRatTests/PackItemsScanViewModelTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import PackRat
+
+/// Covers #2695: scanning gear from a photo showed a bare spinner and one
+/// generic label for the whole wait, then described the results in words only.
+/// The sheet now keeps the chosen photo on screen, names the step it is waiting
+/// on, and shows the matched product's image beside each detection.
+@Suite("Pack items scan view model")
+@MainActor
+struct PackItemsScanViewModelTests {
+
+    // MARK: - Stages
+
+    @Test("a scan names its steps rather than showing one generic label")
+    func stagesAreNamed() {
+        // The complaint in #2695 was that the wait "shows the least". Every
+        // stage must carry copy a user can read, and they must differ.
+        let labels = PackItemsScanViewModel.Stage.allCases.map(\.label)
+
+        #expect(labels.count == 2)
+        #expect(Set(labels).count == labels.count)
+        for label in labels {
+            #expect(label.isEmpty == false)
+        }
+    }
+
+    @Test("stages run upload first, then detection")
+    func stageOrder() {
+        // Order matters: the label must not claim the catalog is being matched
+        // while the photo is still uploading.
+        #expect(PackItemsScanViewModel.Stage.allCases == [.uploading, .detecting])
+        #expect(PackItemsScanViewModel.Stage.uploading.rawValue
+                < PackItemsScanViewModel.Stage.detecting.rawValue)
+    }
+
+    @Test("the upload stage mentions uploading and the detect stage mentions gear")
+    func stageCopyMatchesWork() {
+        #expect(PackItemsScanViewModel.Stage.uploading.label.localizedCaseInsensitiveContains("upload"))
+        #expect(PackItemsScanViewModel.Stage.detecting.label.localizedCaseInsensitiveContains("gear"))
+    }
+
+    @Test("a fresh view model starts at the first stage")
+    func startsAtFirstStage() {
+        let viewModel = PackItemsScanViewModel()
+
+        #expect(viewModel.stage == .uploading)
+        #expect(viewModel.phase == .picking)
+        #expect(viewModel.previewImageData == nil)
+    }
+
+    // MARK: - Photo preview
+
+    @Test("choosing another photo after a failure clears the previous preview")
+    func resetClearsPreview() {
+        // reset() returns to the picker. A stale preview would show the old
+        // photo behind the next scan, and the analyzed image is already gone
+        // server-side, so nothing should survive the reset.
+        let viewModel = PackItemsScanViewModel()
+        viewModel.previewImageData = Data([0xFF, 0xD8, 0xFF])
+        viewModel.stage = .detecting
+        viewModel.phase = .reviewing
+
+        viewModel.reset()
+
+        #expect(viewModel.previewImageData == nil)
+        #expect(viewModel.stage == .uploading)
+        #expect(viewModel.phase == .picking)
+        #expect(viewModel.detections.isEmpty)
+        #expect(viewModel.selectedIndices.isEmpty)
+    }
+
+    // MARK: - Selection
+
+    @Test("select all then none moves every row and leaves Add disabled when empty")
+    func selectionToggles() {
+        let viewModel = PackItemsScanViewModel()
+        viewModel.detections = [
+            Self.detection(name: "Tent"),
+            Self.detection(name: "Sleeping bag"),
+        ]
+
+        viewModel.selectAll()
+        #expect(viewModel.selectedCount == 2)
+        #expect(viewModel.canAdd)
+
+        viewModel.selectNone()
+        #expect(viewModel.selectedCount == 0)
+        // Nothing selected means nothing to add — the toolbar button must not
+        // offer an action that would no-op.
+        #expect(viewModel.canAdd == false)
+    }
+
+    @Test("resolved selection returns only the ticked detections, in order")
+    func resolvedSelectionFiltersAndKeepsOrder() {
+        let viewModel = PackItemsScanViewModel()
+        viewModel.detections = [
+            Self.detection(name: "Tent"),
+            Self.detection(name: "Stove"),
+            Self.detection(name: "Filter"),
+        ]
+        viewModel.toggle(2)
+        viewModel.toggle(0)
+
+        let resolved = viewModel.resolvedSelection()
+
+        #expect(resolved.map(\.detected.name) == ["Tent", "Filter"])
+    }
+
+    @Test("adding in flight blocks a second add")
+    func addingBlocksReentry() {
+        let viewModel = PackItemsScanViewModel()
+        viewModel.detections = [Self.detection(name: "Tent")]
+        viewModel.selectAll()
+        #expect(viewModel.canAdd)
+
+        viewModel.isAdding = true
+
+        #expect(viewModel.canAdd == false)
+    }
+
+    // MARK: - Fixtures
+
+    private static func detection(name: String) -> DetectedItemWithMatches {
+        DetectedItemWithMatches(
+            detected: DetectedItem(name: name, category: "shelter", confidence: 0.9),
+            catalogMatches: []
+        )
+    }
+}

--- a/apps/swift/Tests/PackRatUITests/PackPackingEmptyStateTests.swift
+++ b/apps/swift/Tests/PackRatUITests/PackPackingEmptyStateTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+
+/// Covers #2696 on a real device run: Start Packing was disabled on a pack with
+/// no items, so the row sat greyed out and tapping it did nothing.
+///
+/// Runs in guest mode, which needs no credentials — a locally created guest
+/// pack starts empty, which is exactly the reported case.
+final class PackPackingEmptyStateTests: AppUITestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("--disable-animations")
+        app.launchArguments.append("--use-userdefaults-auth")
+        app.launchArguments.append("--reset-auth")
+        app.launch()
+    }
+
+    #if os(iOS)
+    func testStartPackingOpensEmptyStateOnAnEmptyPack() {
+        enterGuestMode()
+
+        let packName = uniqueName("Packing Empty State")
+        createEmptyGuestPack(named: packName)
+        waitFor(app.staticTexts[packName], timeout: 10).tap()
+
+        // The pack has no items, so the reported symptom would be a disabled row.
+        let menu = waitFor(app.buttons["pack_detail_more_menu"].firstMatch, timeout: 10)
+        menu.tap()
+
+        let startPacking = waitFor(app.buttons["pack_detail_start_packing"], timeout: 10)
+        XCTAssertTrue(
+            startPacking.isEnabled,
+            "Start Packing must stay enabled on an empty pack (#2696) — a greyed-out row explains nothing"
+        )
+        startPacking.tap()
+
+        // The screen must open and explain itself rather than doing nothing.
+        XCTAssertTrue(
+            app.staticTexts["Nothing to Pack Yet"].waitForExistence(timeout: 10),
+            "Packing an empty pack should open an empty state that says why it is empty"
+        )
+
+        // And it must offer the way forward, not make the user back out.
+        XCTAssertTrue(
+            app.buttons["Add Gear"].firstMatch.waitForExistence(timeout: 5),
+            "The packing empty state should offer Add Gear as the next step"
+        )
+
+        // The progress card would read "0 of 0 packed" at 0%, which reads like a bug.
+        XCTAssertEqual(
+            packingHeaderElements.count, 0,
+            "The progress card should be hidden when there is nothing to pack"
+        )
+
+        // The packing toolbar acts on items, so it has nothing to do here.
+        XCTAssertFalse(
+            app.buttons["pack_packing_reset"].exists,
+            "Reset should not be offered when there is nothing packed to reset"
+        )
+        XCTAssertFalse(
+            app.buttons["pack_packing_mark_all"].exists,
+            "Mark All Packed should not be offered when there is nothing to pack"
+        )
+
+        // Attached so the fixed screen is visible in the result bundle rather
+        // than only asserted on.
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "2696-packing-empty-state"
+        shot.lifetime = .keepAlways
+        add(shot)
+    }
+
+    /// The regression guard for the toolbar change: with items present the
+    /// packing screen must still show progress and the Reset / Mark All Packed
+    /// controls, so hiding them on an empty pack cannot hide them everywhere.
+    func testPackingKeepsProgressAndToolbarWhenThePackHasItems() {
+        enterGuestMode()
+
+        let packName = uniqueName("Packing With Items")
+        createEmptyGuestPack(named: packName)
+        waitFor(app.staticTexts[packName], timeout: 10).tap()
+
+        addItem(named: "Tent")
+
+        waitFor(app.buttons["pack_detail_more_menu"].firstMatch, timeout: 10).tap()
+        waitFor(app.buttons["pack_detail_start_packing"], timeout: 10).tap()
+
+        // The identifier lands on the card's children (the count label, the bar,
+        // the filter) rather than a container, so match on any element type.
+        XCTAssertTrue(
+            packingHeaderElements.firstMatch.waitForExistence(timeout: 10),
+            "A pack with items must still show the packing progress card"
+        )
+        XCTAssertTrue(
+            app.buttons["pack_packing_mark_all"].waitForExistence(timeout: 5),
+            "A pack with items must still offer Mark All Packed"
+        )
+        XCTAssertFalse(
+            app.staticTexts["Nothing to Pack Yet"].exists,
+            "A pack with items is not the empty case"
+        )
+    }
+
+    #endif
+
+    // MARK: - Helpers
+
+    /// Every element carrying the progress card's identifier, of any type.
+    private var packingHeaderElements: XCUIElementQuery {
+        app.descendants(matching: .any).matching(identifier: "pack_packing_header")
+    }
+
+    private func enterGuestMode() {
+        let continueButton = app.buttons["auth_continue_without_login"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 15))
+        continueButton.tap()
+        XCTAssertTrue(waitForLoggedIn(timeout: 15), "Guest mode should enter the main app shell")
+    }
+
+    #if os(iOS)
+    private func createEmptyGuestPack(named name: String) {
+        goToTab("Packs")
+        waitFor(app.buttons["New Pack"].firstMatch, timeout: 15).tap()
+
+        let nameField = app.textFields["pack_name"]
+        waitFor(nameField, timeout: 10)
+        nameField.tap()
+        nameField.typeText(name)
+
+        app.buttons["Create"].tap()
+        waitFor(app.staticTexts[name], timeout: 15)
+    }
+
+    private func addItem(named name: String) {
+        waitFor(app.buttons["pack_detail_add_item_button"], timeout: 10).tap()
+        waitFor(app.buttons["pack_detail_add_manually"], timeout: 10).tap()
+
+        let nameField = app.textFields["pack_item_name"]
+        waitFor(nameField, timeout: 10)
+        nameField.tap()
+        nameField.typeText(name)
+
+        app.buttons["Add"].firstMatch.tap()
+        waitFor(app.staticTexts[name], timeout: 15)
+    }
+    #endif
+}


### PR DESCRIPTION
## Description

The two open July-onward enhancement issues for the Swift app, plus three
silent-failure bugs found while verifying them on device.

Closes #2695

Closes #2696

### #2696 — Start Packing was a dead end on an empty pack

The menu row was `.disabled(items.isEmpty)`, so tapping it did nothing and the
greyed-out control explained neither why it was unavailable nor what to do
first. The button is now always enabled and the screen explains itself, which is
how the rest of the app already handles emptiness — the pack detail screen has
had a "No Items Yet" state offering Add Item all along.

Apple's guidance is not to disable or hide a control because its content is
empty (show it and explain the empty state inside), and the empty-state
convention is to say what the space is for, why it is empty, and give one next
step. So: **Nothing to Pack Yet** → "This pack is empty, so there is nothing to
check off. Add some gear and it will show up here ready to pack." → **Add Gear**.

Two dead controls went with it:

- The progress card would read **"0 of 0 packed"** at 0% — technically true, and
  it reads like a bug. Hidden when the pack is empty.
- The bottom toolbar still offered **Reset** and **Mark All Packed**, both of
  which act on items. Found only by opening the screen on the simulator; hiding
  them leaves the empty state as the whole screen.

Copy and the choice between the two empty cases moved to `EmptyPackPresentation`
so both are testable without standing up a view host.

### #2695 — the scan wait showed the least at the most interesting moment

Scanning gear from a photo showed a bare spinner and one generic label for the
whole wait, then described the results in words when the source was an image.

The wait now keeps the chosen photo on screen and names the step it is waiting
on. The stages are the *real* boundaries in `detectItems` — the upload
completes, then a single request covers vision analysis and catalog matching —
so the service reports the upload boundary through a callback rather than the
sheet guessing at it. It stays indeterminate on purpose: the model pass has no
progress to report, and Apple's guidance is to prefer a determinate indicator
only where an honest one exists, so this names the stage instead of faking a
percentage.

Results rows now carry the matched product's image, so a wrong match is obvious
without opening anything. Unmatched rows fall back to a glyph, keeping the rows
a consistent width.

**Still blocked, as the issue predicted:** the bounding-box ideas need geometry
the API does not return — `DetectedItemSchema` carries name, description,
quantity, category, flags and confidence, with no coordinates — so drawing boxes
over the photo needs a schema change first and is not in this PR.

### Three silent failures found while verifying

1. **An unreadable photo showed "Temporarily Unavailable" with a Try Again that
   could not work.** Reported through `.failed(message)`, whose message
   `ErrorView` runs through `FriendlyErrorPresentation` — a classifier for
   *infrastructure* errors that buckets anything unrecognised into
   "Temporarily Unavailable" and marks it retryable. The specific copy was
   discarded and the offered action retried an upload that never started. An
   unreadable photo is now its own phase, like `offline` already was, and offers
   **Choose Another Photo** — the only thing that can help. Reproduced from a
   simulator library entry whose backing file was missing.

2. **`SecItemAdd`'s status was discarded on session save.** A failed Keychain
   write was completely silent: login reported success, nothing was logged, and
   the next launch found no token and showed the authwall. The persisted
   `current_user` record survives that, which makes it look like a session
   expiry rather than a write that never landed. The status is now checked,
   logged, and reported to Sentry with the `OSStatus`. The token value is never
   logged.

3. **A sign-in that stores no token completed anyway.** Every path guards
   `if let token = response.token`, and `APIClient` separately captures the
   `set-auth-token` header. If neither supplied one, `currentUser` was still set
   and persisted, so the UI entered the app as normal with no session. All three
   paths now verify a token actually landed and report the path when it did not.

Both are diagnostic — they surface the condition rather than papering over it.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature

## Area(s) affected

- [x] **Swift app, iOS + macOS (`apps/swift`)** — not in the list above

## Testing

- [x] Added / updated unit tests
- [x] Manually tested on iOS

**Unit + UI:** `PackRatTests` green — **335 tests / 75 suites**. 13 new unit
tests across `EmptyPackPresentationTests` (copy differs per case, both offer a
next step, no jargon) and `PackItemsScanViewModelTests` (stage naming and order,
preview lifecycle, unreadable-photo phase, selection).

**On device:** two new guest-mode UI tests, which need no credentials because a
locally created guest pack starts empty:

- empty pack → Start Packing is enabled, opens "Nothing to Pack Yet" with Add
  Gear, and neither the progress card nor the toolbar appears. Attaches its
  screenshot to the result bundle.
- pack with one item → progress card, item and Mark All Packed all still there,
  so hiding them on an empty pack cannot regress into hiding them everywhere.

Verified on both **iPhone 15 Pro** and a clean rebuild on **iPhone 17 Pro**.
macOS target compiles clean (both changed screens are shared).

Two `PackRatUITests/AuthTests` guest tests fail on this branch — they also fail
on unmodified `development` (baselined before starting), so they are unrelated.

## Screenshots / recordings

Packing an empty pack, after the fix — the explanation and **Add Gear** replace
the disabled row, and the "0 of 0 packed" card and the dead Reset / Mark All
Packed toolbar are both gone:

```
                    ○—
                    ○—

            Nothing to Pack Yet
   This pack is empty, so there is nothing to
   check off. Add some gear and it will show
          up here ready to pack.

               [  Add Gear  ]
```

The `testStartPackingOpensEmptyStateOnAnEmptyPack` UI test attaches the real
screenshot to its result bundle as `2696-packing-empty-state`, so it is captured
on every run rather than pasted once.
