### PR TITLE
docs(swift): note that DeepLink case names must match across clients

### DIFF
--- a/apps/swift/Sources/PackRat/Navigation/DeepLink.swift
+++ b/apps/swift/Sources/PackRat/Navigation/DeepLink.swift
@@ -10,6 +10,8 @@ import Foundation
 ///
 /// The Expo (Android) client parses the same `packrat://` scheme, so any
 /// case added here has a counterpart there — see `docs/parity.md`.
+/// Keep the case names aligned across both clients so a link that works on
+/// one is not silently inert on the other.
 public enum DeepLink: Equatable {
     case home
     case pack(id: String)


### PR DESCRIPTION
## Description

**Re-run of the end-to-end parity test**, now that #2762 fixed the trigger that made the first attempt (#2761) silently record nothing.

Comment-only change to `apps/swift` — no behaviour, no risk. Its purpose is to exercise the one path still unproven: does a `follow:` declaration actually open the counterpart issue on merge?

**Expected on merge:** an issue titled `[parity/expo] docs(swift): note that DeepLink case names must match across clients`, labelled `parity` + `parity:expo`, linking back to this PR.

The comment itself is worth keeping: it tells the next person that `DeepLink` case names are a cross-client contract.

## Type of change

- [x] 📝 Documentation update

## Area(s) affected

- [x] Swift app — iOS + macOS (`apps/swift`)

## Parity

- [x] follow: expo re-verifying the counterpart-issue automation after the trigger fix

## Testing

- [x] Manually tested on iOS (Swift)

Comment-only; no runtime behaviour touched. Note the two Swift smoke jobs fail identically on `development` itself (5 of its last 6 runs) — pre-existing, unrelated to this change.

## Pre-merge checklist

- [x] `bun format && bun lint` passes with no errors
- [x] No new secrets or credentials are committed
- [x] PR title follows conventional commits
