### PR TITLE
fix(expo): answer the assistant's pack tools and drop the hiking assumption

### DIFF
--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -201,16 +201,36 @@ export default function AIChat() {
     if (enableLocalAI && aiMode === 'local' && isLocalReady) {
       const model = getLocalModel();
       if (model) {
-        let systemPrompt = `You are PackRat AI, a helpful assistant for hikers and outdoor enthusiasts.
-      You help users manage their hiking packs and gear efficiently using ultralight principles.
+        let systemPrompt = `You are PackRat AI, a helpful trip planning and packing assistant.
+      You help users plan trips of any kind and manage their packs and gear — city and
+      business travel, beach trips, camping, hiking and backpacking, climbing, water sports,
+      skiing and winter trips, desert trips, and anything else they are packing for.
+      You have deep outdoor and ultralight backpacking expertise, but never assume that is
+      the trip the user is asking about.
 
       Guidelines:
-      - Focus on ultralight hiking principles when appropriate
+      - Treat the trip type and activity as an INPUT you learn from the user, their pack, or
+        the conversation — never as a default. Do not assume a trip is a hike or a
+        backpacking trip, and do not recommend tents, sleeping bags, sleeping pads or other
+        backcountry gear unless the user's actual trip calls for them.
+      - When the trip type or activity is ambiguous, either give advice that holds across
+        trip types, or ask ONE brief clarifying question before recommending specific gear.
+        Ask at most one question — never interrogate the user with a list of questions.
+      - Apply ultralight principles and multi-purpose gear when the trip really is
+        backpacking, hiking, or another carry-everything activity — there they matter a lot.
+        For travel where weight is not the binding constraint, prioritise what does matter,
+        such as documents, electronics, dress code, and airline restrictions.
       - For beginners, emphasize safety and comfort over weight savings
       - Always consider weather conditions in your recommendations
-      - Suggest multi-purpose items to reduce pack weight
       - Be concise but helpful in your responses
       - Use tools proactively to provide accurate, up-to-date information
+      - When the user refers to one of their packs by name (for example "my Japan Trip
+        pack"), call listUserPacks to resolve that name to a pack id first, then pass that id
+        to getPackDetails or addItemToPack. Never invent or guess a pack id, and never tell
+        the user a pack does not exist without checking listUserPacks.
+      - After addItemToPack succeeds, confirm what you added in one short sentence, including
+        the quantity and which pack. If it fails, say what went wrong instead of implying the
+        item was added.
 
       Context:
       - User id is ${userId}

--- a/apps/expo/app/(app)/ai-chat.tsx
+++ b/apps/expo/app/(app)/ai-chat.tsx
@@ -3,6 +3,7 @@ import { clientEnvs } from '@packrat/env/expo-client';
 import { Button } from '@packrat/ui/src/button';
 import { ActivityIndicator } from '@packrat/ui/src/loading-indicator';
 import { Text } from '@packrat/ui/src/text';
+import * as Sentry from '@sentry/react-native';
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -33,8 +34,16 @@ import { createLocalTools } from 'expo-app/features/ai/lib/tools';
 import { useSpeedUnit } from 'expo-app/features/auth/hooks/useSpeedUnit';
 import { useTemperatureUnit } from 'expo-app/features/auth/hooks/useTemperatureUnit';
 import { useWeightUnit } from 'expo-app/features/auth/hooks/useWeightUnit';
+import { useCreatePackItem } from 'expo-app/features/packs/hooks/useCreatePackItem';
 import { getPackItems, packItemsStore } from 'expo-app/features/packs/store/packItems';
 import { packsStore } from 'expo-app/features/packs/store/packs';
+import {
+  type AddItemToPackInput,
+  describeAddedItem,
+  type ListUserPacksInput,
+  listUserPacksFromStore,
+  prepareAddItemToPack,
+} from 'expo-app/features/packs/utils/chatPackTools';
 import { useActiveLocation } from 'expo-app/features/weather/hooks';
 import type { WeatherLocation } from 'expo-app/features/weather/types';
 import { useFeatureFlag } from 'expo-app/hooks/useFeatureFlags';
@@ -94,6 +103,7 @@ export default function AIChat() {
   const aiMode = useAtomValue(aiModeAtom);
   const modelStatus = useAtomValue(localModelStatusAtom);
   const enableLocalAI = useFeatureFlag('enableLocalAI');
+  const createPackItem = useCreatePackItem();
 
   const context = React.useMemo(
     () => ({
@@ -283,6 +293,81 @@ export default function AIChat() {
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     onToolCall: ({ toolCall }) => {
       if (toolCall.dynamic) return;
+
+      // listUserPacks and addItemToPack are declared server-side with no
+      // `execute`, so they are answered here. Every branch must call
+      // addToolOutput exactly once: an unanswered tool call never resolves,
+      // sendAutomaticallyWhen never fires, and the turn hangs (issue #2710).
+      if (toolCall.toolName === 'listUserPacks') {
+        const { nameQuery } = toolCall.input as ListUserPacksInput;
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'listUserPacks called',
+          level: 'info',
+          data: { nameQuery },
+        });
+        try {
+          addToolOutput({
+            tool: 'listUserPacks',
+            toolCallId: toolCall.toolCallId,
+            output: listUserPacksFromStore({ packs: packsStore.get(), nameQuery }),
+          });
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'listUserPacks' },
+            extra: { nameQuery },
+          });
+          addToolOutput({
+            tool: 'listUserPacks',
+            toolCallId: toolCall.toolCallId,
+            output: { success: false, error: 'Failed to list packs on this device' },
+          });
+        }
+        return;
+      }
+
+      if (toolCall.toolName === 'addItemToPack') {
+        const input = toolCall.input as AddItemToPackInput;
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'addItemToPack called',
+          level: 'info',
+          data: { packId: input.packId, name: input.name },
+        });
+        try {
+          const prepared = prepareAddItemToPack({ packs: packsStore.get(), input });
+          if (!prepared.success) {
+            addToolOutput({
+              tool: 'addItemToPack',
+              toolCallId: toolCall.toolCallId,
+              output: prepared,
+            });
+            return;
+          }
+
+          const { pack, itemData } = prepared.data;
+          // Same write path the UI uses: writes to the local store first and
+          // syncs outward through the outbox, so this works offline.
+          const created = createPackItem({ packId: pack.id, itemData });
+
+          addToolOutput({
+            tool: 'addItemToPack',
+            toolCallId: toolCall.toolCallId,
+            output: { success: true, data: describeAddedItem({ pack, item: created }) },
+          });
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'addItemToPack' },
+            extra: { packId: input.packId, itemName: input.name },
+          });
+          addToolOutput({
+            tool: 'addItemToPack',
+            toolCallId: toolCall.toolCallId,
+            output: { success: false, error: 'Failed to add the item on this device' },
+          });
+        }
+        return;
+      }
 
       if (toolCall.toolName === 'getPackDetails') {
         const { packId } = toolCall.input as { packId: string };

--- a/apps/expo/features/ai/lib/tools.ts
+++ b/apps/expo/features/ai/lib/tools.ts
@@ -17,6 +17,12 @@ import { tool } from 'ai';
 import { getPackItems, packItemsStore } from 'expo-app/features/packs/store/packItems';
 import { packsStore } from 'expo-app/features/packs/store/packs';
 import {
+  describeAddedItem,
+  listUserPacksFromStore,
+  prepareAddItemToPack,
+} from 'expo-app/features/packs/utils/chatPackTools';
+import { writePackItem } from 'expo-app/features/packs/utils/writePackItem';
+import {
   formatWeatherData,
   getWeatherData,
   searchLocations,
@@ -43,6 +49,42 @@ function trimCatalogItem(item: unknown) {
 
 export function createLocalTools(isAuthenticated = false) {
   const allTools = {
+    listUserPacks: tool({
+      description:
+        "List the signed-in user's own packs. Use this to resolve a pack the user mentions by " +
+        'NAME (for example "my Japan Trip pack") into a pack id before calling getPackDetails ' +
+        'or addItemToPack. Returns id, name, category and description for each match.',
+      inputSchema: z.object({
+        nameQuery: z
+          .string()
+          .optional()
+          .describe(
+            'Optional fuzzy/partial name filter, matched case-insensitively against the pack ' +
+              "name. Omit to list all of the user's packs.",
+          ),
+      }),
+      execute: async ({ nameQuery }) => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'listUserPacks called',
+          level: 'info',
+          data: { nameQuery },
+        });
+        try {
+          return listUserPacksFromStore({ packs: packsStore.get(), nameQuery });
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'listUserPacks' },
+            extra: { nameQuery },
+          });
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to list packs',
+          };
+        }
+      },
+    }),
+
     getPackDetails: tool({
       description:
         'Get detailed information about a specific pack including all its items, weights, and categories. Use this when the user asks about a specific pack by name or ID.',
@@ -91,6 +133,63 @@ export function createLocalTools(isAuthenticated = false) {
           return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to get pack details',
+          };
+        }
+      },
+    }),
+
+    addItemToPack: tool({
+      description:
+        "Add a gear item to one of the signed-in user's packs. Resolve the pack by name with " +
+        'listUserPacks first and pass its id — never guess a pack id. Prefer filling in weight ' +
+        "and category from a catalog lookup so the pack's weight totals stay meaningful.",
+      inputSchema: z.object({
+        packId: z.string().describe('The ID of the pack to add the item to'),
+        name: z.string().describe('Name of the item, for example "Merino T-Shirt"'),
+        weight: z
+          .number()
+          .optional()
+          .describe('Weight of a single unit, in the unit given by weightUnit'),
+        weightUnit: z
+          .enum(['g', 'kg', 'oz', 'lb'])
+          .optional()
+          .describe('Unit for weight. Required when weight is given.'),
+        quantity: z.number().int().min(1).optional().describe('How many to add. Defaults to 1.'),
+        category: z
+          .string()
+          .optional()
+          .describe('Category such as clothing, shelter, cooking, electronics'),
+        consumable: z.boolean().optional().describe('True for items used up on the trip'),
+        worn: z.boolean().optional().describe('True for items worn rather than carried'),
+        notes: z.string().optional().describe('Optional free-text notes'),
+        catalogItemId: z
+          .string()
+          .optional()
+          .describe('Catalog item id, when chosen from the catalog'),
+      }),
+      execute: async (input) => {
+        Sentry.addBreadcrumb({
+          category: 'ai.tool',
+          message: 'addItemToPack called',
+          level: 'info',
+          data: { packId: input.packId, name: input.name },
+        });
+        try {
+          const prepared = prepareAddItemToPack({ packs: packsStore.get(), input });
+          if (!prepared.success) return prepared;
+
+          const { pack, itemData } = prepared.data;
+          const created = writePackItem({ packId: pack.id, itemData });
+
+          return { success: true, data: describeAddedItem({ pack, item: created }) };
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: { feature: 'ai.tool', action: 'addItemToPack' },
+            extra: { packId: input.packId, itemName: input.name },
+          });
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to add the item',
           };
         }
       },
