### PR TITLE
docs(swift): note the Expo counterpart in DeepLink

### DIFF
--- a/apps/swift/Sources/PackRat/Navigation/DeepLink.swift
+++ b/apps/swift/Sources/PackRat/Navigation/DeepLink.swift
@@ -7,6 +7,9 @@ import Foundation
 /// link into navigation state is a separate concern — `AuthGateView` just
 /// hands the URL to `DeepLink.parse(_:)` and logs (for now) until product
 /// signals which destinations matter most.
+///
+/// The Expo (Android) client parses the same `packrat://` scheme, so any
+/// case added here has a counterpart there — see `docs/parity.md`.
 public enum DeepLink: Equatable {
     case home
     case pack(id: String)


### PR DESCRIPTION
## Description

**End-to-end verification of the parity system merged in #2760.**

A comment-only change to `apps/swift` — no behaviour, no risk — whose sole purpose is to exercise the one path that could not be tested before merge: does a `follow:` declaration actually open the counterpart issue on merge?

The comment itself is genuine and worth keeping: `DeepLink` parses `packrat://`, which the Expo client also parses, so it points the next person at `docs/parity.md`.

**Expected on merge:** an issue titled `[parity/expo] docs(swift): note the Expo counterpart in DeepLink`, labelled `parity` + `parity:expo`, linking back to this PR.

## Type of change

- [x] 📝 Documentation update

## Area(s) affected

- [x] Swift app — iOS + macOS (`apps/swift`)

## Parity

- [x] follow: expo verifying the counterpart-issue automation end to end

## Testing

- [x] Manually tested on iOS (Swift)

Comment-only change; no runtime behaviour touched.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation clarifying deep-link scheme compatibility with the Android client.
  - Referenced the parity documentation for corresponding deep-link cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->