### PR TITLE
docs: make the iOS/Android platform split load itself

### DIFF
--- a/.claude/rules/platform-split.md
+++ b/.claude/rules/platform-split.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "apps/expo/**"
+  - "apps/swift/**"
+---
+
+# Mobile is split by platform
+
+| Platform | Codebase | Validate on |
+|---|---|---|
+| iOS, watchOS, macOS | `apps/swift` (SwiftUI) | Apple simulator or device |
+| Android | `apps/expo` (React Native) | Android emulator or device |
+
+**iOS is not shipped from Expo.** The Expo iOS target still builds but no store
+build comes from it, so a change in `apps/expo` is validated on Android and a
+change in `apps/swift` is validated on an Apple device.
+
+Launching an iOS simulator to check Expo work tests a platform the project does
+not ship — and an Android emulator says nothing about the Swift app.
+
+The two apps are separate codebases, so a feature in one does not appear in the
+other by itself. Declare the gap in the PR's `## Parity` section
+(`docs/parity.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,264 +1,41 @@
-# PackRat Monorepo
+# PackRat — instructions for coding agents
 
-Outdoor adventure planning platform — helps users plan trips, manage packing lists, discover destinations, and get weather/activity suggestions.
+This file is the shared instruction set for coding agents that read
+`AGENTS.md`. Claude Code reads [`CLAUDE.md`](./CLAUDE.md), which carries the
+full conventions; this file states the rules an agent most needs before it
+builds, tests, or launches anything.
 
-**Live**: https://packrat.world (alpha)
+<!-- Keep this file short and keep it a summary. It was previously a full copy
+of CLAUDE.md; the two drifted, and the platform split below reached one file
+and not the other. If a convention belongs to every agent, put it in CLAUDE.md
+and summarise it here. -->
 
-## Architecture
+## Mobile is split by platform
 
-Bun workspace monorepo with three apps and two packages:
+**Each mobile platform has its own codebase.**
 
-| Workspace | Stack | Purpose |
+| Platform | Codebase | Validate on |
 |---|---|---|
-| `apps/expo` | React Native 0.83 / Expo 55 / Expo Router 55 | Mobile app (iOS + Android) |
-| `apps/guides` | Next.js 15 / React 19 / Radix UI / Shadcn | Content/guides site |
-| `apps/landing` | Next.js 15 / React 19 / Framer Motion | Marketing site |
-| `packages/api` | Elysia on Cloudflare Workers / Drizzle ORM / Neon PostgreSQL | Backend API |
-| `packages/ui` | `@expo/ui` wrappers + plain RN components | Shared UI components |
+| iOS, watchOS, macOS | `apps/swift` (SwiftUI) | Apple simulator or device |
+| Android | `apps/expo` (React Native) | Android emulator or device |
 
-### Infrastructure
+**iOS is not shipped from Expo.** The Expo project still has an iOS target and
+it still builds, but no store build comes from it, so a bug that only
+reproduces there is not worth fixing.
 
-- **Compute**: Cloudflare Workers (API), Durable Objects (containers)
-- **Database**: Neon PostgreSQL with Drizzle ORM, pgvector (1536-dim embeddings)
-- **Storage**: 3 R2 buckets — `packrat-bucket`, `packrat-scrapy-bucket`, `packrat-guides`
-- **Queues**: `packrat-etl-queue` (serial), `packrat-embeddings-queue` (batch 100)
-- **AI**: Vercel AI SDK (OpenAI, Google, Perplexity, Workers AI), on-device llama.rn
-- **Monitoring**: Sentry (mobile + API)
-- **Mobile CI/CD**: EAS Build (dev, preview, e2e, production profiles)
+Consequences worth holding in mind:
 
-## Commands
+- A change in `apps/expo` is validated on **Android**. Launching an iOS
+  simulator to check it tests a platform the project does not ship.
+- A change in `apps/swift` is validated on an **Apple** simulator or device. An
+  Android emulator says nothing about it.
+- An iOS bug report is fixed in `apps/swift`, not in `apps/expo`.
+- EAS builds Android. iOS/watchOS/macOS ship via Xcode and App Store Connect.
 
-```bash
-# Dev
-bun expo              # Start Expo dev server
-bun ios               # iOS simulator
-bun android           # Android emulator
-bun api               # API dev server (wrangler)
-cd apps/guides && bun dev   # Guides dev server
-cd apps/landing && bun dev  # Landing dev server
+Each app directory carries its own `AGENTS.md` and `CLAUDE.md` with that
+platform's specifics.
 
-# Quality
-bun lint              # Biome check --write (auto-fix)
-bun format            # Biome format --write
-bun check             # Biome check (no auto-fix, CI mode)
-bun check-types       # tsc --noEmit
+## Everything else
 
-# Testing — see docs/testing.md for the full policy
-bun test:api:unit       # API unit tests (Vitest, Node env, deps mocked)
-bun test:expo           # Expo pure-TS tests (Vitest)
-bun test:mcp            # MCP package tests
-bun test:scripts        # scripts/lint analyzer tests (ratchet + assertion lint)
-bun check:coverage      # Coverage ratchet — fails on regression vs coverage-baselines.json
-bun lint:weak-assertions # Catches assertion-free tests, bare .toBeDefined / .toHaveBeenCalled, oversized snapshots
-
-# Dependencies
-bun install           # Install all workspaces (takes 120s+, never cancel)
-bun check:deps        # manypkg check for workspace version consistency
-bun fix:deps          # manypkg auto-fix dependency issues
-
-# Versioning
-bun bump              # Bump monorepo version
-```
-
-## Testing Policy (summary)
-
-PackRat enforces coverage at two layers: each workspace's `vitest.config.ts` declares per-metric thresholds (mostly 95%+; `packages/units` 100%, `packages/{analytics,overpass}` 80%), and a **coverage ratchet** (`bun check:coverage` against `coverage-baselines.json`) blocks any PR that lowers a workspace's coverage. An **assertion-strength lint** (`bun lint:weak-assertions`) flags coverage-theater patterns (assertion-free tests, bare `.toBeDefined()`, bare `.toHaveBeenCalled()`, oversized snapshots). `packages/api` integration tests still run (`api-tests.yml`) but are not coverage-counted — V8 instrumentation is unsupported under the Cloudflare Workers pool. Full policy and patterns: **`docs/testing.md`**.
-
-## Code Style
-
-Enforced by **Biome 2.0** via lefthook pre-commit hook:
-
-- 2 spaces, 100 char line width, single quotes
-- Alphabetical imports (Biome auto-sorts)
-- No `any` — use proper TypeScript types or `unknown`
-- Strict null checks enabled, no unchecked indexed access
-
-### TypeScript conventions
-
-- **Never use `as unknown as T`** to bypass type errors. Widen the function signature with a generic constraint, extract a structural type, or fix the source type instead. Each `as unknown` site is a place where two types don't agree and TS is being silenced — over time these become load-bearing lies. The only legitimate use is documenting a known third-party type bug inline with a precise assertion and a comment naming the bug.
-- **Prefer `Object.freeze({...} as const)` over bare `as const`** for narrow-typed lookup tables, column whitelists, and config dictionaries. `as const` is type-only; `Object.freeze` adds runtime immutability so accidental mutations fail loudly rather than silently corrupting state. Keep the inner `as const` for literal-type narrowing.
-
-## Conventions
-
-### API (packages/api)
-
-- Routes are built with **Elysia** on Cloudflare Workers using `new Elysia({ prefix: '...' }).use(plugin)`
-- OpenAPI docs generated by `@elysiajs/openapi`; typed client uses Eden Treaty (`@elysiajs/eden`)
-- Validation schemas live in `src/schemas/`
-- Business logic goes in `src/services/`, not in route handlers
-- Middleware in `src/middleware/` — use the `authPlugin` macro (`isAuthenticated: true`) for protected routes
-- Soft deletes for all user content
-- async/await everywhere (no raw promises)
-
-#### DB query projection discipline (cost-bearing)
-
-Neon compute + egress are metered. Every column a query SELECTs is bytes shipped from Postgres to the Worker. The `catalog_items` and `pack_items` tables carry a 1536-dim `vector(1536)` embedding column plus large JSONB content (`reviews`, `qas`, `faqs`, `techs`, `links`, `variants`) — a single unprojected row is ~50-100 KB. List endpoints, ETL `.returning()`, and embedding-backfill scans that don't project columns can ship multi-MB payloads per call.
-
-**Default to explicit projection at every Drizzle query touching `catalog_items` or `pack_items`:**
-
-- `db.select({ id: t.id, name: t.name, ... }).from(t)` — never `db.select().from(t)` for these tables
-- `db.query.X.findFirst/findMany({ columns: { id: true, ... } })` — never `with: { foo: true }` shortcut, never an unfiltered `findMany`
-- `.returning({ id: t.id, ... })` — never `.returning()` no-arg on insert/update/upsert against these tables
-- For exclude patterns (drop only embedding, keep everything else), use `getTableColumns(t)` destructure: `const { embedding: _, ...cols } = getTableColumns(catalogItems); db.select({ ...cols, similarity }).from(catalogItems)` — Drizzle docs document this as the official exclude shape
-- **Don't mix `true` and `false` in a `columns:` object** — Drizzle silently ignores the `false` entries when any `true` is present. Either all-whitelist or all-exclude.
-
-When a service or compute helper reads only a subset of columns, extract a projection type in `packages/db/src/projections.ts` (derive from the inferred schema via `Pick<>` so column renames propagate) and make the consumer generic over it. Lets callers narrow DB queries without `as unknown` casts at the boundary. Existing types there: `PackItemForWeights`, `PackForWeights`, `PackItemForBreakdown`, `PackForBreakdown`.
-
-**Lint:** `bun packages/api/scripts/lint/no-unprojected-fat-table-queries.ts` (runs in CI) fails the build on new `SELECT *` / no-`columns:` / no-arg `.returning()` against the fat tables. Use the inline opt-out `// lint:allow-unprojected-fat-table reason: <text>` only when the full row is genuinely needed (e.g., embedding regen text, detail endpoint).
-
-### Mobile (apps/expo)
-
-Feature module structure:
-```
-features/{name}/
-├── components/    # UI components
-├── hooks/         # React Query hooks
-├── screens/       # Screen components
-├── types.ts       # TypeScript interfaces
-└── index.ts       # Public exports
-```
-
-- **Routing**: File-based via Expo Router in `app/(app)/`
-- **Styling**: NativeWind (Tailwind for RN) with CSS variable-based color system, manual dark mode toggle
-- **State**: Jotai for local state, TanStack React Query for server state, Legend State for reactive state
-- **Forms**: TanStack React Form
-- **Feature flags**: `apps/expo/config.ts` — `featureFlags` object, default new flags to `false`
-- **Animations**: React Native Reanimated 4
-- **E2E selectors**: Prefer stable `testID` values from `apps/expo/lib/testIds.ts` for Maestro and Playwright selectors. Add or extend app-controlled test IDs for important user actions and assertions instead of matching visible text. Use text selectors only when the surface is external or not app-controlled, such as Expo dev-client UI, native permission dialogs, or unavoidable system copy.
-
-### Web Apps (apps/guides, apps/landing, apps/trails)
-
-- Radix UI + Shadcn components, Tailwind CSS
-- TanStack React Query for data fetching
-- Zod for form validation
-
-### Monitoring (Sentry)
-
-All new code that performs async operations or calls external services must include Sentry instrumentation. Sentry is already initialised per-platform — you only need to import and call the helpers.
-
-**Expo / React Native** — import from `@sentry/react-native`:
-
-```ts
-import * as Sentry from '@sentry/react-native';
-
-// Before an async operation
-Sentry.addBreadcrumb({ category: 'feature', message: 'Action started', level: 'info', data: { ... } });
-
-// In every catch block — capture the original error, never a re-wrapped one
-} catch (error) {
-  Sentry.captureException(error, {
-    tags: { feature: 'myFeature', action: 'doThing' },
-    extra: { userId, relevantId },
-  });
-  throw error;
-}
-```
-
-- **Never wrap the root error** in `new Error(...)` before passing to `captureException` — that loses the original stack and context.
-- **Better Auth errors** (plain objects with `{ message, status, code }`) are not JS Errors. Use `toAuthError` from `expo-app/features/auth/lib/authErrors` to convert them into an `AuthClientError` that carries `status` and `code`. Capture and throw that — do not create a separate synthetic error for Sentry and another for throwing.
-- Include `httpStatus` and `errorCode` in `extra` for any HTTP error so they're searchable in Sentry.
-
-**API / Cloudflare Workers** — helpers from `@packrat/api/utils/sentry`. There are **three boundaries by where code runs** — match the tier to the situation instead of wrapping everything in try/catch:
-
-1. **Route handlers → do nothing.** Elysia's global `.onError` (`src/app.ts`) is the central sink: it reports unexpected errors (skips `VALIDATION`/`PARSE`/`NOT_FOUND`), tagged by the matched **route template** + `request_id`. Let errors propagate — don't add a try/catch *just* to report. Only catch in a route to **translate** an error into a specific response (and then it's a swallow — see tier 3).
-
-2. **Sub-operations you rethrow from → wrap in `record`.** Workflow `step.do` bodies, queue/cron consumers, and services called outside an Elysia request. It opens a Sentry span (OTel-semantic, Workers-native) **and** captures-with-context **and** rethrows:
-
-   ```ts
-   import { record } from '@packrat/api/utils/sentry';
-
-   await record({ operation: 'etl.processLogsBatch', extra: { jobId } }, async () => {
-     await db.insert(logs).values(rows);
-   });
-   ```
-
-3. **Catches that swallow → call `captureApiException`** (object signature). Fail-closed `return false`, best-effort metrics, per-item loops that continue, route catches that return an error response:
-
-   ```ts
-   } catch (error) {
-     captureApiException({ error, operation: 'verifyAdmin', extra: { userId } });
-     return false; // swallowed — nothing to rethrow
-   }
-   ```
-
-- Capture is **idempotent + deduped** (a marker is stamped on the error), so `record`/`captureApiException` + the outer boundary (`.onError`, `withSentry`, `instrumentWorkflowWithSentry`) never double-report — enrich-and-rethrow is always safe.
-- Every event in a request shares a **`request_id`** tag (`cf-ray`, set in `.onRequest`), echoed in the `X-Request-Id` response header — pivot on it to tie an `.onError` report to the granular `record`/`captureApiException` events. Sentry's automatic `trace_id` correlates them too.
-- Don't use raw `captureException` — the wrappers add operation context + console logging. Include `httpStatus`/`errorCode` in `extra` for HTTP errors; breadcrumb significant steps with `apiAddBreadcrumb`.
-- **Not** `@elysiajs/opentelemetry`: its Node OTel SDK doesn't run on workerd (BatchSpanProcessor, AsyncHooks). `record` gives the same `record(name, fn)` ergonomics on Sentry's Workers-native tracer.
-
-### API Client (`@packrat/api-client`)
-
-Use `createApiClient` from `@packrat/api-client` for all PackRat API calls in web apps. **Never write manual fetch wrappers for PackRat API endpoints.**
-
-```ts
-// apps/<name>/lib/apiClient.ts
-import { createApiClient } from '@packrat/api-client';
-import { clearTokens, clearUser, getAccessToken, getRefreshToken, setTokens } from './auth';
-
-export const apiClient = createApiClient({
-  baseUrl: typeof window !== 'undefined' ? window.location.origin : '',
-  auth: {
-    getAccessToken,
-    getRefreshToken,
-    onAccessTokenRefreshed: (token) => { /* persist new access token */ },
-    onRefreshTokenRefreshed: (token) => { /* persist new refresh token */ },
-    onNeedsReauth: () => { clearTokens(); clearUser(); },
-  },
-});
-```
-
-- `baseUrl` should be the same origin when routing through a CF Worker proxy (so rate limiting applies); use `EXPO_PUBLIC_API_URL` for the Expo app
-- `AuthHooks` wires your platform's token storage — the package is transport-only
-- The client handles 401 → refresh → retry automatically; `onNeedsReauth` fires only when refresh itself fails
-- Call via Treaty path syntax: `apiClient.auth.login.post(...)`, `apiClient.trails.search.get({ query: { q } })`
-- Responses are `{ data, error, status }` — check `if (error || !data)` before using `data`
-
-## Path Aliases
-
-Defined in root `tsconfig.json`:
-
-- `@packrat/api/*` → `packages/api/src/*`
-- `@packrat/ui/*` → `packages/ui/*`
-- `expo-app/*` → `apps/expo/*`
-- `guides-app/*` → `apps/guides/*`
-- `landing-app/*` → `apps/landing/*`
-- `nativewindui/*` → `apps/expo/components/ui/*`
-
-## Database
-
-- ORM: Drizzle (`packages/db/src/schema/` after the schema extraction)
-- Migrations: **always** Drizzle Kit (`drizzle-kit generate`) — never hand-written SQL
-- Embeddings: pgvector with 1536 dimensions
-
-### Migrations — HARD RULE
-
-**Do not hand-write SQL migrations.** Always use Drizzle Kit:
-
-1. Change the schema in `packages/api/src/db/schema.ts` or `packages/db/src/schema.ts` / `packages/db/src/schema/*.ts`, depending on where the table is owned.
-2. Run `bun run db:generate` from `packages/api/` or the matching package Drizzle command to emit the migration SQL.
-3. Keep the random migration filename that Drizzle Kit generates. Do not rename it.
-4. Review the generated SQL, snapshot, and journal entry for correctness.
-5. Commit both the schema change and the generated migration in the same PR.
-6. Run `bunx drizzle-kit check` from `packages/api/` before pushing when API migrations changed.
-
-Hand-written migrations get out of sync with the schema, drift across environments, and break the Better Auth / drizzle-zod / inferred-TS-types unified pipeline (PR #2414). If `drizzle-kit generate` produces a migration you disagree with, **fix the schema or the generator config** — do not edit the SQL by hand.
-
-If you find a migration in the repo that was hand-written (no `drizzle-kit` provenance), flag it in your PR description and regenerate from schema as a follow-up commit.
-
-## EAS Build Profiles
-
-| Profile | Use | Distribution |
-|---|---|---|
-| `development` | Dev client | Internal |
-| `preview` | QA testing | Internal (auto-increment) |
-| `e2e` | Maestro E2E tests | iOS Simulator / Android APK |
-| `production` | App Store / Play Store | Store (auto-increment) |
-
-## Common Issues
-
-- **Next.js build failures**: `apps/guides` and `apps/landing` may fail without internet (fetches remote data)
-- **Bun install hangs**: Normal — takes 120+ seconds. Never cancel mid-install.
-
-## Documented Solutions
-
-`docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+See [`CLAUDE.md`](./CLAUDE.md) for architecture, commands, code style, database
+and migration rules, feature gating, testing policy, and Sentry conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,13 @@ but it is not a shipping surface and is not worth fixing or validating.
 Launching an iOS simulator to check an Expo change tests a platform the project
 does not ship.
 
+Each mobile app carries its own `CLAUDE.md` (`apps/expo/CLAUDE.md`,
+`apps/swift/CLAUDE.md`) with that platform's build, validation and device
+gotchas. Those load automatically when an agent reads files in the directory,
+so platform-specific rules belong there rather than here. The same rules are
+also a path-scoped rule in `.claude/rules/platform-split.md`, which fires when
+a file under either app is opened.
+
 ### Infrastructure
 
 - **Compute**: Cloudflare Workers (API), Durable Objects (containers)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,33 @@ Outdoor adventure planning platform — helps users plan trips, manage packing l
 
 ## Architecture
 
-Bun workspace monorepo with three apps and two packages:
+Bun workspace monorepo. **Mobile is split by platform: iOS ships from
+`apps/swift`, Android ships from `apps/expo`.**
 
 | Workspace | Stack | Purpose |
 |---|---|---|
-| `apps/expo` | React Native 0.83 / Expo 55 / Expo Router 55 | Mobile app (iOS + Android) |
+| `apps/swift` | SwiftUI / SwiftData | **iOS app (and watchOS, macOS)** |
+| `apps/expo` | React Native 0.83 / Expo 55 / Expo Router 55 | **Android app** |
 | `apps/guides` | Next.js 15 / React 19 / Radix UI / Shadcn | Content/guides site |
 | `apps/landing` | Next.js 15 / React 19 / Framer Motion | Marketing site |
+| `apps/web` | Next.js / React | Web app |
+| `apps/admin` | Next.js / React | Admin console |
+| `apps/trails` | Next.js / React | Trails site |
 | `packages/api` | Elysia on Cloudflare Workers / Drizzle ORM / Neon PostgreSQL | Backend API |
 | `packages/ui` | `@expo/ui` wrappers + plain RN components | Shared UI components |
+
+### Platform split — read before testing mobile work
+
+iOS is **no longer shipped from Expo**. The Expo app's iOS target still builds,
+but it is not a shipping surface and is not worth fixing or validating.
+
+- Work in `apps/expo` is **Android** work — validate it on an Android emulator
+  or device, never an iOS simulator.
+- Work in `apps/swift` is **iOS/watchOS/macOS** work — validate it on an iOS
+  simulator or device.
+
+Launching an iOS simulator to check an Expo change tests a platform the project
+does not ship.
 
 ### Infrastructure
 
@@ -24,15 +42,16 @@ Bun workspace monorepo with three apps and two packages:
 - **Queues**: `packrat-etl-queue` (serial), `packrat-embeddings-queue` (batch 100)
 - **AI**: Vercel AI SDK (OpenAI, Google, Perplexity, Workers AI), on-device llama.rn
 - **Monitoring**: Sentry (mobile + API)
-- **Mobile CI/CD**: EAS Build (dev, preview, e2e, production profiles)
+- **Android CI/CD**: EAS Build (dev, preview, e2e, production profiles)
+- **iOS CI/CD**: Xcode + App Store Connect from `apps/swift`
 
 ## Commands
 
 ```bash
 # Dev
-bun expo              # Start Expo dev server
-bun ios               # iOS simulator
-bun android           # Android emulator
+bun expo              # Start Expo dev server (Android)
+bun android           # Android emulator — the Expo app's shipping target
+bun ios               # Expo on iOS simulator — NOT a shipping target, see Platform split
 bun api               # API dev server (wrangler)
 cd apps/guides && bun dev   # Guides dev server
 cd apps/landing && bun dev  # Landing dev server
@@ -126,7 +145,7 @@ When a service or compute helper reads only a subset of columns, extract a proje
 
 **Lint:** `bun packages/api/scripts/lint/no-unprojected-fat-table-queries.ts` (runs in CI) fails the build on new `SELECT *` / no-`columns:` / no-arg `.returning()` against the fat tables. Use the inline opt-out `// lint:allow-unprojected-fat-table reason: <text>` only when the full row is genuinely needed (e.g., embedding regen text, detail endpoint).
 
-### Mobile (apps/expo)
+### Android (apps/expo)
 
 Feature module structure:
 ```
@@ -271,8 +290,11 @@ If you find a migration in the repo that was hand-written (no `drizzle-kit` prov
 |---|---|---|
 | `development` | Dev client | Internal |
 | `preview` | QA testing | Internal (auto-increment) |
-| `e2e` | Maestro E2E tests | iOS Simulator / Android APK |
-| `production` | App Store / Play Store | Store (auto-increment) |
+| `e2e` | Maestro E2E tests | Android APK |
+| `production` | Play Store | Store (auto-increment) |
+
+EAS builds the **Android** app. iOS/watchOS/macOS ship from `apps/swift` via
+Xcode and App Store Connect, not EAS.
 
 ## Common Issues
 

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/expo/CLAUDE.md
+++ b/apps/expo/CLAUDE.md
@@ -1,0 +1,45 @@
+# apps/expo — the Android app
+
+**This workspace ships Android. It does not ship iOS.**
+
+iOS, watchOS and macOS ship from `apps/swift` (SwiftUI). The Expo project still
+has an iOS target and it still builds, but it is not a shipping surface: no
+store build comes from it, and bugs that only reproduce there are not worth
+fixing.
+
+## Validate on Android
+
+Anything you change here is validated on an **Android emulator or device**:
+
+```bash
+bun android        # Android emulator — the shipping target
+bun expo           # Metro, then connect the Android dev client
+```
+
+Do not boot an iOS simulator to check a change made in this directory. A green
+run on iOS says nothing about what users get, and it costs a slow build to
+learn nothing. If you need to see an iOS behaviour, the code is in
+`apps/swift` — go there instead.
+
+`bun ios` still exists for the rare case of debugging shared JS in a second
+runtime. Treat a result from it as a hint, never as validation.
+
+## Android dev-client gotchas
+
+- The dev launcher **ignores `?url=` in a deep link**. Open the launcher, tap
+  the `exp://` field, type the dev-server URL, then tap Connect.
+- Emulators reach the host at `10.0.2.2`; a physical device needs the LAN IP
+  from `ipconfig getifaddr en0`. `adb reverse tcp:8081 tcp:8081` also works.
+- A fresh emulator can boot with **airplane mode on**, which makes the host
+  unreachable and looks exactly like a broken bundler.
+- On a cold emulator the dev client can ANR on first launch ("failed to
+  complete startup"). Relaunch once it is warm.
+- Prefer raw `adb` over higher-level device wrappers here: `adb shell input
+  tap`, `adb exec-out screencap -p`, `adb shell uiautomator dump`.
+
+## Parity with iOS
+
+The two apps are separate codebases, so a feature added here does not appear on
+iOS by itself. Declare the gap in the PR's `## Parity` section — the template in
+`.github/PULL_REQUEST_TEMPLATE.md` asks for it and `.github/workflows/parity.yml`
+opens the counterpart issue. Full contract: `docs/parity.md`.

--- a/apps/swift/AGENTS.md
+++ b/apps/swift/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/apps/swift/CLAUDE.md
+++ b/apps/swift/CLAUDE.md
@@ -1,0 +1,40 @@
+# apps/swift — the Apple app
+
+**This workspace ships iOS, watchOS and macOS.** Android ships from
+`apps/expo` (React Native).
+
+There is no React Native in this directory and no Expo tooling in this build.
+An iOS bug reported against the app is fixed here, not in `apps/expo` — the
+Expo project's iOS target is not shipped.
+
+## Validate on an Apple simulator or device
+
+```bash
+bun swift          # regenerate the Xcode project (it is NOT committed)
+```
+
+Regenerate after any change to `project.yml`, then build the `PackRat-iOS`
+scheme. Pin the simulator explicitly by UDID — this machine runs parallel
+agents and each owns its own simulator, so letting the tooling pick one steals
+somebody else's device.
+
+Build with a **shared** DerivedData path so worktrees reuse object files rather
+than each carrying a 3-6 GB copy:
+
+```
+-derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/PackRat-shared"
+```
+
+## Parity with Android
+
+The two apps are separate codebases, so a feature added here does not appear on
+Android by itself. Declare the gap in the PR's `## Parity` section — the
+template in `.github/PULL_REQUEST_TEMPLATE.md` asks for it and
+`.github/workflows/parity.yml` opens the counterpart issue. Full contract:
+`docs/parity.md`.
+
+## Release
+
+iOS/watchOS/macOS ship through Xcode and App Store Connect, **not EAS**. EAS
+builds the Android app only. See `apps/swift/README.md` for the TestFlight and
+preflight commands.


### PR DESCRIPTION
## Why

iOS ships from `apps/swift`; Android ships from `apps/expo`. The root
`CLAUDE.md` still described Expo as the "Mobile app (iOS + Android)" and
**omitted `apps/swift` entirely** — so agents (including me, twice today) kept
booting iOS simulators to validate Android changes, and burning slow builds to
learn nothing.

Writing the rule down once at the top of a 280-line root file does not fix
that. An agent editing `apps/expo` does not re-read the root file before
picking a device. The convention has to arrive *with the code*.

## What

Three mechanisms, each of which loads on its own:

| Mechanism | Loads when |
|---|---|
| `apps/expo/CLAUDE.md`, `apps/swift/CLAUDE.md` | On demand, when an agent reads a file in that directory |
| `.claude/rules/platform-split.md` (`paths:` scoped) | When a file under either app is opened |
| `AGENTS.md` | At launch, for agents that read `AGENTS.md` instead of `CLAUDE.md` |

Each per-app file states what that workspace ships, where to validate it, and
the device gotchas for that platform — the Android dev-launcher ignoring
`?url=`, `10.0.2.2` vs LAN IP, cold-emulator ANR on first launch; the Swift
side's uncommitted Xcode project, explicit simulator pinning, shared
DerivedData path.

## AGENTS.md was drifting

`AGENTS.md` was a full copy of `CLAUDE.md`, already 20 lines out of sync, and
it never received the platform split at all. Per Anthropic's guidance Claude
Code reads `CLAUDE.md`, not `AGENTS.md`, so the root `AGENTS.md` is now a short
summary that leads with the split, and the per-app `AGENTS.md` files are
symlinks to the `CLAUDE.md` beside them so they cannot drift again.

## Also corrected

- Workspace table now lists all seven apps (it was missing `swift`, `web`, `admin`, `trails`)
- EAS profiles table said "App Store / Play Store" and "iOS Simulator / Android APK"; EAS builds Android only
- `bun ios` is marked as not a shipping target

Docs only — no code changes.