@@ -383,8 +482,8 @@ export function createLocalTools(isAuthenticated = false) {
   }
 
   // For unauthenticated users, only expose tools that operate on local device data.
-  const { getPackDetails, getPackItemDetails } = allTools;
-  return { getPackDetails, getPackItemDetails };
+  const { listUserPacks, getPackDetails, getPackItemDetails, addItemToPack } = allTools;
+  return { listUserPacks, getPackDetails, getPackItemDetails, addItemToPack };
 }
 
 export type LocalTools = ReturnType<typeof createLocalTools>;

--- a/apps/expo/features/packs/hooks/useCreatePackItem.ts
+++ b/apps/expo/features/packs/hooks/useCreatePackItem.ts
@@ -1,37 +1,11 @@
-import { packItemsStore, packsStore } from 'expo-app/features/packs/store';
-import { obs } from 'expo-app/lib/store';
-import { nanoid } from 'nanoid';
 import { useCallback } from 'react';
-import { recordPackWeight } from '../store/packWeightHistory';
-import type { PackItem, PackItemInput } from '../types';
+import type { PackItemInput } from '../types';
+import { writePackItem } from '../utils/writePackItem';
 
 export function useCreatePackItem() {
   const createPackItem = useCallback(
-    ({ packId, itemData }: { packId: string; itemData: PackItemInput }) => {
-      const id = nanoid();
-
-      const newItem: PackItem = {
-        id,
-        name: itemData.name,
-        description: itemData.description ?? undefined,
-        weight: itemData.weight,
-        weightUnit: itemData.weightUnit,
-        quantity: itemData.quantity,
-        category: itemData.category || 'general',
-        consumable: itemData.consumable,
-        worn: itemData.worn,
-        notes: itemData.notes,
-        image: itemData.image,
-        catalogItemId: itemData.catalogItemId,
-        packId,
-        isAIGenerated: false,
-        deleted: false,
-      };
-
-      obs({ store: packItemsStore, id: id }).set(newItem);
-      obs({ store: packsStore, id: packId }).localUpdatedAt.set(new Date().toISOString());
-      recordPackWeight(packId);
-    },
+    ({ packId, itemData }: { packId: string; itemData: PackItemInput }) =>
+      writePackItem({ packId, itemData }),
     [],
   );
 

--- a/apps/expo/features/packs/utils/__tests__/buildNewPackItem.test.ts
+++ b/apps/expo/features/packs/utils/__tests__/buildNewPackItem.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { PackItemInput } from '../../types';
+import { buildNewPackItem } from '../buildNewPackItem';
+
+const baseInput: PackItemInput = {
+  name: 'T-shirt',
+  weight: 150,
+  weightUnit: 'g',
+  quantity: 1,
+  category: 'clothing',
+  consumable: false,
+  worn: false,
+};
+
+describe('buildNewPackItem', () => {
+  it('builds a live, non-AI-flagged item bound to the pack', () => {
+    const item = buildNewPackItem({ id: 'i1', packId: 'p1', itemData: baseInput });
+
+    expect(item).toEqual({
+      id: 'i1',
+      packId: 'p1',
+      name: 'T-shirt',
+      description: undefined,
+      weight: 150,
+      weightUnit: 'g',
+      quantity: 1,
+      category: 'clothing',
+      consumable: false,
+      worn: false,
+      notes: undefined,
+      image: undefined,
+      catalogItemId: undefined,
+      isAIGenerated: false,
+      deleted: false,
+    });
+  });
+
+  it('falls back to the general category when none is given', () => {
+    for (const category of [undefined, '']) {
+      const item = buildNewPackItem({
+        id: 'i1',
+        packId: 'p1',
+        itemData: { ...baseInput, category },
+      });
+      expect(item.category).toBe('general');
+    }
+  });
+
+  it('normalises a null description to undefined', () => {
+    const item = buildNewPackItem({
+      id: 'i1',
+      packId: 'p1',
+      itemData: { ...baseInput, description: null },
+    });
+
+    expect(item.description).toBeUndefined();
+  });
+
+  it('carries optional fields through when supplied', () => {
+    const item = buildNewPackItem({
+      id: 'i1',
+      packId: 'p1',
+      itemData: {
+        ...baseInput,
+        description: 'base layer',
+        notes: 'packed last',
+        image: 'cached.jpg',
+        catalogItemId: 42,
+        consumable: true,
+        worn: true,
+        quantity: 3,
+      },
+    });
+
+    expect(item).toMatchObject({
+      description: 'base layer',
+      notes: 'packed last',
+      image: 'cached.jpg',
+      catalogItemId: 42,
+      consumable: true,
+      worn: true,
+      quantity: 3,
+    });
+  });
+});

--- a/apps/expo/features/packs/utils/__tests__/chatPackTools.test.ts
+++ b/apps/expo/features/packs/utils/__tests__/chatPackTools.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type { PackInStore } from '../../types';
+import {
+  buildPackItemInput,
+  describeAddedItem,
+  listUserPacksFromStore,
+  prepareAddItemToPack,
+} from '../chatPackTools';
+
+function storePack(overrides: { id: string; name: string; deleted?: boolean }): PackInStore {
+  return {
+    description: null,
+    category: 'hiking',
+    isPublic: false,
+    image: null,
+    tags: null,
+    deleted: false,
+    ...overrides,
+  };
+}
+
+const japanTrip = storePack({ id: 'p1', name: 'Japan Trip' });
+
+const packs: Record<string, PackInStore> = {
+  p1: japanTrip,
+  p2: storePack({ id: 'p2', name: 'Ski Weekend' }),
+  p3: storePack({ id: 'p3', name: 'Archived Trip', deleted: true }),
+};
+
+describe('listUserPacksFromStore', () => {
+  it('resolves the pack named in the prompt to its id', () => {
+    const result = listUserPacksFromStore({ packs, nameQuery: 'Japan Trip' });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('lists live packs when no query is given', () => {
+    const result = listUserPacksFromStore({ packs });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((p) => p.name)).toEqual(['Japan Trip', 'Ski Weekend']);
+  });
+
+  it('succeeds with an empty list rather than failing when nothing matches', () => {
+    // A miss must not read as a tool error — the model should be able to fall
+    // back to listing everything and asking the user.
+    const result = listUserPacksFromStore({ packs, nameQuery: 'Patagonia' });
+
+    expect(result).toEqual({ success: true, data: [] });
+  });
+});
+
+describe('buildPackItemInput', () => {
+  it('defaults weight, unit, quantity and category when the model omits them', () => {
+    expect(buildPackItemInput({ packId: 'p1', name: 'T-shirt' })).toEqual({
+      name: 'T-shirt',
+      weight: 0,
+      weightUnit: 'g',
+      quantity: 1,
+      category: 'general',
+      consumable: false,
+      worn: false,
+      notes: undefined,
+      catalogItemId: undefined,
+    });
+  });
+
+  it('keeps the values the model supplied', () => {
+    const result = buildPackItemInput({
+      packId: 'p1',
+      name: 'Merino T-Shirt',
+      weight: 150,
+      weightUnit: 'g',
+      quantity: 2,
+      category: 'clothing',
+      consumable: false,
+      worn: true,
+      notes: 'base layer',
+      catalogItemId: '42',
+    });
+
+    expect(result).toMatchObject({
+      name: 'Merino T-Shirt',
+      weight: 150,
+      weightUnit: 'g',
+      quantity: 2,
+      category: 'clothing',
+      worn: true,
+      notes: 'base layer',
+      catalogItemId: 42,
+    });
+  });
+
+  it('trims the item name and a whitespace-only category', () => {
+    const result = buildPackItemInput({ packId: 'p1', name: '  T-shirt  ', category: '   ' });
+
+    expect(result.name).toBe('T-shirt');
+    expect(result.category).toBe('general');
+  });
+
+  it('clamps a zero, negative or fractional quantity to a whole count of at least one', () => {
+    expect(buildPackItemInput({ packId: 'p1', name: 'x', quantity: 0 }).quantity).toBe(1);
+    expect(buildPackItemInput({ packId: 'p1', name: 'x', quantity: -3 }).quantity).toBe(1);
+    expect(buildPackItemInput({ packId: 'p1', name: 'x', quantity: 2.7 }).quantity).toBe(2);
+  });
+
+  it('drops a non-numeric catalog id instead of failing the add', () => {
+    expect(
+      buildPackItemInput({ packId: 'p1', name: 'x', catalogItemId: 'not-an-id' }).catalogItemId,
+    ).toBeUndefined();
+    expect(
+      buildPackItemInput({ packId: 'p1', name: 'x', catalogItemId: '0' }).catalogItemId,
+    ).toBeUndefined();
+  });
+});
+
+describe('prepareAddItemToPack', () => {
+  it('resolves the pack and builds the item payload', () => {
+    const result = prepareAddItemToPack({
+      packs,
+      input: { packId: 'p1', name: 'T-shirt', weight: 150, weightUnit: 'g' },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.pack.name).toBe('Japan Trip');
+    expect(result.data.itemData).toMatchObject({ name: 'T-shirt', weight: 150, quantity: 1 });
+  });
+
+  it('refuses an unknown pack id and tells the model how to recover', () => {
+    const result = prepareAddItemToPack({ packs, input: { packId: 'nope', name: 'T-shirt' } });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain('listUserPacks');
+  });
+
+  it('refuses a soft-deleted pack', () => {
+    const result = prepareAddItemToPack({ packs, input: { packId: 'p3', name: 'T-shirt' } });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain('p3');
+  });
+
+  it('refuses a blank item name', () => {
+    const result = prepareAddItemToPack({ packs, input: { packId: 'p1', name: '   ' } });
+
+    expect(result).toEqual({ success: false, error: 'An item name is required.' });
+  });
+});
+
+describe('describeAddedItem', () => {
+  it('names the pack back so the assistant can confirm the write', () => {
+    const result = describeAddedItem({
+      pack: japanTrip,
+      item: {
+        id: 'i1',
+        name: 'T-shirt',
+        quantity: 1,
+        weight: 150,
+        weightUnit: 'g',
+        category: 'clothing',
+      },
+    });
+
+    expect(result).toEqual({
+      packId: 'p1',
+      packName: 'Japan Trip',
+      item: {
+        id: 'i1',
+        name: 'T-shirt',
+        quantity: 1,
+        weight: 150,
+        weightUnit: 'g',
+        category: 'clothing',
+      },
+    });
+  });
+});

--- a/apps/expo/features/packs/utils/__tests__/matchPacksByName.test.ts
+++ b/apps/expo/features/packs/utils/__tests__/matchPacksByName.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { matchPacksByName, type PackNameCandidate } from '../matchPacksByName';
+
+function pack(overrides: Partial<PackNameCandidate> & { id: string; name: string }) {
+  return {
+    description: null,
+    category: 'hiking',
+    isPublic: false,
+    tags: null,
+    deleted: false,
+    ...overrides,
+  } satisfies PackNameCandidate;
+}
+
+const japanTrip = pack({ id: 'p1', name: 'Japan Trip', category: 'travel' });
+const skiWeekend = pack({ id: 'p2', name: 'Ski Weekend', category: 'skiing' });
+const deleted = pack({ id: 'p3', name: 'Old Japan Trip', deleted: true });
+
+describe('matchPacksByName', () => {
+  // The exact scenario from issue #2710: the pack is on screen, the user names
+  // it exactly, and the assistant claimed it did not exist.
+  it('finds a pack by its exact name', () => {
+    const result = matchPacksByName({ packs: [japanTrip, skiWeekend], nameQuery: 'Japan Trip' });
+
+    expect(result).toEqual([
+      {
+        id: 'p1',
+        name: 'Japan Trip',
+        description: null,
+        category: 'travel',
+        isPublic: false,
+        tags: null,
+      },
+    ]);
+  });
+
+  it('matches case-insensitively', () => {
+    for (const query of ['japan trip', 'JAPAN TRIP', 'jApAn TrIp']) {
+      const result = matchPacksByName({ packs: [japanTrip, skiWeekend], nameQuery: query });
+      expect(result.map((p) => p.id)).toEqual(['p1']);
+    }
+  });
+
+  it('ignores surrounding whitespace in the query', () => {
+    const result = matchPacksByName({
+      packs: [japanTrip, skiWeekend],
+      nameQuery: '   Japan Trip \n ',
+    });
+
+    expect(result.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('collapses internal whitespace runs on both sides', () => {
+    const doubleSpaced = pack({ id: 'p4', name: 'Japan   Trip' });
+
+    expect(matchPacksByName({ packs: [doubleSpaced], nameQuery: 'Japan Trip' })).toHaveLength(1);
+    expect(matchPacksByName({ packs: [japanTrip], nameQuery: 'Japan   Trip' })).toHaveLength(1);
+  });
+
+  it('matches on a partial name so "japan" finds "Japan Trip"', () => {
+    const result = matchPacksByName({ packs: [japanTrip, skiWeekend], nameQuery: 'japan' });
+    expect(result.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('matches a substring that is not a prefix', () => {
+    const result = matchPacksByName({ packs: [japanTrip, skiWeekend], nameQuery: 'trip' });
+    expect(result.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('ranks exact over prefix over substring', () => {
+    const exact = pack({ id: 'exact', name: 'Japan' });
+    const prefix = pack({ id: 'prefix', name: 'Japan Trip' });
+    const substring = pack({ id: 'substring', name: 'Trip to Japan' });
+
+    const result = matchPacksByName({
+      packs: [substring, prefix, exact],
+      nameQuery: 'Japan',
+    });
+
+    expect(result.map((p) => p.id)).toEqual(['exact', 'prefix', 'substring']);
+  });
+
+  it('excludes soft-deleted packs even on an exact name match', () => {
+    const result = matchPacksByName({ packs: [deleted], nameQuery: 'Old Japan Trip' });
+    expect(result).toEqual([]);
+  });
+
+  it('excludes soft-deleted packs when listing everything', () => {
+    const result = matchPacksByName({ packs: [japanTrip, skiWeekend, deleted] });
+    expect(result.map((p) => p.id)).toEqual(['p1', 'p2']);
+  });
+
+  it('lists every live pack when the query is omitted, empty or whitespace', () => {
+    for (const nameQuery of [undefined, null, '', '   ']) {
+      const result = matchPacksByName({ packs: [japanTrip, skiWeekend], nameQuery });
+      expect(result.map((p) => p.id)).toEqual(['p1', 'p2']);
+    }
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    const result = matchPacksByName({ packs: [japanTrip, skiWeekend], nameQuery: 'Patagonia' });
+    expect(result).toEqual([]);
+  });
+
+  it('returns every pack that matches a shared substring', () => {
+    const alpha = pack({ id: 'a', name: 'Japan Trip 2024' });
+    const beta = pack({ id: 'b', name: 'Japan Trip 2025' });
+
+    const result = matchPacksByName({ packs: [alpha, beta], nameQuery: 'Japan Trip' });
+    expect(result.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('handles an empty pack list', () => {
+    expect(matchPacksByName({ packs: [], nameQuery: 'Japan Trip' })).toEqual([]);
+  });
+});

--- a/apps/expo/features/packs/utils/buildNewPackItem.ts
+++ b/apps/expo/features/packs/utils/buildNewPackItem.ts
@@ -1,0 +1,38 @@
+/**
+ * Builds the `PackItem` record written to the local store.
+ *
+ * Pure and separate from `writePackItem` so the defaulting rules — the ones
+ * that decide what an assistant-added item actually looks like in the pack —
+ * are unit testable without a Legend-State store.
+ */
+
+import type { PackItem, PackItemInput } from '../types';
+
+export function buildNewPackItem({
+  id,
+  packId,
+  itemData,
+}: {
+  id: string;
+  packId: string;
+  itemData: PackItemInput;
+}): PackItem {
+  return {
+    id,
+    name: itemData.name,
+    description: itemData.description ?? undefined,
+    weight: itemData.weight,
+    weightUnit: itemData.weightUnit,
+    quantity: itemData.quantity,
+    // An empty category would render as a blank group header in the pack list.
+    category: itemData.category || 'general',
+    consumable: itemData.consumable,
+    worn: itemData.worn,
+    notes: itemData.notes,
+    image: itemData.image,
+    catalogItemId: itemData.catalogItemId,
+    packId,
+    isAIGenerated: false,
+    deleted: false,
+  };
+}

--- a/apps/expo/features/packs/utils/chatPackTools.ts
+++ b/apps/expo/features/packs/utils/chatPackTools.ts
@@ -1,0 +1,132 @@
+/**
+ * Client-side implementations of the assistant's pack tools.
+ *
+ * `listUserPacks` and `addItemToPack` are declared on the server with no
+ * `execute` (packages/api/src/utils/ai/tools.ts), so the model's call is
+ * streamed to the client and answered from the local store. That keeps reads
+ * consistent with what the user is looking at and keeps writes on the offline
+ * path — but it means every client MUST answer both tools. A client that
+ * ignores one leaves the tool call unresolved and the turn stalls forever.
+ *
+ * These helpers hold the shared logic so the remote chat screen and the
+ * on-device toolset cannot drift apart.
+ */
+
+import type { PackInStore, PackItem, PackItemInput, WeightUnit } from '../types';
+import { matchPacksByName, type PackMatchSummary } from './matchPacksByName';
+
+export type ListUserPacksInput = { nameQuery?: string | null };
+
+export type AddItemToPackInput = {
+  packId: string;
+  name: string;
+  weight?: number;
+  weightUnit?: WeightUnit;
+  quantity?: number;
+  category?: string;
+  consumable?: boolean;
+  worn?: boolean;
+  notes?: string;
+  catalogItemId?: string;
+};
+
+export type ToolResult<T> = { success: true; data: T } | { success: false; error: string };
+
+/**
+ * Resolve a pack name the user mentioned into pack ids the model can use.
+ *
+ * Returns the match list rather than a single pack: when a query matches
+ * several packs the model needs to see them all so it can ask which one,
+ * instead of silently writing to the wrong pack.
+ */
+export function listUserPacksFromStore({
+  packs,
+  nameQuery,
+}: {
+  packs: Record<string, PackInStore>;
+  nameQuery?: string | null;
+}): ToolResult<PackMatchSummary[]> {
+  const matches = matchPacksByName({ packs: Object.values(packs), nameQuery });
+  return { success: true, data: matches };
+}
+
+/** Catalog ids in the API are numeric; a non-numeric value from the model means
+ *  "not a catalog item" rather than an error. */
+function parseCatalogItemId(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Build the pack-item payload for an `addItemToPack` call.
+ *
+ * Split out from the write itself so the defaulting rules are unit testable
+ * without a Legend-State store: an item added without a weight silently
+ * degrades the pack totals the app exists to compute, so the defaults matter.
+ */
+export function buildPackItemInput(input: AddItemToPackInput): PackItemInput {
+  return {
+    name: input.name.trim(),
+    weight: input.weight ?? 0,
+    weightUnit: input.weightUnit ?? 'g',
+    quantity: Math.max(1, Math.floor(input.quantity ?? 1)),
+    category: input.category?.trim() || 'general',
+    consumable: input.consumable ?? false,
+    worn: input.worn ?? false,
+    notes: input.notes,
+    catalogItemId: parseCatalogItemId(input.catalogItemId),
+  };
+}
+
+/**
+ * Validate an `addItemToPack` call against the local store and produce the item
+ * payload to write.
+ *
+ * Returns the resolved pack so the caller can confirm which pack it wrote to —
+ * the assistant has to name the pack back to the user, and it must not claim
+ * success against a pack that is deleted or was never there.
+ */
+export function prepareAddItemToPack({
+  packs,
+  input,
+}: {
+  packs: Record<string, PackInStore>;
+  input: AddItemToPackInput;
+}): ToolResult<{ pack: PackInStore; itemData: PackItemInput }> {
+  const pack = packs[input.packId];
+  if (!pack || pack.deleted) {
+    return {
+      success: false,
+      error: `No pack with id ${input.packId} exists on this device. Call listUserPacks to resolve the pack by name first.`,
+    };
+  }
+
+  if (!input.name.trim()) {
+    return { success: false, error: 'An item name is required.' };
+  }
+
+  return { success: true, data: { pack, itemData: buildPackItemInput(input) } };
+}
+
+/** Shape the tool output the model sees after a successful add. */
+export function describeAddedItem({
+  pack,
+  item,
+}: {
+  pack: PackInStore;
+  item: Pick<PackItem, 'id' | 'name' | 'quantity' | 'weight' | 'weightUnit' | 'category'>;
+}) {
+  return {
+    packId: pack.id,
+    packName: pack.name,
+    item: {
+      id: item.id,
+      name: item.name,
+      quantity: item.quantity,
+      weight: item.weight,
+      weightUnit: item.weightUnit,
+      category: item.category,
+    },
+  };
+}

--- a/apps/expo/features/packs/utils/matchPacksByName.ts
+++ b/apps/expo/features/packs/utils/matchPacksByName.ts
@@ -64,7 +64,7 @@ function normalize(value: string): string {
  * "Japan Trip", asking for "Japan" resolves to the pack actually called
  * "Japan" rather than whichever happens to sort first.
  */
-function matchRank(packName: string, query: string): number | null {
+function matchRank({ packName, query }: { packName: string; query: string }): number | null {
   const name = normalize(packName);
   if (name === query) return 0;
   if (name.startsWith(query)) return 1;
@@ -96,7 +96,7 @@ export function matchPacksByName({
     query === ''
       ? live
       : live
-          .map((pack) => ({ pack, rank: matchRank(pack.name, query) }))
+          .map((pack) => ({ pack, rank: matchRank({ packName: pack.name, query }) }))
           .filter(
             (scored): scored is { pack: PackNameCandidate; rank: number } => scored.rank !== null,
           )

--- a/apps/expo/features/packs/utils/matchPacksByName.ts
+++ b/apps/expo/features/packs/utils/matchPacksByName.ts
@@ -40,7 +40,21 @@ export type PackMatchSummary = {
  * model echoes back whatever the user typed.
  */
 function normalize(value: string): string {
-  return value.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+  // Whitespace-split without a regex literal: apps/expo does not depend on
+  // magic-regexp, and the repo's no-raw-regex rule flags the `/\s+/` form.
+  // Any run of whitespace collapses to one space, so "Japan  Trip" === "Japan Trip".
+  const words: string[] = [];
+  let word = '';
+  for (const char of value) {
+    if (char.trim() === '') {
+      if (word) words.push(word);
+      word = '';
+    } else {
+      word += char;
+    }
+  }
+  if (word) words.push(word);
+  return words.join(' ').toLocaleLowerCase();
 }
 
 /**

--- a/apps/expo/features/packs/utils/matchPacksByName.ts
+++ b/apps/expo/features/packs/utils/matchPacksByName.ts
@@ -1,0 +1,100 @@
+/**
+ * Name matching for the assistant's `listUserPacks` tool.
+ *
+ * The model resolves a pack the user mentioned by NAME ("my Japan Trip pack")
+ * into a pack id before it can read or write that pack, so this is the step
+ * that decides whether "add a T-shirt to my Japan Trip pack" works at all.
+ *
+ * Kept pure and free of store/Legend-State imports so it can be unit tested
+ * directly, and so the Swift and TypeScript clients can be held to the same
+ * matching rules (see `LocalChatPackTools.listPacks` in apps/swift).
+ */
+
+/** The subset of a pack this module needs. Structural so both the Legend-State
+ *  store record and test fixtures satisfy it without casts. */
+export type PackNameCandidate = {
+  id: string;
+  name: string;
+  description?: string | null;
+  category?: string | null;
+  isPublic?: boolean;
+  tags?: string[] | null;
+  deleted?: boolean;
+};
+
+export type PackMatchSummary = {
+  id: string;
+  name: string;
+  description?: string | null;
+  category?: string | null;
+  isPublic?: boolean;
+  tags?: string[] | null;
+};
+
+/**
+ * Normalise for comparison: strip surrounding whitespace, collapse internal
+ * runs of whitespace, and case-fold.
+ *
+ * Collapsing internal runs matters because pack names are free text typed on a
+ * phone — "Japan  Trip" and "Japan Trip" are the same pack to the user, and the
+ * model echoes back whatever the user typed.
+ */
+function normalize(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+/**
+ * Rank a pack against a query. Lower is better; `null` means no match.
+ *
+ * Exact beats prefix beats substring so that when a user has both "Japan" and
+ * "Japan Trip", asking for "Japan" resolves to the pack actually called
+ * "Japan" rather than whichever happens to sort first.
+ */
+function matchRank(packName: string, query: string): number | null {
+  const name = normalize(packName);
+  if (name === query) return 0;
+  if (name.startsWith(query)) return 1;
+  if (name.includes(query)) return 2;
+  return null;
+}
+
+/**
+ * Find the user's packs matching an optional name query.
+ *
+ * Soft-deleted packs are always excluded — they are not visible on the Packs
+ * screen, so the assistant must not offer to add items to them.
+ *
+ * An empty, whitespace-only or omitted query lists every live pack, which is
+ * what lets the model answer "what packs do I have?" and recover when its first
+ * guess at a name misses.
+ */
+export function matchPacksByName({
+  packs,
+  nameQuery,
+}: {
+  packs: PackNameCandidate[];
+  nameQuery?: string | null;
+}): PackMatchSummary[] {
+  const live = packs.filter((pack) => !pack.deleted);
+  const query = normalize(nameQuery ?? '');
+
+  const selected =
+    query === ''
+      ? live
+      : live
+          .map((pack) => ({ pack, rank: matchRank(pack.name, query) }))
+          .filter(
+            (scored): scored is { pack: PackNameCandidate; rank: number } => scored.rank !== null,
+          )
+          .sort((a, b) => a.rank - b.rank)
+          .map((scored) => scored.pack);
+
+  return selected.map((pack) => ({
+    id: pack.id,
+    name: pack.name,
+    description: pack.description,
+    category: pack.category,
+    isPublic: pack.isPublic,
+    tags: pack.tags,
+  }));
+}

--- a/apps/expo/features/packs/utils/writePackItem.ts
+++ b/apps/expo/features/packs/utils/writePackItem.ts
@@ -2,10 +2,13 @@
  * Store-level pack-item write.
  *
  * Extracted from `useCreatePackItem` so non-React callers — the assistant's
- * on-device `addItemToPack` tool — write through exactly the same path as a
- * user tapping "add item": local store first, outbox sync outward, pack weight
- * history recorded. Duplicating this logic is how an assistant-added item ends
- * up missing from weight totals or from the sync queue.
+ * `addItemToPack` tool — write through exactly the same path as a user tapping
+ * "add item": local store first, outbox sync outward, pack weight history
+ * recorded. Duplicating this logic is how an assistant-added item ends up
+ * missing from weight totals or from the sync queue.
+ *
+ * The record itself is built by `buildNewPackItem`, which is pure and covered
+ * by tests; this file is only the store effect around it.
  */
 
 import { packItemsStore, packsStore } from 'expo-app/features/packs/store';
@@ -13,6 +16,7 @@ import { recordPackWeight } from 'expo-app/features/packs/store/packWeightHistor
 import { obs } from 'expo-app/lib/store';
 import { nanoid } from 'nanoid';
 import type { PackItem, PackItemInput } from '../types';
+import { buildNewPackItem } from './buildNewPackItem';
 
 export function writePackItem({
   packId,
@@ -21,27 +25,9 @@ export function writePackItem({
   packId: string;
   itemData: PackItemInput;
 }): PackItem {
-  const id = nanoid();
+  const newItem = buildNewPackItem({ id: nanoid(), packId, itemData });
 
-  const newItem: PackItem = {
-    id,
-    name: itemData.name,
-    description: itemData.description ?? undefined,
-    weight: itemData.weight,
-    weightUnit: itemData.weightUnit,
-    quantity: itemData.quantity,
-    category: itemData.category || 'general',
-    consumable: itemData.consumable,
-    worn: itemData.worn,
-    notes: itemData.notes,
-    image: itemData.image,
-    catalogItemId: itemData.catalogItemId,
-    packId,
-    isAIGenerated: false,
-    deleted: false,
-  };
-
-  obs({ store: packItemsStore, id }).set(newItem);
+  obs({ store: packItemsStore, id: newItem.id }).set(newItem);
   obs({ store: packsStore, id: packId }).localUpdatedAt.set(new Date().toISOString());
   recordPackWeight(packId);
 

--- a/apps/expo/features/packs/utils/writePackItem.ts
+++ b/apps/expo/features/packs/utils/writePackItem.ts
@@ -1,0 +1,49 @@
+/**
+ * Store-level pack-item write.
+ *
+ * Extracted from `useCreatePackItem` so non-React callers — the assistant's
+ * on-device `addItemToPack` tool — write through exactly the same path as a
+ * user tapping "add item": local store first, outbox sync outward, pack weight
+ * history recorded. Duplicating this logic is how an assistant-added item ends
+ * up missing from weight totals or from the sync queue.
+ */
+
+import { packItemsStore, packsStore } from 'expo-app/features/packs/store';
+import { recordPackWeight } from 'expo-app/features/packs/store/packWeightHistory';
+import { obs } from 'expo-app/lib/store';
+import { nanoid } from 'nanoid';
+import type { PackItem, PackItemInput } from '../types';
+
+export function writePackItem({
+  packId,
+  itemData,
+}: {
+  packId: string;
+  itemData: PackItemInput;
+}): PackItem {
+  const id = nanoid();
+
+  const newItem: PackItem = {
+    id,
+    name: itemData.name,
+    description: itemData.description ?? undefined,
+    weight: itemData.weight,
+    weightUnit: itemData.weightUnit,
+    quantity: itemData.quantity,
+    category: itemData.category || 'general',
+    consumable: itemData.consumable,
+    worn: itemData.worn,
+    notes: itemData.notes,
+    image: itemData.image,
+    catalogItemId: itemData.catalogItemId,
+    packId,
+    isAIGenerated: false,
+    deleted: false,
+  };
+
+  obs({ store: packItemsStore, id }).set(newItem);
+  obs({ store: packsStore, id: packId }).localUpdatedAt.set(new Date().toISOString());
+  recordPackWeight(packId);
+
+  return newItem;
+}

--- a/apps/expo/vitest.config.ts
+++ b/apps/expo/vitest.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
         '**/*.web.ts', // Browser-API files; not runnable in Node vitest environment
         // React Native file-system APIs — not runnable in Node environment
         'features/**/utils/uploadImage.ts',
+        // Legend-State store effect; the record it writes is built by
+        // buildNewPackItem.ts, which is pure and covered.
+        'features/**/utils/writePackItem.ts',
         // UI helper files that depend on React Native navigation primitives
         'features/**/utils/getPackDetailOptions.tsx',
         'features/**/utils/getPackItemDetailOptions.tsx',


### PR DESCRIPTION
Fixes #2710 and #2709 for the Expo app.

Both issues were fixed server-side on 2026-08-12, but only half of #2710's fix
ever shipped: the server declares `listUserPacks` and `addItemToPack` as
**client-executed** tools, and the Expo app never implemented them.

## #2710 — "I couldn't find a pack named 'Japan Trip'"

`ai-chat.tsx`'s `onToolCall` handler answered only `getPackDetails` and
`getPackItemDetails`, and fell through silently on anything else. So
`listUserPacks` received no response at all, the model could never resolve a
pack name to an id, and it told the user the pack did not exist — while the
pack was sitting right there in the local store.

This answers both tools from the local stores, so name resolution and
add-to-pack work, including for packs that have not synced yet.

## #2709 — assistant assumes every trip is a hike

The server prompt was corrected in August. The Expo app carries a **second**
system prompt for on-device mode that still opened with "assistant for hikers …
using ultralight principles". Cloud is the default mode, so most users already
had the fixed behaviour; anyone switching to on-device AI did not. That prompt
now matches the server's: treat trip type as an input, and ask one clarifying
question when it is ambiguous.

## Notes

- Pack matching is extracted to `matchPacksByName` and the write path to
  `buildNewPackItem` / `writePackItem`, so `useCreatePackItem` and the assistant
  build the same record rather than two divergent ones.
- 26 new tests covering name matching, the tool handlers, and the item record.
  Full Expo suite: 422 passing. Typecheck and Biome clean.
- A Swift banner commit that shared the original triage branch is deliberately
  **not** included — the sync/settings work removes that banner entirely, so it
  would have conflicted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI chat can now list your gear packs and add items directly to a selected pack.
  - Pack searches support flexible matching, including partial names and different capitalization or spacing.
  - Added support for item details such as quantity, category, weight, notes, and consumable or worn status.
  - Pack-item updates can be handled locally, supporting offline use.

- **Improvements**
  - AI responses provide clearer confirmations and guidance when a pack or item name is invalid.
  - Trip-related chat assistance now handles a wider range of trip types and ambiguous activities more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->