### PR TITLE
fix(parity): trigger the record job on push, not pull_request_target

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -14,15 +14,19 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: ['**']
-  pull_request_target:
-    types: [closed]
-    branches: ['**']
+  # `record` runs on push, not `pull_request_target`. A pull_request_target
+  # trigger is only registered from the workflow file already on the base
+  # branch when the PR was opened, so it silently never fires for PRs opened
+  # before this workflow landed — and it is awkward for forks besides. Push
+  # always fires, and the merge commit carries the PR number we need.
+  push:
+    branches: [development, main]
 
 concurrency:
   # Keyed by event so an edit-triggered `validate` can never cancel an
   # in-flight `record`. `record` is the only thing that opens the counterpart
   # issue and it has no retry, so a cancelled run drops the gap silently.
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -64,10 +68,9 @@ jobs:
 
   record:
     name: Open counterpart issue
-    # pull_request_target so the token can write issues on merge. Safe here:
-    # nothing from the PR head is checked out or executed — only the base repo's
-    # own scripts run, against the PR body as data.
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
+    # Runs from the merged commit on the base branch, so only base-repo code
+    # executes; the PR body is fetched via the API and treated purely as data.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,35 +78,46 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Collect changed files
+      # A direct push carries no PR, so this resolves to empty and every
+      # later step no-ops — only merges of a PR record anything.
+      - name: Resolve the PR this push merged
+        id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+          pr=$(gh api "repos/$REPO/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null)][0].number // empty')
+          if [[ -z "$pr" ]]; then
+            echo 'No merged PR for this commit — nothing to record.'
+            echo 'number=' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+          gh api "repos/$REPO/pulls/$pr" > /tmp/pr.json
+          jq -r '.title'     /tmp/pr.json > /tmp/pr-title.txt
+          jq -r '.body // ""' /tmp/pr.json > /tmp/pr-body.txt
+          jq -r '.html_url'  /tmp/pr.json > /tmp/pr-url.txt
+          jq -r '.user.login' /tmp/pr.json > /tmp/pr-author.txt
+          gh api "repos/$REPO/pulls/$pr/files" --paginate \
             --jq '.[].filename' > /tmp/changed-files.txt
 
-      - name: Write PR body
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: printf '%s' "$PR_BODY" > /tmp/pr-body.txt
-
       - name: Open counterpart issue if one is owed
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
+          PR_TITLE="$(cat /tmp/pr-title.txt)" \
+          PR_URL="$(cat /tmp/pr-url.txt)" \
+          PR_AUTHOR="$(cat /tmp/pr-author.txt)" \
           bun scripts/parity/open-counterpart-issue.ts \
             --body /tmp/pr-body.txt \
             --changed-files /tmp/changed-files.txt

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -50,6 +50,14 @@ The issue carries a hidden `parity-of:#<pr>` marker, so a re-run or a re-merge
 finds the existing one instead of opening a duplicate. Duplicate gap issues
 would train everyone to ignore the label, which would end the scheme.
 
+The `record` job triggers on **push to `development`/`main`**, resolving the
+merged PR from the pushed commit. It deliberately does not use
+`pull_request_target`: that trigger is only registered from the workflow file
+already present on the base branch when the PR was opened, so it silently
+never fires for PRs opened before the workflow landed — which is exactly how
+the first end-to-end test failed (PR #2761). A push trigger always fires and
+works for forks too. A direct push with no associated PR simply no-ops.
+
 ## Where the gap list lives
 
 **The open `parity` issues _are_ the gap list.** There is no document to
@@ -112,6 +120,6 @@ kinks, the other adopts
 | `scripts/lint/check-parity-declaration.ts` | Validates it; blocks the PR |
 | `scripts/parity/open-counterpart-issue.ts` | Opens the counterpart issue on merge |
 | `scripts/lint/parity-gaps-report.ts` | Renders the derived gap report |
-| `.github/workflows/parity.yml` | Validate on PR, record on merge |
+| `.github/workflows/parity.yml` | Validate on PR; record on push to a base branch |
 | `.github/workflows/parity-report.yml` | Weekly + on-close report refresh |
 | `docs/parity/OPEN-GAPS.md` | Generated snapshot — do not edit |


### PR DESCRIPTION
## Description

**The end-to-end test found a real bug. This fixes it.**

PR #2761 declared `follow: expo`, passed validation, and merged — and no counterpart issue appeared. No `pull_request_target` run fired at all.

**Cause:** `pull_request_target` is registered from the workflow file *already on the base branch when the PR is opened*. #2761 was opened 71 seconds after #2760 merged, so GitHub had no such trigger registered for it. This isn't just a first-run quirk — the same hole hits any PR opened before the workflow landed, and `pull_request_target` is awkward for forks besides.

**Fix:** `record` now triggers on **push to `development`/`main`** and resolves the merged PR from the pushed commit. Always registered, fork-safe, and still only base-repo code executes — the PR body is fetched via the API and treated as data. A direct push with no associated PR no-ops.

**The record logic was never wrong.** Replaying #2761's real body and file list through it produces exactly the intended result:

```
landedOn:   [ "swift" ]
directive:  {"kind":"follow","target":"expo","note":"verifying the counterpart-issue automation end to end"}
violations: []
WOULD CREATE: [parity/expo] docs(swift): note the Expo counterpart in DeepLink
WITH LABELS : parity, parity:expo
```

Only the trigger was broken.

## Type of change

- [x] 🐛 Bug fix
- [x] 🔧 CI / configuration change

## Area(s) affected

- [x] CI / CD (`.github/`)

## Parity

- [x] n/a: CI workflow and docs only — touches neither client

## Testing

- [x] Workflow structure validated (triggers, job conditions, step order parsed and asserted)
- [x] Record logic replayed against #2761's real PR body and file list

Merging this PR is itself the next test: it lands on `development` via push, so the `record` job will run for the first time. It should no-op cleanly here (this PR declares `n/a`), which verifies the trigger fires without creating a spurious issue.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parity workflow documentation to reflect recording on pushes to the development and main branches.
  * Documented support for forked pull requests and cases where no associated pull request is found.
  * Clarified the workflow’s validation and recording responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->