### PR TITLE
test(mcp): cover the error branches holding back the coverage ratchet

### DIFF
--- a/packages/mcp/src/__tests__/client.test.ts
+++ b/packages/mcp/src/__tests__/client.test.ts
@@ -187,6 +187,28 @@ describe('call()', () => {
     expect(nth(result.content, 0).text.toLowerCase()).toContain('conflict');
   });
 
+  it('still formats an error when the body cannot be serialised', async () => {
+    // No `.message` and no `.error`, so extractErrorMessage falls through to
+    // stringifying the whole body — and a throwing `toJSON` is the one input
+    // that still escapes safeJsonStringify. The tool must report the status
+    // rather than propagate the serialisation failure.
+    const hostile = {
+      toJSON() {
+        throw new Error('nope');
+      },
+    };
+    const mockPromise = Promise.resolve({
+      data: null,
+      error: { status: 500, value: hostile },
+      status: 500,
+    });
+
+    const result = await call({ promise: mockPromise, action: 'update pack' });
+
+    expect(result.isError).toBe(true);
+    expect(nth(result.content, 0).text.length).toBeGreaterThan(0);
+  });
+
   it('formats 422 validation error', async () => {
     const mockPromise = Promise.resolve({
       data: null,

--- a/packages/mcp/src/__tests__/resources.test.ts
+++ b/packages/mcp/src/__tests__/resources.test.ts
@@ -227,6 +227,27 @@ describe('U9 pack list provider', () => {
     expect(nth(result.resources, 0).name).toBe('Pack p_no_name');
   });
 
+  it('treats a blank name as missing rather than listing an empty label', async () => {
+    // A whitespace-only name is present and a string, so only the `.trim()`
+    // check stops it becoming an unclickable blank row in the resource list.
+    const { agent, server } = makeAgent({
+      packsGet: () =>
+        Promise.resolve({
+          data: [{ id: 'p_blank', name: '   ' }],
+          error: null,
+          status: 200,
+        }),
+    });
+    registerResources(agent);
+    const template = templateByName(server, 'pack');
+    const result = await (
+      template.resourceTemplate.listCallback as () => Promise<{
+        resources: Array<{ uri: string; name: string }>;
+      }>
+    )();
+    expect(nth(result.resources, 0).name).toBe('Pack p_blank');
+  });
+
   it('skips entries without a string id', async () => {
     const { agent, server } = makeAgent({
       packsGet: () =>
@@ -325,6 +346,27 @@ describe('U9 trip list provider', () => {
     expect(nth(result.resources, 0).name).toBe('JMT 2026');
     expect(nth(result.resources, 1).name).toBe('Wind River Range');
     expect(nth(result.resources, 2).name).toBe('Trip t_three');
+  });
+
+  it('treats blank name and destination as missing', async () => {
+    // Both fields are strings here, so the two `.trim()` checks are the only
+    // thing between a whitespace value and a blank row in the resource list.
+    const { agent, server } = makeAgent({
+      tripsGet: () =>
+        Promise.resolve({
+          data: [{ id: 't_blank', name: '  ', destination: '\t' }],
+          error: null,
+          status: 200,
+        }),
+    });
+    registerResources(agent);
+    const template = templateByName(server, 'trip');
+    const result = await (
+      template.resourceTemplate.listCallback as () => Promise<{
+        resources: Array<{ uri: string; name: string }>;
+      }>
+    )();
+    expect(nth(result.resources, 0).name).toBe('Trip t_blank');
   });
 
   it('returns empty array on API error (no propagation)', async () => {

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -85,6 +85,28 @@ describe('previewForLog', () => {
     circular.self = circular;
     expect(() => previewForLog(circular)).not.toThrow();
   });
+
+  // The two "must not fail a tool call" guards. `safeJsonStringify` is
+  // circular-safe, so neither is reachable through circular input — the test
+  // above passes without either guard existing.
+  it('returns the marker when serialising throws', () => {
+    // A throwing `toJSON` is the one input that still escapes
+    // safe-stable-stringify, so this is what actually exercises the catch.
+    const hostile = {
+      toJSON() {
+        throw new Error('nope');
+      },
+    };
+
+    expect(previewForLog(hostile)).toBe('[unserializable]');
+  });
+
+  it('returns the marker when serialising yields no string', () => {
+    // A bare function stringifies to `undefined`, not a string — without the
+    // isString check the scrubber would then run against a non-string.
+    expect(previewForLog(() => {})).toBe('[unserializable]');
+    expect(previewForLog(undefined)).toBe('[unserializable]');
+  });
 });
 
 describe('argKeysOf', () => {
@@ -171,6 +193,67 @@ describe('ReviewTelemetry', () => {
       expect(line?.level).toBe('error');
       expect(line?.json.errorCode).toBe('handler_threw');
       expect(line?.json.preview).toContain('kaboom');
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it('logs a non-Error throw without losing the value', () => {
+    // `throw 'string'` is legal JS and reaches the same arm, where the
+    // `instanceof Error` check decides whether `.message` exists to read.
+    const cap = captureLogs();
+    try {
+      new ReviewTelemetry('session:abc').toolCall({
+        toolName: 'packrat_broken',
+        durationMs: 5,
+        args: {},
+        thrown: 'bare string failure',
+      });
+      const line = cap.lines.find((l) => l.json.msg === 'mcp.tool.call');
+      expect(line?.level).toBe('error');
+      expect(line?.json.errorCode).toBe('handler_threw');
+      expect(line?.json.preview).toContain('bare string failure');
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it('reports zero chars when content is not an array', () => {
+    // A malformed result must still produce a log line — the char counter and
+    // the preview picker both guard the shape, and telemetry may not throw.
+    const cap = captureLogs();
+    try {
+      new ReviewTelemetry('session:abc').toolCall({
+        toolName: 'packrat_list_packs',
+        durationMs: 10,
+        args: {},
+        result: { content: undefined, structuredContent: { data: 'from structured' } },
+      });
+      const line = cap.lines.find((l) => l.json.msg === 'mcp.tool.call');
+      expect(line?.json.resultChars).toBe(0);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it('counts only blocks that carry text', () => {
+    const cap = captureLogs();
+    try {
+      new ReviewTelemetry('session:abc').toolCall({
+        toolName: 'packrat_list_packs',
+        durationMs: 10,
+        args: {},
+        // An image block has no `text`, so it contributes nothing rather than
+        // making the total NaN.
+        result: {
+          content: [
+            { type: 'text', text: '12345' },
+            { type: 'image', data: 'base64…' },
+          ],
+        },
+      });
+      const line = cap.lines.find((l) => l.json.msg === 'mcp.tool.call');
+      expect(line?.json.resultChars).toBe(5);
     } finally {
       cap.restore();
     }

--- a/packages/mcp/src/__tests__/tools-admin.test.ts
+++ b/packages/mcp/src/__tests__/tools-admin.test.ts
@@ -509,6 +509,45 @@ describe('admin auditOutcome failure branch (accept then API 500)', () => {
   });
 });
 
+// The analytics tools reshape their result into `{ data: { items } }` to match
+// their declared outputSchema, so unlike the tools that hand the promise
+// straight to `call`, their failure arm is a separate branch. Untested, a failed
+// fetch could read as "no activity" rather than an error.
+describe('admin analytics failure branches', () => {
+  it('packrat_admin_analytics_activity surfaces an error rather than empty items', async () => {
+    const { agent, server } = hMakeAgent({ apiFail: true });
+    registerAdminTools(agent);
+    const result = await hGetToolHandler(server, 'packrat_admin_analytics_activity')(
+      {},
+      hMakeExtra(),
+    );
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent?.error as { code: string }).code).toBe('api_error');
+  });
+
+  it('packrat_admin_analytics_pack_breakdown surfaces an error rather than empty items', async () => {
+    const { agent, server } = hMakeAgent({ apiFail: true });
+    registerAdminTools(agent);
+    const result = await hGetToolHandler(server, 'packrat_admin_analytics_pack_breakdown')(
+      {},
+      hMakeExtra(),
+    );
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent?.error as { code: string }).code).toBe('api_error');
+  });
+
+  it('packrat_admin_analytics_growth surfaces an error rather than empty items', async () => {
+    const { agent, server } = hMakeAgent({ apiFail: true });
+    registerAdminTools(agent);
+    const result = await hGetToolHandler(server, 'packrat_admin_analytics_growth')(
+      { period: 'week', range: 4 },
+      hMakeExtra(),
+    );
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent?.error as { code: string }).code).toBe('api_error');
+  });
+});
+
 describe('admin audit context — getAuditContext present branch', () => {
   it('uses the agent-provided audit context when getAuditContext is defined', async () => {
     const { agent, server, calls } = hMakeAgent({ resolve: { action: 'cancel' } });

--- a/packages/mcp/src/__tests__/tools-packs.test.ts
+++ b/packages/mcp/src/__tests__/tools-packs.test.ts
@@ -637,4 +637,22 @@ describe('packs error paths — apiFail returns structured error', () => {
     expect(typeof code).toBe('string');
     expect((code as string).length).toBeGreaterThan(0);
   });
+
+  it('list_pack_items surfaces an error envelope instead of an empty list', async () => {
+    // This tool does not hand the promise straight to `call` — it inspects the
+    // result so it can normalise the API's bare array into the `{ data,
+    // nextOffset }` envelope its outputSchema declares. The failure branch is
+    // therefore its own code path, and without it a failed fetch could look
+    // like a pack that simply has no items.
+    const { agent, server } = makeAgent({ apiFail: true });
+    registerPackTools(agent);
+    const result = await getToolHandler(server, 'packrat_list_pack_items')(
+      { pack_id: 'p_abc123' },
+      makeExtra(),
+    );
+    expect(result.isError).toBe(true);
+    const code = errorCodeOf(result.structuredContent);
+    expect(typeof code).toBe('string');
+    expect((code as string).length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Description

The last regression keeping `Coverage Ratchet` red on `development`:

```
❌  packages/mcp — REGRESSION:
     branches: 98.38% → 97.21%
```

Unlike the `packages/api` gap (#2755), this one is not traceable to a single commit — it was spread across five files, and every uncovered branch turned out to be an error or malformed-input path. Ten tests, each pinning a guard whose absence would show up as a *wrong* result rather than a crash:

| File | Branches | What was uncovered |
|---|---|---|
| `telemetry.ts` | 78.12% → 94.87% | both `previewForLog` markers, a non-Error `throw`, non-array content, a block with no `text` |
| `tools/admin.ts` | 93.44% → 98.50% | the three analytics tools' failure arms |
| `tools/packs.ts` | 95.65% → 97.91% | `list_pack_items` failure arm |
| `client.ts` | 97.50% → 98.75% | `extractErrorMessage` on an unserialisable body |
| `resources.ts` | 97.53% → 97.56% | whitespace-only pack name / trip name+destination |

Two findings worth the reviewer's attention:

**The existing circular-input test did not cover what it looks like it covers.** `previewForLog`'s `catch` is unreachable through circular input because `safeJsonStringify` is configured circular-safe — the old test passes with both guards deleted. A throwing `toJSON` is the one input that still escapes it; I verified that against the real `safeJsonStringify` before writing the assertion.

**The analytics/`list_pack_items` tools reshape their results** into the `{ data: { items } }` envelope their `outputSchema` declares, instead of handing the promise straight to `call`. That makes their failure arm a genuinely separate code path — and untested, a failed fetch reads as "no activity" or "a pack with no items" rather than an error.

**Two arms left uncovered on purpose:** `resources.ts:169` and `:182` (`return fallback` in `packName`/`tripName`). The list providers `.filter()` on `isString(id)` before calling those helpers, so the arms are unreachable defensive code — hitting them would mean calling the private helper directly, which tests the test rather than the app.

## Type of change

- [x] ♻️ Refactor / code improvement (test coverage)

## Area(s) affected

- [x] `packages/mcp`

## Testing

- [x] `bun test:mcp` — **1380 passed**, 37 files (was 1370)
- [x] `bun check:coverage` — mcp now reports **"coverage improved"**, not a regression:
      `branches: 98.38% → 98.79%`, `lines: 98.87% → 99.86%`
- [x] `bun check-types` — clean
- [x] `bunx biome check` on all five files — clean
- [x] `bun lint:weak-assertions` — zero hits in the changed files

Unlike #2755, mcp's v8 instrumentation works locally, so the ratchet result above is a real local verification rather than a CI-only claim.

## Pre-merge checklist

- [x] `bun check-types` passes with no errors
- [x] Added / updated unit tests
- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits
- [ ] Database migration included (n/a)
- [ ] Feature flag added (n/a — test coverage)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed, unserializable, or unexpected error responses so failures return clear error results instead of appearing as empty data.
  * Blank names and destinations now fall back to generated labels when displaying packs and trips.
  * Telemetry more accurately records unexpected failures and counts text content in results.

* **Tests**
  * Added coverage for error handling, fallback labels, analytics failures, and telemetry edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->